### PR TITLE
Amazon Linux 2023: Use Ruby 3.2 to build explicitly

### DIFF
--- a/td-agent/yum/amazonlinux-2023/Dockerfile
+++ b/td-agent/yum/amazonlinux-2023/Dockerfile
@@ -44,9 +44,9 @@ RUN \
     zlib-devel \
     rpmlint \
     cmake3 \
-    ruby3.1 \
-    ruby3.1-rubygems \
-    ruby3.1-rubygem-rake \
+    ruby3.2 \
+    ruby3.2-rubygems \
+    ruby3.2-rubygem-rake \
     && \
   # raise IPv4 priority
   echo "precedence ::ffff:0:0/96 100" > /etc/gai.conf && \

--- a/td-agent/yum/td-agent.spec.in
+++ b/td-agent/yum/td-agent.spec.in
@@ -62,10 +62,10 @@ BuildRequires:	rh-ruby%{scl_ruby_ver}-ruby-devel
 BuildRequires:	rh-ruby%{scl_ruby_ver}-rubygems
 BuildRequires:	rh-ruby%{scl_ruby_ver}-rubygem-bundler
 %else
-%if %{_amazon_ver} >= 2022
-BuildRequires:	ruby3.1
-BuildRequires:	ruby3.1-rubygems
-BuildRequires:	ruby3.1-rubygem-rake
+%if %{_amazon_ver} >= 2023
+BuildRequires:	ruby3.2
+BuildRequires:	ruby3.2-rubygems
+BuildRequires:	ruby3.2-rubygem-rake
 %else
 %if %{_amazon_ver} > 0
 BuildRequires:	ruby


### PR DESCRIPTION
Even when ruby3.1 is specified, dnf downloads Ruby 3.2 in actual on Amaxon Linux 2023.