### PR TITLE
migrate to new user/group name

### DIFF
--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -503,7 +503,11 @@ class BuildTask
         configs.each do |config|
           src = template_path(config)
           dest = File.join(STAGING_DIR, config)
-          render_template(dest, src, template_params)
+          if File.readlines("/etc/os-release").any? { |entry| ["ID=debian", "ID=ubuntu"].include?(entry.chomp) }
+            render_template(dest, src, template_params({ pkg_type: "deb"}))
+          else
+            render_template(dest, src, template_params({ pkg_type: "rpm"}))
+          end
         end
       end
 

--- a/fluent-package/templates/etc/systemd/fluentd.service.erb
+++ b/fluent-package/templates/etc/systemd/fluentd.service.erb
@@ -5,8 +5,13 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-User=<%= Shellwords.shellescape(compat_service_name) %>
-Group=<%= Shellwords.shellescape(compat_service_name) %>
+<% if pkg_type == 'deb' %>
+User=_<%= Shellwords.shellescape(service_name) %>
+Group=_<%= Shellwords.shellescape(service_name) %>
+<% else %>
+User=<%= Shellwords.shellescape(service_name) %>
+Group=<%= Shellwords.shellescape(service_name) %>
+<% end %>
 LimitNOFILE=65536
 Environment=LD_PRELOAD=<%= install_path %>/lib/libjemalloc.so
 Environment=GEM_HOME=<%= gem_install_path %>/

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postinst
@@ -7,25 +7,43 @@ set -e
 prevver="$2"
 
 add_system_user() {
-    if ! getent passwd <%= compat_service_name %> >/dev/null; then
-        adduser --group --system --home /var/lib/<%= package_dir %> <%= compat_service_name %>
+    if ! getent passwd _<%= service_name %> >/dev/null; then
+	if ! getent passwd <%= compat_service_name %> >/dev/null; then
+	    # With underscore prefix, need to disable NAME_REGEX restriction
+	    adduser --group --system --force-badname --home /var/lib/<%= package_dir %> _<%= service_name %>
+	else
+	    if getent group <%= compat_service_name %> >/dev/null; then
+		groupmod --new-name _<%= service_name %> <%= compat_service_name %>
+	    fi
+	    if getent passwd <%= compat_service_name %> >/dev/null; then
+		usermod --login _<%= service_name %> <%= compat_service_name %>
+	    fi
+	fi
     fi
 }
 
 add_directories() {
     mkdir -p /var/run/<%= package_dir %>
-    mkdir -p /etc/<%= package_dir %>
-    mkdir -p /etc/<%= package_dir %>/plugin
-    mkdir -p /var/log/<%= package_dir %>
+    mkdir -p /etc/<%= compat_package_dir %>
+    mkdir -p /etc/<%= compat_package_dir %>/plugin
+    mkdir -p /var/log/<%= compat_package_dir %>
 }
 
 fixperms() {
+    # If statoverride entry exits, use --force-all to ensure statoverride-add will work.
+    # If statoverride entry doen't exit, no need to --force-all.
     dpkg-statoverride --list /var/run/<%= package_dir %> >/dev/null || \
-        dpkg-statoverride --update --add <%= compat_service_name %> <%= compat_service_name %> 0755 /var/run/<%= package_dir %>
-    dpkg-statoverride --list /etc/<%= package_dir %> >/dev/null || \
-        dpkg-statoverride --update --add <%= compat_service_name %> <%= compat_service_name %> 0755 /etc/<%= package_dir %>
-    dpkg-statoverride --list /var/log/<%= package_dir %> >/dev/null || \
-        dpkg-statoverride --update --add <%= compat_service_name %> <%= compat_service_name %> 0755 /var/log/<%= package_dir %>
+        dpkg-statoverride --update --add _<%= service_name %> _<%= service_name %> 0755 /var/run/<%= package_dir %>
+    dpkg-statoverride --list /var/run/<%= package_dir %> >/dev/null && \
+        dpkg-statoverride --force-all --update --add _<%= service_name %> _<%= service_name %> 0755 /var/run/<%= package_dir %>
+    dpkg-statoverride --list /etc/<%= compat_package_dir %> >/dev/null || \
+        dpkg-statoverride --update --add _<%= service_name %> _<%= service_name %> 0755 /etc/<%= compat_package_dir %>
+    dpkg-statoverride --list /etc/<%= compat_package_dir %> >/dev/null && \
+        dpkg-statoverride --force-all --update --add _<%= service_name %> _<%= service_name %> 0755 /etc/<%= compat_package_dir %>
+    dpkg-statoverride --list /var/log/<%= compat_package_dir %> >/dev/null || \
+        dpkg-statoverride --update --add _<%= service_name %> _<%= service_name %> 0755 /var/log/<%= compat_package_dir %>
+    dpkg-statoverride --list /var/log/<%= compat_package_dir %> >/dev/null && \
+        dpkg-statoverride --force-all --update --add _<%= service_name %> _<%= service_name %> 0755 /var/log/<%= compat_package_dir %>
 }
 
 case "$1" in

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postinst
@@ -44,6 +44,8 @@ fixperms() {
         dpkg-statoverride --update --add _<%= service_name %> _<%= service_name %> 0755 /var/log/<%= compat_package_dir %>
     dpkg-statoverride --list /var/log/<%= compat_package_dir %> >/dev/null && \
         dpkg-statoverride --force-all --update --add _<%= service_name %> _<%= service_name %> 0755 /var/log/<%= compat_package_dir %>
+    # Cleanup /var/run/<%= compat_package_dir %>
+    dpkg-statoverride --force-all --remove /var/run/<%= compat_package_dir %>
 }
 
 case "$1" in

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postrm
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postrm
@@ -6,21 +6,21 @@ set -e
 
 if [ "$1" = "purge" ]; then
 	rm -f /etc/default/<%= compat_service_name %>
-	dpkg-statoverride --list /etc/<%= package_dir %> > /dev/null && \
-		dpkg-statoverride --remove /etc/<%= package_dir %>
-	rm -f /etc/<%= package_dir %>/<%= compat_service_name %>.conf
-	rm -rf /etc/<%= package_dir %>
+	dpkg-statoverride --list /etc/<%= compat_package_dir %> > /dev/null && \
+		dpkg-statoverride --remove /etc/<%= compat_package_dir %>
+	rm -f /etc/<%= compat_package_dir %>/<%= compat_service_name %>.conf
+	rm -rf /etc/<%= compat_package_dir %>
 	dpkg-statoverride --list /var/run/<%= package_dir %> > /dev/null && \
 		dpkg-statoverride --remove /var/run/<%= package_dir %>
 	rm -f /var/run/<%= package_dir %>/*
 	rm -rf /var/run/<%= package_dir %>
-	dpkg-statoverride --list /var/log/<%= package_dir %> > /dev/null && \
-		dpkg-statoverride --remove /var/log/<%= package_dir %>
-	rm -rf /var/log/<%= package_dir %>/buffer
-	rm -rf /var/log/<%= package_dir %>/*
-	rm -rf /var/log/<%= package_dir %>
+	dpkg-statoverride --list /var/log/<%= compat_package_dir %> > /dev/null && \
+		dpkg-statoverride --remove /var/log/<%= compat_package_dir %>
+	rm -rf /var/log/<%= compat_package_dir %>/buffer
+	rm -rf /var/log/<%= compat_package_dir %>/*
+	rm -rf /var/log/<%= compat_package_dir %>
 
-	getent passwd <%= compat_service_name %> && userdel -r <%= compat_service_name %>
+	getent passwd _<%= service_name %> && userdel -r _<%= service_name %>
 fi
 
 #DEBHELPER#

--- a/fluent-package/templates/usr/lib/tmpfiles.d/fluentd.conf
+++ b/fluent-package/templates/usr/lib/tmpfiles.d/fluentd.conf
@@ -1,9 +1,21 @@
-d /tmp/<%= package_dir %> 0755 <%= compat_service_name %> <%= compat_service_name %> - -
-<% if ENV["NO_VAR_RUN"] %>
-d /run/<%= package_dir %> 0755 <%= compat_service_name %> <%= compat_service_name %> - -
+<% if pkg_type == "deb" %>
+d /tmp/<%= package_dir %> 0755 _<%= service_name %> _<%= service_name %> - -
 <% else %>
-d /var/run/<%= package_dir %> 0755 <%= compat_service_name %> <%= compat_service_name %> - -
+d /tmp/<%= package_dir %> 0755 <%= service_name %> <%= service_name %> - -
+<% end %>
+<% if pkg_type == "deb" %>
+<% if ENV["NO_VAR_RUN"] %>
+d /run/<%= package_dir %> 0755 _<%= service_name %> _<%= service_name %> - -
+<% else %>
+d /var/run/<%= package_dir %> 0755 _<%= service_name %> _<%= service_name %> - -
+<% end %>
+<% else %>
+<% if ENV["NO_VAR_RUN"] %>
+d /run/<%= package_dir %> 0755 <%= service_name %> <%= service_name %> - -
+<% else %>
+d /var/run/<%= package_dir %> 0755 <%= service_name %> <%= service_name %> - -
+<% end %>
 <% end %>
 
-# Exclude td-agent
+# Exclude <%= service_name %>
 x /tmp/<%= package_dir %>

--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -139,14 +139,32 @@ mkdir -p %{buildroot}/tmp/@PACKAGE_DIR@
 
 %pre
 if ! getent group @COMPAT_SERVICE_NAME@ >/dev/null; then
-    /usr/sbin/groupadd -r @COMPAT_SERVICE_NAME@
+    if ! getent group @SERVICE_NAME@ >/dev/null; then
+        /usr/sbin/groupadd -r @SERVICE_NAME@
+    fi
+else
+    if ! getent group @SERVICE_NAME@ >/dev/null; then
+       echo "Migrate group @COMPAT_SERVICE_NAME@ to @SERVICE_NAME@..."
+       /usr/sbin/groupmod --new-name @SERVICE_NAME@ @COMPAT_SERVICE_NAME@
+    fi
 fi
 if ! getent passwd @COMPAT_SERVICE_NAME@ >/dev/null; then
+    if ! getent passwd @SERVICE_NAME@ >/dev/null; then
 %if %{use_suse}
-    /usr/sbin/useradd -r -g @COMPAT_SERVICE_NAME@ -d %{_localstatedir}/lib/@PACKAGE_DIR@ -s /sbin/nologin -c '@COMPAT_SERVICE_NAME@' @COMPAT_SERVICE_NAME@
+        /usr/sbin/useradd -r -g @SERVICE_NAME@ -d %{_localstatedir}/lib/@PACKAGE_DIR@ -s /sbin/nologin -c '@SERVICE_NAME@' @SERVICE_NAME@
 %else
-    /usr/sbin/adduser -r -g @COMPAT_SERVICE_NAME@ -d %{_localstatedir}/lib/@PACKAGE_DIR@ -s /sbin/nologin -c '@COMPAT_SERVICE_NAME@' @COMPAT_SERVICE_NAME@
+        /usr/sbin/adduser -r -g @SERVICE_NAME@ -d %{_localstatedir}/lib/@PACKAGE_DIR@ -s /sbin/nologin -c '@SERVICE_NAME@' @SERVICE_NAME@
 %endif
+    fi
+else
+    if ! getent passwd @SERVICE_NAME@ >/dev/null; then
+       systemctl is-active @COMPAT_SERVICE_NAME@
+       if [ $? -ne 0 ]; then
+           # As service is down, renaming user here.
+	   echo "Migrate user @COMPAT_SERVICE_NAME@ to @SERVICE_NAME@..."
+           /usr/sbin/usermod --login @SERVICE_NAME@ @COMPAT_SERVICE_NAME@
+       fi
+    fi
 fi
 
 %preun
@@ -157,6 +175,16 @@ fi
 if [ $1 -eq 1 ]; then
     systemctl is-active @COMPAT_SERVICE_NAME@
     if [ $? -eq 0 ]; then
+	if getent passwd @COMPAT_SERVICE_NAME@ >/dev/null; then
+	    if ! getent passwd @SERVICE_NAME@ >/dev/null; then
+		# usermod fails when user process is active, so
+		# postpone username migration step here. (During %pre
+		# stage, mismatch of user/group configuration cause
+		# restarting service failure.)
+		systemctl stop @COMPAT_SERVICE_NAME@.service
+		/usr/sbin/usermod --login @SERVICE_NAME@ @COMPAT_SERVICE_NAME@
+	    fi
+	fi
 	# When upgrading from v4, td-agent.service will be removed
 	# with %postun scriptlet. fluentd service also inactive even though
 	# td-agent.service is running before upgrade process. Try to
@@ -221,12 +249,12 @@ fi
 %config(noreplace) %{_sysconfdir}/sysconfig/@SERVICE_NAME@
 %config(noreplace) %{_sysconfdir}/@COMPAT_PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/@COMPAT_SERVICE_NAME@
-%attr(0755,td-agent,td-agent) %dir %{_localstatedir}/log/@COMPAT_PACKAGE_DIR@
-%attr(0755,td-agent,td-agent) %dir %{_localstatedir}/log/@COMPAT_PACKAGE_DIR@/buffer
-%attr(0755,td-agent,td-agent) %dir %{_sysconfdir}/@COMPAT_PACKAGE_DIR@
-%attr(0755,td-agent,td-agent) %dir %{_sysconfdir}/@COMPAT_PACKAGE_DIR@/plugin
+%attr(0755,fluentd,fluentd) %dir %{_localstatedir}/log/@COMPAT_PACKAGE_DIR@
+%attr(0755,fluentd,fluentd) %dir %{_localstatedir}/log/@COMPAT_PACKAGE_DIR@/buffer
+%attr(0755,fluentd,fluentd) %dir %{_sysconfdir}/@COMPAT_PACKAGE_DIR@
+%attr(0755,fluentd,fluentd) %dir %{_sysconfdir}/@COMPAT_PACKAGE_DIR@/plugin
 # NOTE: %{_tmpfilesdir} is available since CentOS 7
-%attr(0755,td-agent,td-agent) %dir /tmp/@PACKAGE_DIR@
+%attr(0755,fluentd,fluentd) %dir /tmp/@PACKAGE_DIR@
 %changelog
 * Tue Jan 17 2023 Takuro Ashie <ashie@clear-code.com> - 5.0.0-1
 - New upstream release.

--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -221,6 +221,18 @@ if [ -f /usr/sbin/@COMPAT_SERVICE_NAME@-gem ]; then
   rm -f /usr/sbin/@COMPAT_SERVICE_NAME@-gem
 fi
 
+if [ $1 -eq 0 ]; then
+   # Removing
+   if getent passwd @SERVICE_NAME@ >/dev/null; then
+       echo "Removing @SERVICE_NAME@ user..."
+       /usr/sbin/userdel --remove @SERVICE_NAME@
+   fi
+   if getent group @SERVICE_NAME@ >/dev/null; then
+       echo "Removing @SERVICE_NAME@ group..."
+       /usr/sbin/groupdel @SERVICE_NAME@
+   fi
+fi
+
 %posttrans
 if [ ! -f /usr/sbin/@COMPAT_SERVICE_NAME@ ]; then
   # provides /usr/sbin/td-agent for backward compatibility

--- a/serverspec/linux/td-agent.rb
+++ b/serverspec/linux/td-agent.rb
@@ -7,13 +7,24 @@ describe package("fluent-package") do
   it { should be_installed }
 end
 
-describe user("td-agent") do
-  it { should exist }
-  it { should belong_to_group "td-agent" }
-end
+if os[:family] == 'redhat'
+  describe user("fluentd") do
+    it { should exist }
+    it { should belong_to_group "fluentd" }
+  end
 
-describe group("td-agent") do
-  it { should exist }
+  describe group("fluentd") do
+    it { should exist }
+  end
+else
+  describe user("_fluentd") do
+    it { should exist }
+    it { should belong_to_group "_fluentd" }
+  end
+
+  describe group("_fluentd") do
+    it { should exist }
+  end
 end
 
 describe "gem files" do


### PR DESCRIPTION
for deb, according Debian policy, dynamically allocated name should be prefixed
with an underscore.
(It may be not applicable for group name, but there is an prefixed
group name example e.g. _ssh/_cvsadmin)

See
https://www.debian.org/doc/debian-policy/ch-opersys.html#introduction

Note that adduser doesn't accept _name prefix by default. To avoid
it, we need to specify --force-badname explicitly

  * migration from to td-agent to _fluentd
    * service, hook script, tmpfiles.d and so on.
    * cleanup td-agent statoverride

For rpm, no prefixed underscore for user/group name.

  * migration from td-agent to fluentd
    * service, hook script, tmpfiles.d, permission and so on.
    * cleanup user/group on removing package


