### PR TITLE
Drop centos8 and use alternative image

### DIFF
--- a/.github/workflows/yum-arm.yml
+++ b/.github/workflows/yum-arm.yml
@@ -11,15 +11,11 @@ jobs:
       matrix:
         label:
           - CentOS 7 aarch64
-          - CentOS 8 aarch64
           - Amazon Linux 2 aarch64
         include:
           - label: CentOS 7 aarch64
             rake-job: centos-7
             test-docker-image: centos:7
-          - label: CentOS 8 aarch64
-            rake-job: centos-8
-            test-docker-image: centos:8
           - label: Amazon Linux 2 aarch64
             rake-job: amazonlinux-2
             test-docker-image: amazonlinux:2

--- a/.github/workflows/yum-arm.yml
+++ b/.github/workflows/yum-arm.yml
@@ -11,11 +11,15 @@ jobs:
       matrix:
         label:
           - CentOS 7 aarch64
+          - RockyLinux 8 aarch64
           - Amazon Linux 2 aarch64
         include:
           - label: CentOS 7 aarch64
             rake-job: centos-7
             test-docker-image: centos:7
+          - label: RockyLinux 8 aarch64
+            rake-job: rockylinux-8
+            test-docker-image: rockylinux:8
           - label: Amazon Linux 2 aarch64
             rake-job: amazonlinux-2
             test-docker-image: amazonlinux:2

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -11,17 +11,12 @@ jobs:
       matrix:
         label:
           - CentOS 7 x86_64
-          - CentOS 8 x86_64
           - CentOS Stream 8 x86_64
           - Amazon Linux 2 x86_64
         include:
           - label: CentOS 7 x86_64
             rake-job: centos-7
             test-docker-image: centos:7
-            centos-stream: false
-          - label: CentOS 8 x86_64
-            rake-job: centos-8
-            test-docker-image: centos:8
             centos-stream: false
           - label: CentOS Stream 8 x86_64
             rake-job: centos-stream-8

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -12,6 +12,7 @@ jobs:
         label:
           - CentOS 7 x86_64
           - CentOS Stream 8 x86_64
+          - RockyLinux 8 x86_64
           - Amazon Linux 2 x86_64
         include:
           - label: CentOS 7 x86_64
@@ -22,6 +23,10 @@ jobs:
             rake-job: centos-stream-8
             test-docker-image: centos:8
             centos-stream: true
+          - label: RockyLinux 8 x86_64
+            rake-job: rockylinux-8
+            test-docker-image: rockylinux/rockylinux:8
+            centos-stream: false
           - label: Amazon Linux 2 x86_64
             rake-job: amazonlinux-2
             test-docker-image: amazonlinux:2

--- a/td-agent/yum/binstubs-test.sh
+++ b/td-agent/yum/binstubs-test.sh
@@ -45,6 +45,10 @@ case ${distribution} in
         ;;
     esac
     ;;
+  rocky)
+    DNF=dnf
+    DISTRIBUTION_VERSION=$(echo ${version} | cut -d. -f1)
+    ;;
 esac
 
 repositories_dir=/fluentd/td-agent/yum/repositories

--- a/td-agent/yum/install-test.sh
+++ b/td-agent/yum/install-test.sh
@@ -45,6 +45,11 @@ case ${distribution} in
         ;;
     esac
     ;;
+  rocky)
+    ENABLE_UPGRADE_TEST=0
+    DNF=dnf
+    DISTRIBUTION_VERSION=$(echo ${version} | cut -d. -f1)
+    ;;
 esac
 
 echo "INSTALL TEST"

--- a/td-agent/yum/pkgsize-test.sh
+++ b/td-agent/yum/pkgsize-test.sh
@@ -55,6 +55,12 @@ case ${DISTRIBUTION} in
 		;;
 	esac
 	;;
+    rockylinux)
+	# FIXME: no previous release package for rockylinux
+	SKIP_SIZE_COMPARISON=1
+	# /etc/os-release ID=rocky
+	DISTRIBUTION=rocky
+	;;
     *)
 	echo "${DISTRIBUTION} is not supported"
 	exit 1

--- a/td-agent/yum/serverspec-test.sh
+++ b/td-agent/yum/serverspec-test.sh
@@ -48,6 +48,11 @@ case ${distribution} in
         ;;
     esac
     ;;
+  rocky)
+    DNF=dnf
+    DISTRIBUTION_VERSION=$(echo ${version} | cut -d. -f1)
+    version=$DISTRIBUTION_VERSION
+    ;;
 esac
 
 echo "INSTALL TEST"


### PR DESCRIPTION
CentOS 8 had reached already EOL, so just replace it with an alternative base build image for RHEL.