### PR TITLE
Fix build error of Docker images due to using older Ruby

### DIFF
--- a/td-agent/apt/debian-buster/Dockerfile
+++ b/td-agent/apt/debian-buster/Dockerfile
@@ -54,5 +54,6 @@ RUN \
   # raise IPv4 priority
   sed -i'' -e 's,#precedence ::ffff:0:0/96  100,precedence ::ffff:0:0/96  100,' /etc/gai.conf && \
   # enable multiplatform feature
-  gem install --no-document --install-dir /usr/share/rubygems-integration/all bundler builder && \
+  gem install --no-document --install-dir /usr/share/rubygems-integration/all bundler --version 2.3.26 && \
+  gem install --no-document --install-dir /usr/share/rubygems-integration/all builder && \
   rm -rf /var/lib/apt/lists/*

--- a/td-agent/apt/ubuntu-bionic/Dockerfile
+++ b/td-agent/apt/ubuntu-bionic/Dockerfile
@@ -58,5 +58,6 @@ RUN \
   # raise IPv4 priority
   sed -i'' -e 's,#precedence ::ffff:0:0/96  100,precedence ::ffff:0:0/96  100,' /etc/gai.conf && \
   # enable multiplatform feature
-  gem install --no-document bundler builder && \
+  gem install --no-document bundler --version 2.3.26 && \
+  gem install --no-document builder && \
   rm -rf /var/lib/apt/lists/*

--- a/td-agent/yum/rockylinux-8/Dockerfile
+++ b/td-agent/yum/rockylinux-8/Dockerfile
@@ -24,6 +24,7 @@ ARG DEBUG
 
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  dnf module enable ruby:3.1 -y && \
   dnf install --enablerepo=powertools -y ${quiet} \
     make \
     gcc-c++ \
@@ -50,6 +51,5 @@ RUN \
     # raise IPv4 priority
     echo "precedence ::ffff:0:0/96 100" > /etc/gai.conf && \
     # enable multiplatform feature
-    gem install --no-document --install-dir /usr/share/gems bundler --version 2.3.26 && \
-    gem install --no-document --install-dir /usr/share/gems builder && \
+    gem install --no-document --install-dir /usr/share/gems bundler builder && \
   yum clean ${quiet} all

--- a/td-agent/yum/rockylinux-8/Dockerfile
+++ b/td-agent/yum/rockylinux-8/Dockerfile
@@ -50,5 +50,6 @@ RUN \
     # raise IPv4 priority
     echo "precedence ::ffff:0:0/96 100" > /etc/gai.conf && \
     # enable multiplatform feature
-    gem install --no-document --install-dir /usr/share/gems bundler builder && \
+    gem install --no-document --install-dir /usr/share/gems bundler --version 2.3.26 && \
+    gem install --no-document --install-dir /usr/share/gems builder && \
   yum clean ${quiet} all


### PR DESCRIPTION
Recently `gem install bundler` installs Bundler v2.4 or later which requires Ruby 2.6 or later, but some of our Docker images still use Ruby 2.5. It causes build error like this:
https://github.com/fluent/fluent-package-builder/actions/runs/3908735547/jobs/6711234402

* For Rocky Linux 8 it can easily update Ruby to 3.1 by `dnf module enable ruby:3.1`
* For debian-buster it's [already EOL](https://wiki.debian.org/DebianReleases). So we no longer take care of it. Just stay bundler to v2.3.26.
* For ubunt-bionic [it's close to EOL](https://wiki.ubuntu.com/Releases). So we no longer take care of it too. Just stay bundler to v2.3.26.

FYI: Ruby 2.5 is used to run `rake` for build, it's not included in built packages.