### PR TITLE
CI: Don't trigger build actions for Arm platform automatically

### DIFF
--- a/.github/workflows/apt-arm.yml
+++ b/.github/workflows/apt-arm.yml
@@ -1,8 +1,6 @@
 name: Apt based Linux (AArch64)
 on:
-  push:
-    branches: [master]
-  pull_request:
+  workflow_dispatch:
 jobs:
   build:
     name: Build

--- a/.github/workflows/yum-arm.yml
+++ b/.github/workflows/yum-arm.yml
@@ -1,8 +1,6 @@
 name: Yum based Linux (AArch64)
 on:
-  push:
-    branches: [master]
-  pull_request:
+  workflow_dispatch:
 jobs:
   build:
     name: Build


### PR DESCRIPTION
They take too long time to complete on CI environment since they use QEMU. Due to this they often time out.

Instead trigger them manually by `workflow_dispatch`. 
In addition, I'm considering to prepare self-hosted runner for them.
