### PR TITLE
yum: use rockylinux as base build image

### DIFF
--- a/td-agent/yum/rockylinux-8-aarch64/from
+++ b/td-agent/yum/rockylinux-8-aarch64/from
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+arm64v8/rockylinux:8

--- a/td-agent/yum/rockylinux-8/Dockerfile
+++ b/td-agent/yum/rockylinux-8/Dockerfile
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ARG FROM=rockylinux/rockylinux:8
+FROM ${FROM}
+
+COPY qemu-* /usr/bin/
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  dnf install --enablerepo=powertools -y ${quiet} \
+    make \
+    gcc-c++ \
+    ruby-devel  \
+    rubygems \
+    rubygem-rake \
+    rubygem-bundler \
+    libedit-devel \
+    ncurses-devel \
+    libyaml-devel \
+    git \
+    cyrus-sasl-devel \
+    nss-softokn-freebl-devel \
+    pkg-config \
+    rpm-build \
+    rpmdevtools \
+    redhat-rpm-config \
+    openssl-devel \
+    tar \
+    zlib-devel \
+    rpmlint && \
+    # raise IPv4 priority
+    echo "precedence ::ffff:0:0/96 100" > /etc/gai.conf && \
+    # enable multiplatform feature
+    gem install --no-document --install-dir /usr/share/gems bundler && \
+  yum clean ${quiet} all

--- a/td-agent/yum/rockylinux-8/qemu-dummy-static
+++ b/td-agent/yum/rockylinux-8/qemu-dummy-static
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Do nothing. This exists only for not requiring qemu-aarch64-static copy.
+# Recent Debian (buster or later) and Ubuntu (18.10 or later) on amd64 hosts or
+# arm64 host don't require qemu-aarch64-static in Docker image. But old Debian
+# and Ubuntu hosts on amd64 require qemu-aarch64-static in Docker image.
+#
+# We use "COPY qemu* /usr/bin/" in Dockerfile. If we don't put any "qemnu*",
+# the "COPY" is failed. It means that we always require "qemu*" even if we
+# use recent Debian/Ubuntu or arm64 host. If we have this dummy "qemu*" file,
+# the "COPY" isn't failed. It means that we can copy "qemu*" only when we
+# need.
+#
+# See also "script" in dev/tasks/linux-packages/azure.linux.arm64.yml.
+# Azure Pipelines uses old Ubuntu (18.04).
+# So we need to put "qemu-aarch64-static" into this directory.


### PR DESCRIPTION
It stores RPMs under td-agent/yum/repositories/centos for
compatibility.

TODO: support armv64v8/rockylinux:8 as well. It is not accessible from my
environment :-<, It will be handled in another PR.
