### PR TITLE
dmg: fix bin scripts paths

### DIFF
--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -517,7 +517,9 @@ class BuildTask
         scripts.each do |script|
           src = template_path("#{script}.erb")
           dest = if macos?
-                   File.join(STAGING_DIR, File.join("opt", PACKAGE_DIR, script))
+                   # We should avoid touching `/usr/sbin/` because we
+                   # don't prepare the uninstall feature for macOS.
+                   File.join(td_agent_staging_dir, "sbin", File.basename(script))
                  else
                    File.join(STAGING_DIR, script)
                  end

--- a/fluent-package/templates/fluentd.plist.erb
+++ b/fluent-package/templates/fluentd.plist.erb
@@ -8,7 +8,7 @@
   <string><%= project_name %></string>
   <key>ProgramArguments</key>
   <array>
-    <string>/opt/<%= package_dir %>/usr/sbin/<%= service_name %></string>
+    <string>/opt/<%= package_dir %>/sbin/<%= service_name %></string>
     <string>--log</string>
     <string>/var/log/<%= compat_package_dir %>/<%= service_name %>.log</string>
     <string>--use-v1-config</string>


### PR DESCRIPTION
Change both `/opt/fluent/usr/sbin/` and `/opt/fluent/usr/bin/` paths
to `/opt/fluent/sbin/` for simplicity.

Note: we can't put them into `/opt/fluent/bin/` because the filenames
conflict with internal Fluentd gems.