### PR TITLE
package: do not include extra prefix for publish snapshot

### DIFF
--- a/td-agent/manage-fluent-repositories.sh
+++ b/td-agent/manage-fluent-repositories.sh
@@ -94,12 +94,18 @@ EOF
 		buster|bullseye)
 		    aptly -config=$conf repo add td-agent4-$d $FLUENT_RELEASE_DIR/4/debian/$d/
 		    aptly -config=$conf snapshot create td-agent4-$d-${FLUENT_PACKAGE_VERSION}-1 from repo td-agent4-$d
-		    aptly -config=$conf publish snapshot -component=contrib -gpg-key=$SIGNING_KEY td-agent4-$d-${FLUENT_PACKAGE_VERSION}-1 debian/$d
+		    # publish snapshot with prefix, InRelease looks like (e.g. bullseye):
+		    #   Origin: bullseye bullseye
+		    #   Label: bullseye bullseye
+		    aptly -config=$conf publish snapshot -component=contrib -gpg-key=$SIGNING_KEY td-agent4-$d-${FLUENT_PACKAGE_VERSION}-1 $d
 		    ;;
 		xenial|bionic|focal|jammy)
 		    aptly -config=$conf repo add td-agent4-$d $FLUENT_RELEASE_DIR/4/ubuntu/$d/
 		    aptly -config=$conf snapshot create td-agent4-$d-${FLUENT_PACKAGE_VERSION}-1 from repo td-agent4-$d
-		    aptly -config=$conf publish snapshot -component=contrib -gpg-key=$SIGNING_KEY td-agent4-$d-${FLUENT_PACKAGE_VERSION}-1 ubuntu/$d
+		    # publish snapshot with prefix, InRelease looks like (e.g. focal):
+		    #   Origin: focal focal
+		    #   Label: focal focal
+		    aptly -config=$conf publish snapshot -component=contrib -gpg-key=$SIGNING_KEY td-agent4-$d-${FLUENT_PACKAGE_VERSION}-1 $d
 		    ;;
 	    esac
 	done


### PR DESCRIPTION
In the previous versions, it seems that prefix with vendor is not set.
Unexpectedly, the previous version set it. so apt update complains
mismatch of Origin and Label.

Before: InRelease

  Origin: ubuntu/focal focal
  Label: ubuntu/focal focal

After: InRelease

  Origin: focal focal
  Label: focal focal

This commit follows the previous behavior.