### PR TITLE
deb: add bookworm

### DIFF
--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -1260,6 +1260,7 @@ EOS
   def apt_targets_default
     [
       "debian-bullseye",
+      "debian-bookworm",
       "ubuntu-focal",
       "ubuntu-jammy",
     ]

--- a/fluent-package/apt/commonvar.sh
+++ b/fluent-package/apt/commonvar.sh
@@ -19,4 +19,10 @@ case ${code_name} in
     channel=main
     mirror=http://deb.debian.org/debian
     ;;
+  bookworm)
+    distribution=debian
+    channel=main
+    mirror=http://deb.debian.org/debian
+    java_jdk=openjdk-17-jre
+    ;;
 esac

--- a/fluent-package/apt/debian-bookworm-arm64/from
+++ b/fluent-package/apt/debian-bookworm-arm64/from
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+arm64v8/debian:bookworm

--- a/fluent-package/apt/debian-bookworm/Dockerfile
+++ b/fluent-package/apt/debian-bookworm/Dockerfile
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ARG FROM=debian:bookworm
+FROM ${FROM}
+
+COPY qemu-* /usr/bin/
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+ARG DEBUG
+
+RUN sed -i'' -e 's/main$/main contrib non-free-firmware/g' /etc/apt/sources.list.d/debian.sources
+RUN sed -i'' -e 's/^Types: deb/Types: deb deb-src/g' /etc/apt/sources.list.d/debian.sources
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    build-essential \
+    debhelper \
+    devscripts \
+    ruby-dev \
+    ruby-bundler \
+    libedit2 \
+    libncurses5-dev \
+    libyaml-dev \
+    libffi-dev \
+    libreadline-dev \
+    git \
+    pkg-config \
+    libssl-dev \
+    libpq-dev \
+    tar \
+    lsb-release \
+    zlib1g-dev \
+    cmake && \
+  apt build-dep -y ruby && \
+  apt clean && \
+  # raise IPv4 priority
+  sed -i'' -e 's,#precedence ::ffff:0:0/96  100,precedence ::ffff:0:0/96  100,' /etc/gai.conf && \
+  # enable multiplatform feature
+  gem install --no-document --install-dir /usr/share/rubygems-integration/all bundler builder && \
+  rm -rf /var/lib/apt/lists/* && \
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/fluent-package/apt/debian-bookworm/qemu-dummy-static
+++ b/fluent-package/apt/debian-bookworm/qemu-dummy-static
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Do nothing. This exists only for not requiring qemu-aarch64-static copy.
+# Recent Debian (buster or later) and Ubuntu (18.10 or later) on amd64 hosts or
+# arm64 host don't require qemu-aarch64-static in Docker image. But old Debian
+# and Ubuntu hosts on amd64 require qemu-aarch64-static in Docker image.
+#
+# We use "COPY qemu* /usr/bin/" in Dockerfile. If we don't put any "qemnu*",
+# the "COPY" is failed. It means that we always require "qemu*" even if we
+# use recent Debian/Ubuntu or arm64 host. If we have this dummy "qemu*" file,
+# the "COPY" isn't failed. It means that we can copy "qemu*" only when we
+# need.
+#
+# See also "script" in dev/tasks/linux-packages/azure.linux.arm64.yml.
+# Azure Pipelines uses old Ubuntu (18.04).
+# So we need to put "qemu-aarch64-static" into this directory.

--- a/fluent-package/apt/pkgsize-test.sh
+++ b/fluent-package/apt/pkgsize-test.sh
@@ -16,6 +16,11 @@ ARCH=$2
 
 REPOSITORIES_DIR=fluent-package/apt/repositories
 
+if [ "${code_name}" == "bookworm" ]; then
+    echo "As bookworm is not published yet, so package size check for ${code_name} is disabled"
+    exit 0
+fi
+
 if [ -f .git/shallow ]; then
     git fetch --unshallow
 fi

--- a/fluentd-apt-source/Rakefile
+++ b/fluentd-apt-source/Rakefile
@@ -86,6 +86,8 @@ class FluentdAptSourcePackageTask < PackageTask
   def apt_targets_default
     [
       "debian-buster",
+      "debian-bulleye",
+      "debian-bookworm",
       "ubuntu-xenial",
       "ubuntu-bionic",
       "ubuntu-focal",

--- a/fluentd-apt-source/apt/debian-bookworm/Dockerfile
+++ b/fluentd-apt-source/apt/debian-bookworm/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:bookworm
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    debhelper \
+    devscripts \
+    gnupg && \
+  apt clean && \
+  rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Debian 12 (bookworm) is scheduled to be released 6/10.

Note that bookworm container adopts deb822 format by default.
deb822 is similar to RFS 822.

/etc/apt/sources.list.d/debian.sources:

    Types: deb
    # http://snapshot.debian.org/archive/debian/20230411T000000Z
    URIs: http://deb.debian.org/debian
    Suites: bookworm bookworm-updates
    Components: main
    Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg

