### PR TITLE
msi: Use `3.5-windowsservercore-ltsc2019` explicitly to build container

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build
     strategy:
       fail-fast: false
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/td-agent/msi/Dockerfile
+++ b/td-agent/msi/Dockerfile
@@ -16,8 +16,7 @@
 
 # The "servercore" image cannot install DotNet3.5 (which is required by
 # wixtoolset) by chocolatey.
-#ARG FROM=mcr.microsoft.com/windows/servercore:ltsc2019
-ARG FROM=mcr.microsoft.com/dotnet/framework/runtime:3.5
+ARG FROM=mcr.microsoft.com/dotnet/framework/runtime:3.5-windowsservercore-ltsc2019
 FROM ${FROM}
 
 # Install Chocolatey to set up toolchain


### PR DESCRIPTION
3.5-windowsservercore-ltsc2022 lacks something to build td-agent.

Fix #382
