### PR TITLE
msi: migrate td-agent*.bat

### DIFF
--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -544,8 +544,8 @@ class BuildTask
         ensure_directory(staging_bindir)
         cp("msi/assets/#{PACKAGE_NAME}-prompt.bat", td_agent_staging_dir)
         cp("msi/assets/#{PACKAGE_NAME}-post-install.bat", staging_bindir)
-        cp("msi/assets/#{COMPAT_SERVICE_NAME}.bat", staging_bindir)
-        cp("msi/assets/#{COMPAT_SERVICE_NAME}-gem.bat", staging_bindir)
+        cp("msi/assets/#{SERVICE_NAME}.bat", td_agent_staging_dir)
+        cp("msi/assets/fluent-gem.bat", td_agent_staging_dir)
         cp("msi/assets/#{PACKAGE_NAME}-version.rb", staging_bindir)
       end
 

--- a/fluent-package/msi/assets/fluent-gem.bat
+++ b/fluent-package/msi/assets/fluent-gem.bat
@@ -1,0 +1,8 @@
+@echo off
+set FLUENT_PACKAGE_TOPDIR=%~dp0
+set FLUENT_PACKAGE_BINDIR=%FLUENT_PACKAGE_TOPDIR%bin
+set PATH="%FLUENT_PACKAGE_BINDIR%";%PATH%
+for /f "usebackq" %%i in (`%FLUENT_PACKAGE_BINDIR%\ruby.exe -rrbconfig -e "print RbConfig::CONFIG['ruby_version']"`) do set RUBY_VERSION=%%i
+set GEM_HOME=%FLUENT_PACKAGE_TOPDIR%lib\ruby\gems\%RUBY_VERSION%
+set GEM_PATH=%FLUENT_PACKAGE_TOPDIR%lib\ruby\gems\%RUBY_VERSION%
+%FLUENT_PACKAGE_BINDIR%\fluent-gem %*

--- a/fluent-package/msi/assets/fluent-gem.bat
+++ b/fluent-package/msi/assets/fluent-gem.bat
@@ -1,5 +1,9 @@
 @echo off
-set FLUENT_PACKAGE_TOPDIR=%~dp0
+if "%~nx0" == "td-agent-gem.bat" (
+  set FLUENT_PACKAGE_TOPDIR=%~dp0..\
+) else (
+  set FLUENT_PACKAGE_TOPDIR=%~dp0
+)
 set FLUENT_PACKAGE_BINDIR=%FLUENT_PACKAGE_TOPDIR%bin
 set PATH="%FLUENT_PACKAGE_BINDIR%";%PATH%
 for /f "usebackq" %%i in (`%FLUENT_PACKAGE_BINDIR%\ruby.exe -rrbconfig -e "print RbConfig::CONFIG['ruby_version']"`) do set RUBY_VERSION=%%i

--- a/fluent-package/msi/assets/fluent-package-prompt.bat
+++ b/fluent-package/msi/assets/fluent-package-prompt.bat
@@ -1,3 +1,4 @@
 @echo off
 set PATH="%~dp0\bin";%PATH%
+set PATH="%~dp0";%PATH%
 title Fluent Package Command Prompt

--- a/fluent-package/msi/assets/fluentd.bat
+++ b/fluent-package/msi/assets/fluentd.bat
@@ -1,6 +1,11 @@
 @echo off
-set TD_AGENT_TOPDIR=%~dp0
-set PATH="%~dp0";%PATH%
+if "%~nx0" == "td-agent.bat" (
+  set TD_AGENT_TOPDIR=%~dp0..\
+) else (
+  set TD_AGENT_TOPDIR=%~dp0
+)
+set PATH=%TD_AGENT_TOPDIR%bin;%PATH%
+set PATH=%TD_AGENT_TOPDIR%;%PATH%
 set FLUENT_CONF=%TD_AGENT_TOPDIR%\etc\td-agent\td-agent.conf
 set FLUENT_PLUGIN=%TD_AGENT_TOPDIR%\etc\td-agent\plugin
 set TD_AGENT_VERSION=%TD_AGENT_TOPDIR%\bin\fluent-package-version.rb

--- a/fluent-package/msi/assets/fluentd.bat
+++ b/fluent-package/msi/assets/fluentd.bat
@@ -1,5 +1,5 @@
 @echo off
-set TD_AGENT_TOPDIR=%~dp0\..
+set TD_AGENT_TOPDIR=%~dp0
 set PATH="%~dp0";%PATH%
 set FLUENT_CONF=%TD_AGENT_TOPDIR%\etc\td-agent\td-agent.conf
 set FLUENT_PLUGIN=%TD_AGENT_TOPDIR%\etc\td-agent\plugin

--- a/fluent-package/msi/assets/td-agent-gem.bat
+++ b/fluent-package/msi/assets/td-agent-gem.bat
@@ -1,3 +1,0 @@
-@echo off
-set TD_AGENT_BINDIR=%~dp0
-"%TD_AGENT_BINDIR%fluent-gem" %*

--- a/fluent-package/msi/exclude-files.xslt
+++ b/fluent-package/msi/exclude-files.xslt
@@ -25,7 +25,7 @@
     <xsl:template match="*[self::wix:Component or self::wix:ComponentRef][key('conf-search', @Id)]" />
     <xsl:key
         name="service-bat-search"
-        match="wix:Component[wix:File/@Source = '$(var.ProjectSourceDir)\bin\td-agent.bat']"
+        match="wix:Component[wix:File/@Source = '$(var.ProjectSourceDir)\fluentd.bat']"
         use="@Id" />
     <xsl:template match="*[self::wix:Component or self::wix:ComponentRef][key('service-bat-search', @Id)]" />
 </xsl:stylesheet>

--- a/fluent-package/msi/install-test.ps1
+++ b/fluent-package/msi/install-test.ps1
@@ -6,6 +6,7 @@ Write-Host "Installing ${msi} ..."
 Start-Process msiexec -ArgumentList "/i", $msi, "/quiet" -Wait -NoNewWindow
 
 $ENV:PATH="C:\\opt\\td-agent\\bin;" + $ENV:PATH
+$ENV:PATH="C:\\opt\\td-agent;" + $ENV:PATH
 
 td-agent --version
 

--- a/fluent-package/msi/serverspec-test.ps1
+++ b/fluent-package/msi/serverspec-test.ps1
@@ -6,6 +6,7 @@ Write-Host "Installing ${msi} ..."
 Start-Process msiexec -ArgumentList "/i", $msi, "/quiet" -Wait -NoNewWindow
 
 $ENV:PATH="C:\\opt\\td-agent\\bin;" + $ENV:PATH
+$ENV:PATH="C:\\opt\\td-agent;" + $ENV:PATH
 
 td-agent --version
 

--- a/fluent-package/msi/source.wxs
+++ b/fluent-package/msi/source.wxs
@@ -93,19 +93,15 @@
           </Component>
         </Directory>
       </Directory>
-      <Directory Id="TDAgentBinDir"
-                 Name="bin"
-                 ComponentGuidGenerationSeed="3ad15499-f8a4-471b-bc7f-16aa4abfd894">
-        <Component Id="TDAgentBat">
-          <File Name="td-agent.bat"
-                KeyPath="yes"
-                Source="$(var.ProjectSourceDir)\bin\td-agent.bat" />
-          <ServiceControl Id="ServiceControlFluentdWinSvc"
-                          Name="fluentdwinsvc"
-                          Stop="uninstall"
-                          Remove="uninstall" />
-        </Component>
-      </Directory>
+      <Component Id="FluentdBat" Guid="261158e8-7b22-48ff-b7eb-9f8296f30236">
+        <File Name="fluentd.bat"
+              KeyPath="yes"
+              Source="$(var.ProjectSourceDir)\fluentd.bat" />
+        <ServiceControl Id="ServiceControlFluentdWinSvc"
+                        Name="fluentdwinsvc"
+                        Stop="uninstall"
+                        Remove="uninstall" />
+      </Component>
     </DirectoryRef>
 
     <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
@@ -131,8 +127,8 @@
       <ComponentGroupRef Id="ProjectDir" />
       <ComponentRef Id="ApplicationShortcut" />
       <ComponentRef Id="TDAgentConf" />
-      <ComponentRef Id="TDAgentBat" />
       <ComponentRef Id="TDAgentAcl" />
+      <ComponentRef Id="FluentdBat" />
     </Feature>
 
     <!-- UI Stuff -->
@@ -170,7 +166,7 @@
     <Property Id="InstallFluentdWinSvc" Value=" "/>
     <CustomAction Id="SetInstallFluentdWinSvcCommand"
                   Property="InstallFluentdWinSvc"
-                  Value="&quot;[PROJECTLOCATION]bin\td-agent.bat&quot; --reg-winsvc i --reg-winsvc-delay-start --reg-winsvc-auto-start --reg-winsvc-fluentdopt &quot;-c [PROJECTLOCATION]etc\td-agent\td-agent.conf -o [PROJECTLOCATION]td-agent.log&quot;"/>
+                  Value="&quot;[PROJECTLOCATION]fluentd.bat&quot; --reg-winsvc i --reg-winsvc-delay-start --reg-winsvc-auto-start --reg-winsvc-fluentdopt &quot;-c [PROJECTLOCATION]etc\td-agent\td-agent.conf -o [PROJECTLOCATION]td-agent.log&quot;"/>
     <CustomAction Id="InstallFluentdWinSvc"
                   BinaryKey="WixCA"
                   DllEntry="WixQuietExec64"

--- a/fluent-package/msi/source.wxs
+++ b/fluent-package/msi/source.wxs
@@ -173,11 +173,65 @@
                   Execute="deferred"
                   Return="check"
                   Impersonate="no" />
+
+    <Property Id="CreateCompatTdAgentBat" Value=" "/>
+    <CustomAction Id="SetCreateCompatTdAgentBat"
+                  Property="CreateCompatTdAgentBat"
+                  Value="&quot;cmd&quot; /c &quot;fsutil hardlink create [PROJECTLOCATION]bin\td-agent.bat [PROJECTLOCATION]fluentd.bat&quot;"/>
+    <CustomAction Id="CreateCompatTdAgentBat"
+                  BinaryKey="WixCA"
+                  DllEntry="WixQuietExec64"
+                  Execute="deferred"
+                  Return="check"
+                  Impersonate="no" />
+    <Property Id="CreateCompatTdAgentGemBat" Value=" "/>
+    <CustomAction Id="SetCreateCompatTdAgentGemBat"
+                  Property="CreateCompatTdAgentGemBat"
+                  Value="&quot;cmd&quot; /c &quot;fsutil hardlink create [PROJECTLOCATION]bin\td-agent-gem.bat [PROJECTLOCATION]fluent-gem.bat&quot;"/>
+    <CustomAction Id="CreateCompatTdAgentGemBat"
+                  BinaryKey="WixCA"
+                  DllEntry="WixQuietExec64"
+                  Execute="deferred"
+                  Return="check"
+                  Impersonate="no" />
+
+    <Property Id="DeleteCompatTdAgentBat" Value=" "/>
+    <CustomAction Id="SetDeleteCompatTdAgentBat"
+                  Property="DeleteCompatTdAgentBat"
+                  Value="&quot;cmd&quot; /c &quot;del [PROJECTLOCATION]bin\td-agent.bat&quot;"/>
+    <CustomAction Id="DeleteCompatTdAgentBat"
+                  BinaryKey="WixCA"
+                  DllEntry="WixQuietExec64"
+                  Execute="deferred"
+                  Return="check"
+                  Impersonate="no" />
+    <Property Id="DeleteCompatTdAgentGemBat" Value=" "/>
+    <CustomAction Id="SetDeleteCompatTdAgentGemBat"
+                  Property="DeleteCompatTdAgentGemBat"
+                  Value="&quot;cmd&quot; /c &quot;del [PROJECTLOCATION]bin\td-agent-gem.bat&quot;"/>
+    <CustomAction Id="DeleteCompatTdAgentGemBat"
+                  BinaryKey="WixCA"
+                  DllEntry="WixQuietExec64"
+                  Execute="deferred"
+                  Return="check"
+                  Impersonate="no" />
+
     <InstallExecuteSequence>
       <Custom Action="SetPostInstallCommand" After="InstallFiles">NOT Installed</Custom>
       <Custom Action="PostInstall" After="SetPostInstallCommand">NOT Installed</Custom>
       <Custom Action="SetInstallFluentdWinSvcCommand" After="InstallFiles">NOT Installed</Custom>
       <Custom Action="InstallFluentdWinSvc" After="SetInstallFluentdWinSvcCommand">NOT Installed</Custom>
+
+      <Custom Action="SetCreateCompatTdAgentBat" Before="InstallFinalize">NOT Installed</Custom>
+      <Custom Action="CreateCompatTdAgentBat" After="SetCreateCompatTdAgentBat">NOT Installed</Custom>
+      <Custom Action="SetCreateCompatTdAgentGemBat" Before="InstallFinalize">NOT Installed</Custom>
+      <Custom Action="CreateCompatTdAgentGemBat" After="SetCreateCompatTdAgentGemBat">NOT Installed</Custom>
+
+      <!-- Delete hardlink before removing installed files -->
+      <Custom Action="SetDeleteCompatTdAgentBat" After="InstallInitialize">Installed AND NOT REINSTALL</Custom>
+      <Custom Action="DeleteCompatTdAgentBat" After="SetDeleteCompatTdAgentBat">Installed AND NOT REINSTALL</Custom>
+      <Custom Action="SetDeleteCompatTdAgentGemBat" After="InstallInitialize">Installed AND NOT REINSTALL</Custom>
+      <Custom Action="DeleteCompatTdAgentGemBat" After="SetDeleteCompatTdAgentGemBat">Installed AND NOT REINSTALL</Custom>
     </InstallExecuteSequence>
 
   </Product>


### PR DESCRIPTION
msi: migrate td-agent*.bat

Before:

c:\opt\td-agent\bin\td-agent.bat
c:\opt\td-agent\bin\td-agent-gem.bat

After:

c:\opt\td-agent\fluentd.bat
c:\opt\td-agent\fluent-gem.bat

If td-agent-gem.bat was renamed to fluent-gem.bat, it conflict with
c:\opt\td-agent\fluent-gem.bat which fluentd gem provides.
Not to cause such a situation, put them under c:\opt\td-agent.

To keep compatibility, td-agent.bat and td-agent-gem are provided
as hardlink.