### PR TITLE
msi: migrate FeatureMainName

### DIFF
--- a/fluent-package/msi/localization-en-us.wxl
+++ b/fluent-package/msi/localization-en-us.wxl
@@ -15,7 +15,7 @@
 
   <String Id="VerifyReadyDlgInstallTitle">{\WixUI_Font_Title_White}Ready to install [ProductName]</String>
 
-  <String Id="FeatureMainName">Td-agent</String>
+  <String Id="FeatureMainName">Fluent Package</String>
 
   <String Id="MinimumOSVersionMessage">This package requires minimum OS version: Windows 7/Windows Server 2008 R2 or greater.</String>
   <String Id="DowngradeErrorMessage">A newer version of [ProductName] is already installed.</String>


### PR DESCRIPTION
![2023-05-18_13h59_43](https://github.com/fluent/fluent-package-builder/assets/12229857/7b35b5a0-4e8a-4afa-aab8-9d0380b3894a)

It seems that we need to fix this feature name too, related to 

* #449