### PR TITLE
apt: remove deprecated piuparts stuff

### DIFF
--- a/fluent-package/apt/piuparts-test.sh
+++ b/fluent-package/apt/piuparts-test.sh
@@ -15,7 +15,7 @@ TD_AGENT_KEYRING=/usr/share/keyrings/td-agent-archive-keyring.gpg
 ${gpg_command} --no-default-keyring --keyring $TD_AGENT_KEYRING --import td-agent.gpg
 CHROOT=/var/lib/chroot/${code_name}-root
 mkdir -p $CHROOT
-debootstrap ${code_name} $CHROOT ${mirror}
+debootstrap --include=ca-certificates ${code_name} $CHROOT ${mirror}
 cp $TD_AGENT_KEYRING $CHROOT/usr/share/keyrings/
 chmod 644 $CHROOT/usr/share/keyrings/td-agent-archive-keyring.gpg
 chroot $CHROOT apt install -V -y libyaml-0-2

--- a/fluent-package/apt/piuparts-test.sh
+++ b/fluent-package/apt/piuparts-test.sh
@@ -19,11 +19,6 @@ debootstrap ${code_name} $CHROOT ${mirror}
 cp $TD_AGENT_KEYRING $CHROOT/usr/share/keyrings/
 chmod 644 $CHROOT/usr/share/keyrings/td-agent-archive-keyring.gpg
 chroot $CHROOT apt install -V -y libyaml-0-2
-if [ "${code_name}" = "bionic" ]; then
-   echo "deb http://archive.ubuntu.com/ubuntu bionic-updates main" > $CHROOT/etc/apt/sources.list
-   chroot $CHROOT apt update
-   chroot $CHROOT apt install -V -y libssl1.1
-fi
 package=${repositories_dir}/${distribution}/pool/${code_name}/${channel}/*/*/*_${architecture}.deb
 cp ${package} /tmp
 rm -rf $CHROOT/opt

--- a/fluent-package/apt/piuparts-test.sh
+++ b/fluent-package/apt/piuparts-test.sh
@@ -8,8 +8,8 @@ apt install -V -y lsb-release
 . $(dirname $0)/commonvar.sh
 
 find ${repositories_dir}
-	DEBIAN_FRONTEND=noninteractive apt install -V -y piuparts mount gnupg1 curl eatmydata
-	gpg_command=gpg1
+DEBIAN_FRONTEND=noninteractive apt install -V -y piuparts mount gnupg1 curl eatmydata
+gpg_command=gpg1
 curl https://packages.treasuredata.com/GPG-KEY-td-agent > td-agent.gpg
 TD_AGENT_KEYRING=/usr/share/keyrings/td-agent-archive-keyring.gpg
 ${gpg_command} --no-default-keyring --keyring $TD_AGENT_KEYRING --import td-agent.gpg

--- a/fluent-package/apt/piuparts-test.sh
+++ b/fluent-package/apt/piuparts-test.sh
@@ -21,6 +21,7 @@ chmod 644 $CHROOT/usr/share/keyrings/td-agent-archive-keyring.gpg
 chroot $CHROOT apt install -V -y libyaml-0-2
 package=${repositories_dir}/${distribution}/pool/${code_name}/${channel}/*/*/*_${architecture}.deb
 cp ${package} /tmp
+echo "deb [signed-by=/usr/share/keyrings/td-agent-archive-keyring.gpg] https://packages.treasuredata.com/4/${distribution}/${code_name}/ ${code_name} contrib" | tee $CHROOT/etc/apt/sources.list.d/td.list
 rm -rf $CHROOT/opt
 piuparts --distribution=${code_name} \
 	 --existing-chroot=${CHROOT} \

--- a/fluent-package/apt/piuparts-test.sh
+++ b/fluent-package/apt/piuparts-test.sh
@@ -25,6 +25,6 @@ echo "deb [signed-by=/usr/share/keyrings/td-agent-archive-keyring.gpg] https://p
 rm -rf $CHROOT/opt
 piuparts --distribution=${code_name} \
 	 --existing-chroot=${CHROOT} \
-	 --mirror="http://packages.treasuredata.com/4/${distribution}/${code_name}/ ${code_name} contrib" \
+	 --mirror="https://packages.treasuredata.com/4/${distribution}/${code_name}/ ${code_name} contrib" \
 	 --skip-logrotatefiles-test \
 	 /tmp/*_${architecture}.deb

--- a/fluent-package/apt/piuparts-test.sh
+++ b/fluent-package/apt/piuparts-test.sh
@@ -8,8 +8,8 @@ apt install -V -y lsb-release
 . $(dirname $0)/commonvar.sh
 
 find ${repositories_dir}
-DEBIAN_FRONTEND=noninteractive apt install -V -y piuparts mount gnupg1 curl eatmydata
-gpg_command=gpg1
+DEBIAN_FRONTEND=noninteractive apt install -V -y piuparts mount gnupg curl eatmydata
+gpg_command=gpg
 curl https://packages.treasuredata.com/GPG-KEY-td-agent > td-agent.gpg
 TD_AGENT_KEYRING=/usr/share/keyrings/td-agent-archive-keyring.gpg
 ${gpg_command} --no-default-keyring --keyring $TD_AGENT_KEYRING --import td-agent.gpg

--- a/fluent-package/apt/piuparts-test.sh
+++ b/fluent-package/apt/piuparts-test.sh
@@ -25,7 +25,6 @@ echo "deb [signed-by=/usr/share/keyrings/td-agent-archive-keyring.gpg] https://p
 rm -rf $CHROOT/opt
 piuparts --distribution=${code_name} \
 	 --existing-chroot=${CHROOT} \
-	 --keyring=$TD_AGENT_KEYRING \
 	 --mirror="http://packages.treasuredata.com/4/${distribution}/${code_name}/ ${code_name} contrib" \
 	 --skip-logrotatefiles-test \
 	 /tmp/*_${architecture}.deb

--- a/fluent-package/apt/piuparts-test.sh
+++ b/fluent-package/apt/piuparts-test.sh
@@ -16,8 +16,8 @@ ${gpg_command} --no-default-keyring --keyring $TD_AGENT_KEYRING --import td-agen
 CHROOT=/var/lib/chroot/${code_name}-root
 mkdir -p $CHROOT
 debootstrap ${code_name} $CHROOT ${mirror}
-cp $TD_AGENT_KEYRING $CHROOT/etc/apt/trusted.gpg.d/
-chmod 644 $CHROOT/etc/apt/trusted.gpg.d/td-agent-archive-keyring.gpg
+cp $TD_AGENT_KEYRING $CHROOT/usr/share/keyrings/
+chmod 644 $CHROOT/usr/share/keyrings/td-agent-archive-keyring.gpg
 chroot $CHROOT apt install -V -y libyaml-0-2
 if [ "${code_name}" = "bionic" ]; then
    echo "deb http://archive.ubuntu.com/ubuntu bionic-updates main" > $CHROOT/etc/apt/sources.list

--- a/fluent-package/apt/piuparts-test.sh
+++ b/fluent-package/apt/piuparts-test.sh
@@ -8,17 +8,8 @@ apt install -V -y lsb-release
 . $(dirname $0)/commonvar.sh
 
 find ${repositories_dir}
-case ${code_name} in
-    jammy)
-	# TODO: Remove when repository for jammy has been deployed
-	echo "skip piuparts test for jammy"
-	exit 0
-	;;
-    *)
 	DEBIAN_FRONTEND=noninteractive apt install -V -y piuparts mount gnupg1 curl eatmydata
 	gpg_command=gpg1
-	;;
-esac
 curl https://packages.treasuredata.com/GPG-KEY-td-agent > td-agent.gpg
 TD_AGENT_KEYRING=/usr/share/keyrings/td-agent-archive-keyring.gpg
 ${gpg_command} --no-default-keyring --keyring $TD_AGENT_KEYRING --import td-agent.gpg

--- a/fluent-package/apt/piuparts-test.sh
+++ b/fluent-package/apt/piuparts-test.sh
@@ -9,10 +9,6 @@ apt install -V -y lsb-release
 
 find ${repositories_dir}
 case ${code_name} in
-    xenial)
-	apt install -V -y piuparts mount gnupg curl eatmydata apt-transport-https
-	gpg_command=gpg
-	;;
     jammy)
 	# TODO: Remove when repository for jammy has been deployed
 	echo "skip piuparts test for jammy"


### PR DESCRIPTION
   * xenial (16.04LTS) was already reached EOL.
   * do not skip piuparts for jammy (22.04)
   * use recent gnupg (old version is used for xenial, no
     need to do so)
   * remove unused bionic configuration
   * fix key verification failure of keyring path

