### PR TITLE
Stay async-1.30 to avoid upgrading to 2.0

### DIFF
--- a/td-agent/Gemfile
+++ b/td-agent/Gemfile
@@ -18,6 +18,7 @@ gem "msgpack", "1.5.1"
 gem "oj", "3.13.11"
 gem "tzinfo", "2.0.4"
 gem "tzinfo-data", "1.2022.1"
+gem "async", "1.30.2"
 gem "async-http", "0.56.5"
 gem "webrick", "1.7.0"
 

--- a/td-agent/Gemfile.lock
+++ b/td-agent/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
   specs:
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    async (1.30.1)
+    async (1.30.2)
       console (~> 1.10)
       nio4r (~> 2.3)
       timers (~> 4.1)
@@ -66,7 +66,7 @@ GEM
     cmetrics (0.2.5)
       mini_portile2 (~> 2.7)
     concurrent-ruby (1.1.10)
-    console (1.15.0)
+    console (1.15.3)
       fiber-local
     cool.io (1.7.1)
     cool.io (1.7.1-x64-mingw32)
@@ -288,6 +288,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  async (= 1.30.2)
   async-http (= 0.56.5)
   aws-partitions (= 1.577.0)
   aws-sdk-core (= 3.130.1)


### PR DESCRIPTION
async-2.0 requires Ruby 3.0 or later but we still support Ruby 2.7 until EOL.

Signed-off-by: Takuro Ashie <ashie@clear-code.com>