### PR TITLE
td-agent-v4: deb: Remove needless "#{PACKAGE_NAME}" prefix (#442)

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -1192,12 +1192,12 @@ class LinuxPackageTask < PackageTask
       File.join("..", path)
     end
 
-    debian_copyright_file = File.join("#{PACKAGE_NAME}", "debian", "copyright")
+    debian_copyright_file = File.join("debian", "copyright")
     file debian_copyright_file do
       build_copyright_file
     end
 
-    debian_include_binaries_file = File.join("#{PACKAGE_NAME}", "debian", "source", "include-binaries")
+    debian_include_binaries_file = File.join("debian", "source", "include-binaries")
     file debian_include_binaries_file do
       build_include_binaries_file
     end


### PR DESCRIPTION
"debian/copyright" and "debian/source/include-binaries" are generated to "debian/copyright" not "#{PACKAGE_NAME}/debian/copyright" and so on. If we use wrong path to `file`, we always regenerate these files. It slows down `rake apt:build`.