### PR TITLE
td-agent-v4: Drop Debian buster

### DIFF
--- a/.github/workflows/apt-arm.yml
+++ b/.github/workflows/apt-arm.yml
@@ -8,15 +8,11 @@ jobs:
       fail-fast: false
       matrix:
         label:
-          - Debian GNU/Linux buster arm64
           - Debian GNU/Linux bullseye arm64
           - Ubuntu Bionic arm64
           - Ubuntu Focal arm64
           - Ubuntu Jammy arm64
         include:
-          - label: Debian GNU/Linux buster arm64
-            rake-job: debian-buster
-            test-docker-image: arm64v8/debian:buster
           - label: Debian GNU/Linux bullseye arm64
             rake-job: debian-bullseye
             test-docker-image: arm64v8/debian:bullseye

--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -10,15 +10,11 @@ jobs:
       fail-fast: false
       matrix:
         label:
-          - Debian GNU/Linux buster amd64
           - Debian GNU/Linux bullseye amd64
           - Ubuntu Bionic amd64
           - Ubuntu Focal amd64
           - Ubuntu Jammy amd64
         include:
-          - label: Debian GNU/Linux buster amd64
-            rake-job: debian-buster
-            test-docker-image: debian:buster
           - label: Debian GNU/Linux bullseye amd64
             rake-job: debian-bullseye
             test-docker-image: debian:bullseye

--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -1328,7 +1328,6 @@ EOS
 
   def apt_targets_default
     [
-      "debian-buster",
       "debian-bullseye",
       "ubuntu-bionic",
       "ubuntu-focal",


### PR DESCRIPTION
It reaches EOL already.