### PR TITLE
Remove needless files in cmetrics gem

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -1136,11 +1136,13 @@ class BuildTask
     end
     Dir.glob("#{gem_staging_dir}/gems/*").each do |gem_dir|
       cd(gem_dir) do
-        rm_rf(["test", "spec"])
+        rm_rf(["test", "tests", "spec"])
         remove_files("**/gem.build_complete")
         remove_files("ext/**/a.out")
         remove_files("ext/**/*.{o,la,a}")
         remove_files("ext/**/.libs", true)
+        remove_files("ext/**/tmp", true)
+        remove_files("ports", true) if gem_dir.start_with?("#{gem_staging_dir}/gems/cmetrics-")
       end
     end
     Dir.glob("#{td_agent_staging_dir}/lib/lib*.a").each do |static_library|


### PR DESCRIPTION
Suppress following error of rpmlint:

```
td-agent.x86_64: E: non-standard-dir-perm /opt/td-agent/lib/ruby/gems/2.7.0/gems/cmetrics-0.2.5/ext/cmetrics/tmp/x86_64-redhat-linux/ports/cmetrics/0.2.2/cmetrics-0.2.2 775
A standard directory should have permission set to 0755. If you get this
message, it means that you have wrong directory permissions in some dirs
included in your package.
...
```

```
td-agent.x86_64: E: non-readable /opt/td-agent/lib/ruby/gems/3.1.0/gems/cmetrics-0.2.5/ports/archives/v0.2.2 600
The file can't be read by everybody. Review if this is expected.
```
