### PR TITLE
Add fluent-plugin-windows-exporter

### DIFF
--- a/td-agent/Gemfile
+++ b/td-agent/Gemfile
@@ -84,6 +84,7 @@ gem "winevt_c", "0.9.3", platforms: windows_platforms
 gem "win32-eventlog", "0.6.7", platforms: windows_platforms
 gem "fluent-plugin-parser-winevt_xml", "0.2.4", platforms: windows_platforms
 gem "fluent-plugin-windows-eventlog", "0.8.1", platforms: windows_platforms
+gem "fluent-plugin-windows-exporter", "1.0.0", platforms: windows_platforms
 
 not_windows_platforms = [:ruby]
 gem "rdkafka", "0.11.1", platforms: not_windows_platforms

--- a/td-agent/Gemfile.lock
+++ b/td-agent/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
     console (1.14.0)
       fiber-local
     cool.io (1.7.1)
+    cool.io (1.7.1-x64-mingw32)
     digest-crc (0.6.4)
       rake (>= 12.0.0, < 14.0.0)
     digest-murmurhash (1.1.1)
@@ -177,6 +178,9 @@ GEM
       fluentd (>= 0.14.12, < 2)
       win32-eventlog
       winevt_c (>= 0.9.1)
+    fluent-plugin-windows-exporter (1.0.0)
+      bindata (~> 2.4)
+      fluentd (>= 0.14.10, < 2)
     hirb (0.7.3)
     http_parser.rb (0.8.0)
     httpclient (2.8.3)
@@ -324,6 +328,7 @@ DEPENDENCIES
   fluent-plugin-utmpx (= 0.5.0)
   fluent-plugin-webhdfs (= 1.5.0)
   fluent-plugin-windows-eventlog (= 0.8.1)
+  fluent-plugin-windows-exporter (= 1.0.0)
   fluentd!
   http_parser.rb (= 0.8.0)
   httpclient (= 2.8.3)


### PR DESCRIPTION
Fixes #355.

Windows Exporter plugin is a system metrics plugin for Win32 platforms.
It can capture a wide range of metrics (CPU, memory, and network etc.),
and is very convenient for monitoring Windows nodes.

* https://github.com/fluent-plugins-nursery/fluent-plugin-windows-exporter
* https://rubygems.org/gems/fluent-plugin-windows-exporter

The plugin enables Fluentd to act as a replacement of general system
monitoring solution (such as collectd or Prometheus), and should be
very useful for Windows administrators.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>