### PR TITLE
CI: update package name to fluent-package

### DIFF
--- a/.github/workflows/apt-arm.yml
+++ b/.github/workflows/apt-arm.yml
@@ -36,11 +36,11 @@ jobs:
         run: |
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
           rake apt:build APT_TARGETS=${{ matrix.rake-job }}-arm64 ${{ matrix.rake-options }}
-      - name: Upload td-agent deb
+      - name: Upload fluent-package deb
         uses: actions/upload-artifact@master
         with:
           name: packages-${{ matrix.rake-job }}-arm64
-          path: td-agent/apt/repositories
+          path: fluent-package/apt/repositories
       - name: Check Package Size
         run: |
           fluent-package/apt/pkgsize-test.sh ${{ matrix.rake-job }} arm64

--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -35,16 +35,16 @@ jobs:
       - name: Build deb with Docker
         run: |
           rake apt:build APT_TARGETS=${{ matrix.rake-job }}
-      - name: Upload td-agent deb
+      - name: Upload fluent-package deb
         uses: actions/upload-artifact@master
         with:
           name: packages-${{ matrix.rake-job }}
-          path: td-agent/apt/repositories
-      - name: Upload td-agent-apt-source deb
+          path: fluent-package/apt/repositories
+      - name: Upload fluentd-apt-source deb
         uses: actions/upload-artifact@master
         with:
           name: packages-apt-source-${{ matrix.rake-job }}
-          path: td-agent-apt-source/apt/repositories
+          path: fluentd-apt-source/apt/repositories
       - name: Check Package Size
         run: |
           fluent-package/apt/pkgsize-test.sh ${{ matrix.rake-job }} amd64

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,7 +26,7 @@ jobs:
           sudo chown $(whoami) /opt/fluent
           rm -rf fluent/staging
           rake dmg:selfbuild PATH="$HOME/.cargo/bin:$PATH"
-      - name: Upload td-agent dmg
+      - name: Upload fluent-package dmg
         uses: actions/upload-artifact@master
         with:
           name: packages-macos

--- a/.github/workflows/yum-arm.yml
+++ b/.github/workflows/yum-arm.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           cp /usr/bin/qemu-aarch64-static fluent-package/yum/${{ matrix.rake-job }}/
           rake yum:build YUM_TARGETS=${{ matrix.rake-job }}-aarch64
-      - name: Upload td-agent rpm
+      - name: Upload fluent-package rpm
         uses: actions/upload-artifact@master
         with:
           name: packages-${{ matrix.rake-job }}-aarch64

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build rpm with Docker
         run: |
           rake yum:build YUM_TARGETS=${{ matrix.rake-job }}
-      - name: Upload td-agent rpm
+      - name: Upload fluent-package rpm
         uses: actions/upload-artifact@master
         with:
           name: packages-${{ matrix.rake-job }}


### PR DESCRIPTION
This fixes the not found path to upload in apt.

    Warning: No files were found with the provided path:
      td-agent/apt/repositories. No artifacts will be uploaded.
    Warning: No files were found with the provided path:
      td-agent-apt-source/apt/repositories. No artifacts will be uploaded.