### PR TITLE
dmg: change identifier

### DIFF
--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -1485,7 +1485,7 @@ class MacOSPackageTask
       sh("pkgbuild",
          "--root", STAGING_DIR,
          "--component-plist", File.join("resources", "pkg", "#{SERVICE_NAME}.plist"),
-         "--identifier", "com.treasuredata.tdagent",
+         "--identifier", "org.fluent.fluentd",
          "--version", @version,
          "--scripts", File.join("resources", "pkg", "scripts"),
          "--install-location", "/",

--- a/fluent-package/dmg/resources/pkg/Distribution.xml.erb
+++ b/fluent-package/dmg/resources/pkg/Distribution.xml.erb
@@ -9,6 +9,6 @@
         <line choice="default"/>
     </choices-outline>
     <choice id="default">
-        <pkg-ref id="com.treasuredata.tdagent" version="<%= version %>" onConclusion="none">fluent-package.pkg</pkg-ref>
+        <pkg-ref id="org.fluent.fluentd" version="<%= version %>" onConclusion="none">fluent-package.pkg</pkg-ref>
     </choice>
 </installer-gui-script>


### PR DESCRIPTION
It should be fine as long as it is unique.
`org.fluent.fluentd` would be appropriate.