### PR TITLE
Fix cannot build fluentd correctly on Ubuntu bionic & focal

### DIFF
--- a/lib/apt/build.sh
+++ b/lib/apt/build.sh
@@ -49,7 +49,7 @@ run mkdir -p build
 run cp /host/tmp/${PACKAGE}-${VERSION}.tar.gz \
   build/${PACKAGE}_${VERSION}.orig.tar.gz
 run cd build
-run tar xfz ${PACKAGE}_${VERSION}.orig.tar.gz
+run tar xfz ${PACKAGE}_${VERSION}.orig.tar.gz --no-same-owner
 case "${VERSION}" in
   *~dev*)
     run mv ${PACKAGE}-$(echo $VERSION | sed -e 's/~dev/-dev/') \

--- a/lib/yum/build.sh
+++ b/lib/yum/build.sh
@@ -95,7 +95,7 @@ if [ -n "${SOURCE_ARCHIVE}" ]; then
     0.dev*)
       source_archive_base_name=$( \
         echo ${SOURCE_ARCHIVE} | sed -e 's/\.tar\.gz$//')
-      run tar xf /host/tmp/${SOURCE_ARCHIVE} \
+      run tar xf /host/tmp/${SOURCE_ARCHIVE} --no-same-owner \
         --transform="s,^[^/]*,${PACKAGE},"
       run mv \
           ${PACKAGE} \

--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -427,7 +427,7 @@ class BuildTask
         cd(DOWNLOADS_DIR) do
           archive_path = @download_task.file_fluentd_archive
           fluentd_dir = archive_path.sub(/\.tar\.gz$/, '')
-          tar_options = []
+          tar_options = ["--no-same-owner"]
           tar_options << "--force-local" if windows?
           sh(*tar_command, "xvf", archive_path, *tar_options) unless File.exists?(fluentd_dir)
           cd("fluentd-#{FLUENTD_REVISION}") do


### PR DESCRIPTION
Due to CVE-2022-24765, Git 2.35.2 or later cannot run any command when
the paerent directory of a repository is owned by someone else.
To fix it, make sure to set owner of extracted source files &
directories to the current user (root).

`git config --add safe.directory /path/to/fluentd-source` can also avoid
this issue but it's not appropriate on self build case.

Signed-off-by: Takuro Ashie <ashie@clear-code.com>