### PR TITLE
Tweak manage-fluent-repositories.sh

### DIFF
--- a/td-agent/manage-fluent-repositories.sh
+++ b/td-agent/manage-fluent-repositories.sh
@@ -62,7 +62,7 @@ case $COMMAND in
 	$command
 	;;
     upload)
-	TARGETS="amazon redhat windows macosx debian/buster debian/bullseye ubuntu/jammy ubuntu/focal ubuntu/xenial ubuntu/bionic"
+	TARGETS="amazon redhat windows macosx debian/buster debian/bullseye ubuntu/jammy ubuntu/focal ubuntu/bionic"
 	for target in $TARGETS; do
 	    command="aws s3 sync --delete $FLUENT_RELEASE_DIR/4/$target s3://packages.treasuredata.com/4/$target --profile $FLUENT_RELEASE_PROFILE"
 	    echo $command
@@ -91,7 +91,7 @@ EOF
 	echo "Ready to type signing passphrase? (process starts in 10 seconds, Ctrl+C to abort)"
 	sleep 10
 	export GPG_TTY=$(tty)
-	for d in buster bullseye xenial bionic focal jammy; do
+	for d in buster bullseye bionic focal jammy; do
 	    aptly -config=$conf repo create -distribution=$d -component=contrib td-agent4-$d
 	    case $d in
 		buster|bullseye)
@@ -102,7 +102,7 @@ EOF
 		    #   Label: bullseye bullseye
 		    aptly -config=$conf publish snapshot -component=contrib -gpg-key=$SIGNING_KEY td-agent4-$d-${FLUENT_PACKAGE_VERSION}-1 $d
 		    ;;
-		xenial|bionic|focal|jammy)
+		bionic|focal|jammy)
 		    aptly -config=$conf repo add td-agent4-$d $FLUENT_RELEASE_DIR/4/ubuntu/$d/
 		    aptly -config=$conf snapshot create td-agent4-$d-${FLUENT_PACKAGE_VERSION}-1 from repo td-agent4-$d
 		    # publish snapshot with prefix, InRelease looks like (e.g. focal):

--- a/td-agent/manage-fluent-repositories.sh
+++ b/td-agent/manage-fluent-repositories.sh
@@ -14,14 +14,14 @@ set -e
 function usage {
     cat <<EOF
 Usage:
-  $0 COMMAND FLUENT_RELEASE_PROFILE FLUENT_RELEASE_DIR FLUENT_PACKAGE_VERSION
+  $0 COMMAND [FLUENT_RELEASE_PROFILE] [FLUENT_RELEASE_DIR] [FLUENT_PACKAGE_VERSION]
 
 Example:
   $ $0 ls release-td-agent
   $ $0 download release-td-agent /tmp/td-agent-release
-  $ $0 deb release-td-agent /tmp/td-agent-release 4.2.0
-  $ $0 rpm release-td-agent /tmp/td-agent-release 4.2.0
   $ $0 upload release-td-agent /tmp/td-agent-release
+  $ $0 deb /tmp/td-agent-release 4.2.0
+  $ $0 rpm /tmp/td-agent-release 4.2.0
 EOF
 }
 
@@ -31,21 +31,24 @@ if [ $# -eq 0 ]; then
 fi
 
 COMMAND=$1
-FLUENT_RELEASE_PROFILE=$2
-FLUENT_RELEASE_DIR=$3
-FLUENT_PACKAGE_VERSION=$4
 SIGNING_KEY=BEE682289B2217F45AF4CC3F901F9177AB97ACBE
-
-if [ -z "$FLUENT_RELEASE_PROFILE" ]; then
-    echo "ERROR: No s3 profile for releasing fluentd packages"
-    usage
-    exit 1
-fi
 
 case $COMMAND in
     deb|rpm)
+	FLUENT_RELEASE_DIR=$2
+	FLUENT_PACKAGE_VERSION=$3
 	if [ -z "$FLUENT_PACKAGE_VERSION" ]; then
 	    echo "ERROR: No package version for releasing fluentd packages, (e.g export FLUENT_PACKAGE_VERSION=4.2.0)"
+	    exit 1
+	fi
+	;;
+    *)
+	FLUENT_RELEASE_PROFILE=$2
+	FLUENT_RELEASE_DIR=$3
+	FLUENT_PACKAGE_VERSION=$4
+	if [ -z "$FLUENT_RELEASE_PROFILE" ]; then
+	    echo "ERROR: No s3 profile for releasing fluentd packages"
+	    usage
 	    exit 1
 	fi
 	;;

--- a/td-agent/manage-fluent-repositories.sh
+++ b/td-agent/manage-fluent-repositories.sh
@@ -18,7 +18,9 @@ Usage:
 
 Example:
   $ $0 ls release-td-agent
+  $ $0 dry-download release-td-agent /tmp/td-agent-release
   $ $0 download release-td-agent /tmp/td-agent-release
+  $ $0 dry-upload release-td-agent /tmp/td-agent-release
   $ $0 upload release-td-agent /tmp/td-agent-release
   $ $0 deb /tmp/td-agent-release 4.2.0
   $ $0 rpm /tmp/td-agent-release 4.2.0
@@ -61,18 +63,26 @@ case $COMMAND in
 	echo $command
 	$command
 	;;
-    upload)
+    dry-upload|upload)
 	TARGETS="amazon redhat windows macosx debian/buster debian/bullseye ubuntu/jammy ubuntu/focal ubuntu/bionic"
+	DRYRUN_OPTION="--dryrun"
+	if [ $COMMAND = "upload" ]; then
+	   DRYRUN_OPTION=""
+	fi
 	for target in $TARGETS; do
-	    command="aws s3 sync --delete $FLUENT_RELEASE_DIR/4/$target s3://packages.treasuredata.com/4/$target --profile $FLUENT_RELEASE_PROFILE"
+	    command="aws s3 sync $DRYRUN_OPTION --delete $FLUENT_RELEASE_DIR/4/$target s3://packages.treasuredata.com/4/$target --profile $FLUENT_RELEASE_PROFILE"
 	    echo $command
 	    $command
 	done
 	;;
-    download)
+    dry-download|download)
 	VERSIONS="4"
+	DRYRUN_OPTION="--dryrun"
+	if [ $COMMAND = "download" ]; then
+	   DRYRUN_OPTION=""
+	fi
 	for target in $VERSIONS; do
-	    command="aws s3 sync --delete s3://packages.treasuredata.com/$target $FLUENT_RELEASE_DIR/$target --profile $FLUENT_RELEASE_PROFILE"
+	    command="aws s3 sync $DRYRUN_OPTION --delete s3://packages.treasuredata.com/$target $FLUENT_RELEASE_DIR/$target --profile $FLUENT_RELEASE_PROFILE"
 	    echo $command
 	    $command
 	done


### PR DESCRIPTION
* Remove needless S3 profile argument for `deb` and `rpm` commands
* Drop xenial support
* Add `dry-download` and `dry-upload` commands
* Automate copying generated files of apt repositories