### PR TITLE
CI: Fix build error on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,6 +10,10 @@ jobs:
       fail-fast: false
     runs-on: windows-latest
     steps:
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
       - uses: actions/checkout@master
       - name: Build
         run: |

--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -162,7 +162,7 @@ end
 
 def tar_command
   if windows?
-    ["ridk", "exec", File.join(RubyInstaller::Runtime.msys2_installation.msys_path, "usr", "bin", "tar.exe")]
+    ["ridk", "exec", "tar"]
   else
     ["tar"]
   end

--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -1202,7 +1202,7 @@ EOS
       sh("git", "archive", "HEAD",
          "--prefix", "#{@archive_base_name}/",
          "--output", @full_archive_name)
-      sh("tar", "xvf", @full_archive_name)
+      sh("tar", "xvf", @full_archive_name, "--force-local")
       @download_task.files.each do |path|
         src_path = Pathname(path)
         dest_path = Pathname(DOWNLOADS_DIR)
@@ -1218,7 +1218,7 @@ EOS
         cp_r(path, dest_dir) unless path.end_with?(".gem")
       end
       cp_r("#{PACKAGE_NAME}/debian/copyright", "#{@archive_base_name}/#{PACKAGE_NAME}/debian/copyright")
-      sh("tar", "cvfz", @full_archive_name, @archive_base_name)
+      sh("tar", "cvfz", @full_archive_name, @archive_base_name, "--force-local")
       rm_rf(@archive_base_name)
     end
   end

--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -427,7 +427,9 @@ class BuildTask
         cd(DOWNLOADS_DIR) do
           archive_path = @download_task.file_fluentd_archive
           fluentd_dir = archive_path.sub(/\.tar\.gz$/, '')
-          sh(tar_command, "xvf", archive_path) unless File.exists?(fluentd_dir)
+          tar_options = []
+          tar_options << "--force-local" if windows?
+          sh(tar_command, "xvf", archive_path, *tar_options) unless File.exists?(fluentd_dir)
           cd("fluentd-#{FLUENTD_REVISION}") do
             sh("rake", "build")
             setup_local_gem_repo
@@ -972,7 +974,9 @@ class BuildTask
       tarball = @download_task.file_jemalloc_source
       source_dir = File.basename(tarball.sub(/\.tar\.bz2$/, ''))
       license_file = File.join(source_dir, "COPYING")
-      sh(tar_command, "xf", tarball, license_file)
+      tar_options = []
+      tar_options << "--force-local" if windows?
+      sh(tar_command, "xf", tarball, license_file, *tar_options)
       mv(license_file, "LICENSE-jemalloc.txt")
       rm_rf(source_dir)
     end
@@ -987,7 +991,9 @@ class BuildTask
       tarball = @download_task.file_ruby_source
       ruby_source_dir = File.basename(tarball.sub(/\.tar\.gz$/, ''))
       license_file = File.join(ruby_source_dir, "COPYING")
-      sh(tar_command, "xf", tarball, license_file)
+      tar_options = []
+      tar_options << "--force-local" if windows?
+      sh(tar_command, "xf", tarball, license_file, *tar_options)
       mv(license_file, "LICENSE-Ruby.txt")
       rm_rf(ruby_source_dir)
     end
@@ -1210,7 +1216,9 @@ EOS
       sh("git", "archive", "HEAD",
          "--prefix", "#{@archive_base_name}/",
          "--output", @full_archive_name)
-      sh(tar_command, "xvf", @full_archive_name, "--force-local")
+      tar_options = []
+      tar_options << "--force-local" if windows?
+      sh(tar_command, "xvf", @full_archive_name, *tar_options)
       @download_task.files.each do |path|
         src_path = Pathname(path)
         dest_path = Pathname(DOWNLOADS_DIR)
@@ -1226,7 +1234,9 @@ EOS
         cp_r(path, dest_dir) unless path.end_with?(".gem")
       end
       cp_r("#{PACKAGE_NAME}/debian/copyright", "#{@archive_base_name}/#{PACKAGE_NAME}/debian/copyright")
-      sh(tar_command, "cvfz", @full_archive_name, @archive_base_name, "--force-local")
+      tar_options = []
+      tar_options << "--force-local" if windows?
+      sh(tar_command, "cvfz", @full_archive_name, @archive_base_name, *tar_options)
       rm_rf(@archive_base_name)
     end
   end

--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -162,9 +162,9 @@ end
 
 def tar_command
   if windows?
-    File.join(RubyInstaller::Runtime.msys2_installation.msys_path, "usr", "bin", "tar.exe")
+    ["ridk", "exec", File.join(RubyInstaller::Runtime.msys2_installation.msys_path, "usr", "bin", "tar.exe")]
   else
-    "tar"
+    ["tar"]
   end
 end
 
@@ -313,7 +313,7 @@ class DownloadTask
           sh("git", "checkout", FLUENTD_REVISION)
         end
         mv("fluentd", dirname)
-        sh(tar_command, "cvfz", "#{dirname}.tar.gz", dirname)
+        sh(*tar_command, "cvfz", "#{dirname}.tar.gz", dirname)
       end
     end
   end
@@ -429,7 +429,7 @@ class BuildTask
           fluentd_dir = archive_path.sub(/\.tar\.gz$/, '')
           tar_options = []
           tar_options << "--force-local" if windows?
-          sh(tar_command, "xvf", archive_path, *tar_options) unless File.exists?(fluentd_dir)
+          sh(*tar_command, "xvf", archive_path, *tar_options) unless File.exists?(fluentd_dir)
           cd("fluentd-#{FLUENTD_REVISION}") do
             sh("rake", "build")
             setup_local_gem_repo
@@ -636,7 +636,7 @@ class BuildTask
     tarball = @download_task.file_jemalloc_source
     source_dir = tarball.sub(/\.tar\.bz2$/, '')
 
-    sh(tar_command, "xvf", tarball, "-C", DOWNLOADS_DIR)
+    sh(*tar_command, "xvf", tarball, "-C", DOWNLOADS_DIR)
 
     configure_opts = [
       "--prefix=#{install_prefix}",
@@ -705,7 +705,7 @@ class BuildTask
     tarball = @download_task.file_openssl_source
     source_dir = tarball.sub(/\.tar\.gz$/, '')
 
-    sh(tar_command, "xvf", tarball, "-C", DOWNLOADS_DIR)
+    sh(*tar_command, "xvf", tarball, "-C", DOWNLOADS_DIR)
 
     configure_opts = [
       "--prefix=#{install_prefix}",
@@ -740,7 +740,7 @@ class BuildTask
     tarball = @download_task.file_ruby_source
     ruby_source_dir = tarball.sub(/\.tar\.gz$/, '')
 
-    sh(tar_command, "xvf", tarball, "-C", DOWNLOADS_DIR)
+    sh(*tar_command, "xvf", tarball, "-C", DOWNLOADS_DIR)
 
     configure_opts = [
       "--prefix=#{install_prefix}",
@@ -976,7 +976,7 @@ class BuildTask
       license_file = File.join(source_dir, "COPYING")
       tar_options = []
       tar_options << "--force-local" if windows?
-      sh(tar_command, "xf", tarball, license_file, *tar_options)
+      sh(*tar_command, "xf", tarball, license_file, *tar_options)
       mv(license_file, "LICENSE-jemalloc.txt")
       rm_rf(source_dir)
     end
@@ -993,7 +993,7 @@ class BuildTask
       license_file = File.join(ruby_source_dir, "COPYING")
       tar_options = []
       tar_options << "--force-local" if windows?
-      sh(tar_command, "xf", tarball, license_file, *tar_options)
+      sh(*tar_command, "xf", tarball, license_file, *tar_options)
       mv(license_file, "LICENSE-Ruby.txt")
       rm_rf(ruby_source_dir)
     end
@@ -1218,7 +1218,7 @@ EOS
          "--output", @full_archive_name)
       tar_options = []
       tar_options << "--force-local" if windows?
-      sh(tar_command, "xvf", @full_archive_name, *tar_options)
+      sh(*tar_command, "xvf", @full_archive_name, *tar_options)
       @download_task.files.each do |path|
         src_path = Pathname(path)
         dest_path = Pathname(DOWNLOADS_DIR)
@@ -1236,7 +1236,7 @@ EOS
       cp_r("#{PACKAGE_NAME}/debian/copyright", "#{@archive_base_name}/#{PACKAGE_NAME}/debian/copyright")
       tar_options = []
       tar_options << "--force-local" if windows?
-      sh(tar_command, "cvfz", @full_archive_name, @archive_base_name, *tar_options)
+      sh(*tar_command, "cvfz", @full_archive_name, @archive_base_name, *tar_options)
       rm_rf(@archive_base_name)
     end
   end

--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -160,6 +160,14 @@ def render_template(dest, src, config, opts={})
   end
 end
 
+def tar_command
+  if windows?
+    File.join(RubyInstaller::Runtime.msys2_installation.msys_path, "usr", "bin", "tar.exe")
+  else
+    "tar"
+  end
+end
+
 class DownloadTask
   include Rake::DSL
 
@@ -305,7 +313,7 @@ class DownloadTask
           sh("git", "checkout", FLUENTD_REVISION)
         end
         mv("fluentd", dirname)
-        sh("tar", "cvfz", "#{dirname}.tar.gz", dirname)
+        sh(tar_command, "cvfz", "#{dirname}.tar.gz", dirname)
       end
     end
   end
@@ -419,7 +427,7 @@ class BuildTask
         cd(DOWNLOADS_DIR) do
           archive_path = @download_task.file_fluentd_archive
           fluentd_dir = archive_path.sub(/\.tar\.gz$/, '')
-          sh("tar", "xvf", archive_path) unless File.exists?(fluentd_dir)
+          sh(tar_command, "xvf", archive_path) unless File.exists?(fluentd_dir)
           cd("fluentd-#{FLUENTD_REVISION}") do
             sh("rake", "build")
             setup_local_gem_repo
@@ -626,7 +634,7 @@ class BuildTask
     tarball = @download_task.file_jemalloc_source
     source_dir = tarball.sub(/\.tar\.bz2$/, '')
 
-    sh("tar", "xvf", tarball, "-C", DOWNLOADS_DIR)
+    sh(tar_command, "xvf", tarball, "-C", DOWNLOADS_DIR)
 
     configure_opts = [
       "--prefix=#{install_prefix}",
@@ -695,7 +703,7 @@ class BuildTask
     tarball = @download_task.file_openssl_source
     source_dir = tarball.sub(/\.tar\.gz$/, '')
 
-    sh("tar", "xvf", tarball, "-C", DOWNLOADS_DIR)
+    sh(tar_command, "xvf", tarball, "-C", DOWNLOADS_DIR)
 
     configure_opts = [
       "--prefix=#{install_prefix}",
@@ -730,7 +738,7 @@ class BuildTask
     tarball = @download_task.file_ruby_source
     ruby_source_dir = tarball.sub(/\.tar\.gz$/, '')
 
-    sh("tar", "xvf", tarball, "-C", DOWNLOADS_DIR)
+    sh(tar_command, "xvf", tarball, "-C", DOWNLOADS_DIR)
 
     configure_opts = [
       "--prefix=#{install_prefix}",
@@ -964,7 +972,7 @@ class BuildTask
       tarball = @download_task.file_jemalloc_source
       source_dir = File.basename(tarball.sub(/\.tar\.bz2$/, ''))
       license_file = File.join(source_dir, "COPYING")
-      sh("tar", "xf", tarball, license_file)
+      sh(tar_command, "xf", tarball, license_file)
       mv(license_file, "LICENSE-jemalloc.txt")
       rm_rf(source_dir)
     end
@@ -979,7 +987,7 @@ class BuildTask
       tarball = @download_task.file_ruby_source
       ruby_source_dir = File.basename(tarball.sub(/\.tar\.gz$/, ''))
       license_file = File.join(ruby_source_dir, "COPYING")
-      sh("tar", "xf", tarball, license_file)
+      sh(tar_command, "xf", tarball, license_file)
       mv(license_file, "LICENSE-Ruby.txt")
       rm_rf(ruby_source_dir)
     end
@@ -1202,7 +1210,7 @@ EOS
       sh("git", "archive", "HEAD",
          "--prefix", "#{@archive_base_name}/",
          "--output", @full_archive_name)
-      sh("tar", "xvf", @full_archive_name, "--force-local")
+      sh(tar_command, "xvf", @full_archive_name, "--force-local")
       @download_task.files.each do |path|
         src_path = Pathname(path)
         dest_path = Pathname(DOWNLOADS_DIR)
@@ -1218,7 +1226,7 @@ EOS
         cp_r(path, dest_dir) unless path.end_with?(".gem")
       end
       cp_r("#{PACKAGE_NAME}/debian/copyright", "#{@archive_base_name}/#{PACKAGE_NAME}/debian/copyright")
-      sh("tar", "cvfz", @full_archive_name, @archive_base_name, "--force-local")
+      sh(tar_command, "cvfz", @full_archive_name, @archive_base_name, "--force-local")
       rm_rf(@archive_base_name)
     end
   end

--- a/td-agent/msi/Dockerfile
+++ b/td-agent/msi/Dockerfile
@@ -26,7 +26,7 @@ RUN @"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -I
 # Install toolchain
 RUN \
   choco install -y git wixtoolset 7zip cmake && \
-  choco install -y msys2 --params /NoUpdate --version=20211130.0.0 && \
+  choco install -y msys2 --params /NoUpdate --version=20220118.0.0 && \
   choco install ruby -y --version=3.0.3.1 && \
   refreshenv && \
   ridk install 3 && \

--- a/td-agent/msi/Dockerfile
+++ b/td-agent/msi/Dockerfile
@@ -25,7 +25,8 @@ RUN @"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -I
 
 # Install toolchain
 RUN \
-  choco install -y git wixtoolset 7zip cmake && \
+  choco install -y git wixtoolset 7zip & \
+  choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=System' && \
   choco install -y msys2 --params /NoUpdate --version=20220118.0.0 && \
   choco install ruby -y --version=3.0.3.1 && \
   refreshenv && \


### PR DESCRIPTION
Try to fix the following error:

```
Failed to download gem files: <bundle package --no-install> (stdout: Fetching gem metadata from https://rubygems.org/...........
Fetching https://github.com/fluent/fluentd
, stderr: Warning: the running version of Bundler (2.2.9) is older than the version that created the lockfile (2.2.32). We suggest you to upgrade to the version that created the lockfile by running `gem install bundler:2.2.32`.
nokogiri-1.13.1-x64-mingw32 requires ruby version < 3.1.dev, >= 2.6, which is
incompatible with the current version, ruby 2.5.9p229
```

Signed-off-by: Takuro Ashie <ashie@clear-code.com>