### PR TITLE
Tweak CentOS 8 containers

### DIFF
--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -11,7 +11,6 @@ jobs:
       matrix:
         label:
           - CentOS 7 x86_64
-          - CentOS Stream 8 x86_64
           - RockyLinux 8 x86_64
           - Amazon Linux 2 x86_64
         include:
@@ -19,10 +18,6 @@ jobs:
             rake-job: centos-7
             test-docker-image: centos:7
             centos-stream: false
-          - label: CentOS Stream 8 x86_64
-            rake-job: centos-stream-8
-            test-docker-image: centos:8
-            centos-stream: true
           - label: RockyLinux 8 x86_64
             rake-job: rockylinux-8
             test-docker-image: rockylinux/rockylinux:8

--- a/td-agent/yum/centos-8/Dockerfile
+++ b/td-agent/yum/centos-8/Dockerfile
@@ -24,6 +24,8 @@ ARG DEBUG
 
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  sed -i 's|^mirrorlist|#mirrorlist|g' /etc/yum.repos.d/CentOS-*.repo && \
+  sed -i 's|^#baseurl=http://mirror.centos.org/|baseurl=http://vault.centos.org/|g' /etc/yum.repos.d/CentOS-*.repo && \
   dnf install --enablerepo=powertools -y ${quiet} \
     make \
     gcc-c++ \

--- a/td-agent/yum/centos-stream-8/Dockerfile
+++ b/td-agent/yum/centos-stream-8/Dockerfile
@@ -24,6 +24,8 @@ ARG DEBUG
 
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  sed -i 's|^mirrorlist|#mirrorlist|g' /etc/yum.repos.d/CentOS-*.repo && \
+  sed -i 's|^#baseurl=http://mirror.centos.org/|baseurl=http://vault.centos.org/|g' /etc/yum.repos.d/CentOS-*.repo && \
   dnf install centos-release-stream -y && \
   dnf swap centos-{linux,stream}-repos -y && \
   dnf distro-sync -y && \


### PR DESCRIPTION
* CI: Stop running centos-stream-8
* Replace dnf repository URLs to keep them buildable
  We don't use them anymore but keep them for a while for reference.

Signed-off-by: Takuro Ashie <ashie@clear-code.com>