### PR TITLE
yum: generate build_id in -debuginfo

### DIFF
--- a/td-agent/yum/td-agent.spec.in
+++ b/td-agent/yum/td-agent.spec.in
@@ -46,6 +46,10 @@
 %else
 %global __provides_exclude_from ^/opt/%{name}/.*\\.so.*
 %global __requires_exclude libjemalloc.*|libruby.*|/opt/%{name}/.*
+# Omit build_id links (/usr/lib/.build-id/xx/yy) from td-agent package
+# They are bundled in td-agent-debuginfo. It is intended not to
+# conflict with other packages
+%define _build_id_links alldebug
 %endif
 
 %if %{use_systemd}


### PR DESCRIPTION
build_id links may be useful for debug but there is a case that
build_id conflicts with other packages. (e.g. gitlab-ce)

Thus "_build_id_links compat" may not be suitable, so change it to
traditional alldebug.

Before: 
  td-agent contains /usr/lib/debug/.build-id/xx/yy
After: 
  td-agent-debuginfo contains /usr/lib/debug/.build-id/xx/yy

NOTE: rpm --excludepath may be a workaround to install, but it is not
so good.

Closes: #370
