### PR TITLE
msi: migrate to /opt/fluent

### DIFF
--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -1555,7 +1555,7 @@ class WindowsPackageTask
          "-sreg",   # Suppress registry harvesting
          "-gg",                          # Generate guides
          "-cg", "ProjectDir",            # Component Group Name
-         "-dr", "PROJECTLOCATION",       # Root directory reference
+         "-dr", "FLUENTPROJECTLOCATION",       # Root directory reference
          "-var", "var.ProjectSourceDir", # Substitue File/@Source="SourceDir"
          "-t",   "exclude-files.xslt",   # XSLT for exclude files
          "-out", 'project-files.wxs')

--- a/fluent-package/msi/assets/fluent-package-post-install.bat
+++ b/fluent-package/msi/assets/fluent-package-post-install.bat
@@ -1,5 +1,5 @@
 @echo off
 title Td-agent post install script
-if not "%~dp0" == "C:\opt\td-agent\bin\" (
+if not "%~dp0" == "C:\opt\fluent\bin\" (
    "%~dp0gem" pristine --only-executables --all
 )

--- a/fluent-package/msi/assets/fluent-package-version.rb
+++ b/fluent-package/msi/assets/fluent-package-version.rb
@@ -4,4 +4,4 @@ require 'fluent/version'
 td_agent_config = File.expand_path(File.join(File.dirname(__FILE__), "../share/config"))
 require td_agent_config
 
-puts "td-agent #{PACKAGE_VERSION} fluentd #{Fluent::VERSION} (#{FLUENTD_REVISION})"
+puts "fluent-package #{PACKAGE_VERSION} fluentd #{Fluent::VERSION} (#{FLUENTD_REVISION})"

--- a/fluent-package/msi/assets/fluentd.bat
+++ b/fluent-package/msi/assets/fluentd.bat
@@ -1,20 +1,22 @@
 @echo off
 if "%~nx0" == "td-agent.bat" (
-  set TD_AGENT_TOPDIR=%~dp0..\
+  set FLUENT_PACKAGE_TOPDIR=%~dp0..\
+  set TD_AGENT_TOPDIR=%~dp0..\..\td-agent
 ) else (
-  set TD_AGENT_TOPDIR=%~dp0
+  set FLUENT_PACKAGE_TOPDIR=%~dp0
+  set TD_AGENT_TOPDIR=%~dp0..\td-agent
 )
-set PATH=%TD_AGENT_TOPDIR%bin;%PATH%
-set PATH=%TD_AGENT_TOPDIR%;%PATH%
+set PATH=%FLUENT_PACKAGE_TOPDIR%bin;%PATH%
+set PATH=%FLUENT_PACKAGE_TOPDIR%;%PATH%
 set FLUENT_CONF=%TD_AGENT_TOPDIR%\etc\td-agent\td-agent.conf
 set FLUENT_PLUGIN=%TD_AGENT_TOPDIR%\etc\td-agent\plugin
-set TD_AGENT_VERSION=%TD_AGENT_TOPDIR%\bin\fluent-package-version.rb
+set FLUENT_PACKAGE_VERSION=%FLUENT_PACKAGE_TOPDIR%\bin\fluent-package-version.rb
 for %%p in (%*) do (
     if "%%p"=="--version" (
-        ruby "%TD_AGENT_VERSION%"
+        ruby "%FLUENT_PACKAGE_VERSION%"
         goto last
     )
 )
-"%TD_AGENT_TOPDIR%\bin\fluentd" %*
+"%FLUENT_PACKAGE_TOPDIR%\bin\fluentd" %*
 
 :last

--- a/fluent-package/msi/build.bat
+++ b/fluent-package/msi/build.bat
@@ -3,4 +3,4 @@ CALL "%SRC_DIR%env.bat"
 
 tar xvf "%SRC_DIR%..\%PACKAGE%-%VERSION%.tar.gz"
 cd "%PACKAGE%-%VERSION%"
-rake msi:selfbuild TD_AGENT_STAGING_PATH="C:/opt/td-agent" TD_AGENT_MSI_OUTPUT_PATH="%SRC_DIR%\repositories"
+rake msi:selfbuild TD_AGENT_STAGING_PATH="C:/opt/fluent" TD_AGENT_MSI_OUTPUT_PATH="%SRC_DIR%\repositories"

--- a/fluent-package/msi/install-test.ps1
+++ b/fluent-package/msi/install-test.ps1
@@ -5,8 +5,8 @@ Write-Host "Installing ${msi} ..."
 
 Start-Process msiexec -ArgumentList "/i", $msi, "/quiet" -Wait -NoNewWindow
 
-$ENV:PATH="C:\\opt\\td-agent\\bin;" + $ENV:PATH
-$ENV:PATH="C:\\opt\\td-agent;" + $ENV:PATH
+$ENV:PATH="C:\\opt\\fluent\\bin;" + $ENV:PATH
+$ENV:PATH="C:\\opt\\fluent;" + $ENV:PATH
 
 td-agent --version
 

--- a/fluent-package/msi/serverspec-test.ps1
+++ b/fluent-package/msi/serverspec-test.ps1
@@ -5,8 +5,8 @@ Write-Host "Installing ${msi} ..."
 
 Start-Process msiexec -ArgumentList "/i", $msi, "/quiet" -Wait -NoNewWindow
 
-$ENV:PATH="C:\\opt\\td-agent\\bin;" + $ENV:PATH
-$ENV:PATH="C:\\opt\\td-agent;" + $ENV:PATH
+$ENV:PATH="C:\\opt\\fluent\\bin;" + $ENV:PATH
+$ENV:PATH="C:\\opt\\fluent;" + $ENV:PATH
 
 td-agent --version
 

--- a/fluent-package/msi/source.wxs
+++ b/fluent-package/msi/source.wxs
@@ -73,6 +73,13 @@
               </CreateFolder>
             </Component>
           </Directory>
+          <Directory Id="FLUENTPROJECTLOCATION" Name="fluent">
+            <Component Id="FluentAcl" Guid="c2bba014-c3c1-4817-a0c6-096dbd95991d">
+              <CreateFolder>
+                <PermissionEx Sddl="D:(A;OICI;0x1200a9;;;BU)(A;OICI;FA;;;BA)(A;OICI;FA;;;S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464)(A;OICI;FA;;;CO)(A;OICI;FA;;;SY)"/>
+              </CreateFolder>
+            </Component>
+          </Directory>
         </Directory>
       </Directory>
       <Directory Id="ProgramMenuFolder">
@@ -93,6 +100,9 @@
           </Component>
         </Directory>
       </Directory>
+    </DirectoryRef>
+
+    <DirectoryRef Id="FLUENTPROJECTLOCATION">
       <Component Id="FluentdBat" Guid="261158e8-7b22-48ff-b7eb-9f8296f30236">
         <File Name="fluentd.bat"
               KeyPath="yes"
@@ -109,7 +119,7 @@
     <!-- Shortcut on Start Menu -->
     <DirectoryRef Id="ApplicationProgramFolder">
       <Component Id="ApplicationShortcut" Guid="*">
-        <Shortcut Id="ApplicationShortcut" Name="!(loc.ProductName) Command Prompt" Description="Open !(loc.ProductName) Command Prompt" Target="[SystemFolder]cmd.exe" Arguments='/k "[PROJECTLOCATION]fluent-package-prompt.bat"' WorkingDirectory="PROJECTLOCATION" />
+        <Shortcut Id="ApplicationShortcut" Name="!(loc.ProductName) Command Prompt" Description="Open !(loc.ProductName) Command Prompt" Target="[SystemFolder]cmd.exe" Arguments='/k "[FLUENTPROJECTLOCATION]fluent-package-prompt.bat"' WorkingDirectory="FLUENTPROJECTLOCATION" />
         <RemoveFolder Id="ApplicationProgramFolder" On="uninstall" />
         <RegistryValue Root="HKCU" Key="Software\[Manufacturer]\[ProductName]" Name="installed" Type="integer" Value="1" KeyPath="yes" />
         <Environment Id="ProjectLocationDirForConf"
@@ -118,7 +128,7 @@
                      Part="all"
                      System="yes"
                      Name="TD_AGENT_TOPDIR"
-                     Value="[PROJECTLOCATION]"/>
+                     Value="[FLUENTPROJECTLOCATION]"/>
       </Component>
     </DirectoryRef>
 
@@ -128,6 +138,7 @@
       <ComponentRef Id="ApplicationShortcut" />
       <ComponentRef Id="TDAgentConf" />
       <ComponentRef Id="TDAgentAcl" />
+      <ComponentRef Id="FluentAcl" />
       <ComponentRef Id="FluentdBat" />
     </Feature>
 
@@ -156,7 +167,7 @@
     <Property Id="PostInstall" Value=" "/>
     <CustomAction Id="SetPostInstallCommand"
                   Property="PostInstall"
-                  Value="&quot;[PROJECTLOCATION]bin\fluent-package-post-install.bat&quot;"/>
+                  Value="&quot;[FLUENTPROJECTLOCATION]bin\fluent-package-post-install.bat&quot;"/>
     <CustomAction Id="PostInstall"
                   BinaryKey="WixCA"
                   DllEntry="WixQuietExec64"
@@ -166,7 +177,7 @@
     <Property Id="InstallFluentdWinSvc" Value=" "/>
     <CustomAction Id="SetInstallFluentdWinSvcCommand"
                   Property="InstallFluentdWinSvc"
-                  Value="&quot;[PROJECTLOCATION]fluentd.bat&quot; --reg-winsvc i --reg-winsvc-delay-start --reg-winsvc-auto-start --reg-winsvc-fluentdopt &quot;-c [PROJECTLOCATION]etc\td-agent\td-agent.conf -o [PROJECTLOCATION]td-agent.log&quot;"/>
+                  Value="&quot;[FLUENTPROJECTLOCATION]fluentd.bat&quot; --reg-winsvc i --reg-winsvc-delay-start --reg-winsvc-auto-start --reg-winsvc-fluentdopt &quot;-c [PROJECTLOCATION]etc\td-agent\td-agent.conf -o [PROJECTLOCATION]td-agent.log&quot;"/>
     <CustomAction Id="InstallFluentdWinSvc"
                   BinaryKey="WixCA"
                   DllEntry="WixQuietExec64"
@@ -177,7 +188,7 @@
     <Property Id="CreateCompatTdAgentBat" Value=" "/>
     <CustomAction Id="SetCreateCompatTdAgentBat"
                   Property="CreateCompatTdAgentBat"
-                  Value="&quot;cmd&quot; /c &quot;fsutil hardlink create [PROJECTLOCATION]bin\td-agent.bat [PROJECTLOCATION]fluentd.bat&quot;"/>
+                  Value="&quot;cmd&quot; /c &quot;fsutil hardlink create [FLUENTPROJECTLOCATION]bin\td-agent.bat [FLUENTPROJECTLOCATION]fluentd.bat&quot;"/>
     <CustomAction Id="CreateCompatTdAgentBat"
                   BinaryKey="WixCA"
                   DllEntry="WixQuietExec64"
@@ -187,7 +198,7 @@
     <Property Id="CreateCompatTdAgentGemBat" Value=" "/>
     <CustomAction Id="SetCreateCompatTdAgentGemBat"
                   Property="CreateCompatTdAgentGemBat"
-                  Value="&quot;cmd&quot; /c &quot;fsutil hardlink create [PROJECTLOCATION]bin\td-agent-gem.bat [PROJECTLOCATION]fluent-gem.bat&quot;"/>
+                  Value="&quot;cmd&quot; /c &quot;fsutil hardlink create [FLUENTPROJECTLOCATION]bin\td-agent-gem.bat [FLUENTPROJECTLOCATION]fluent-gem.bat&quot;"/>
     <CustomAction Id="CreateCompatTdAgentGemBat"
                   BinaryKey="WixCA"
                   DllEntry="WixQuietExec64"
@@ -198,7 +209,7 @@
     <Property Id="DeleteCompatTdAgentBat" Value=" "/>
     <CustomAction Id="SetDeleteCompatTdAgentBat"
                   Property="DeleteCompatTdAgentBat"
-                  Value="&quot;cmd&quot; /c &quot;del [PROJECTLOCATION]bin\td-agent.bat&quot;"/>
+                  Value="&quot;cmd&quot; /c &quot;del [FLUENTPROJECTLOCATION]bin\td-agent.bat&quot;"/>
     <CustomAction Id="DeleteCompatTdAgentBat"
                   BinaryKey="WixCA"
                   DllEntry="WixQuietExec64"
@@ -208,7 +219,7 @@
     <Property Id="DeleteCompatTdAgentGemBat" Value=" "/>
     <CustomAction Id="SetDeleteCompatTdAgentGemBat"
                   Property="DeleteCompatTdAgentGemBat"
-                  Value="&quot;cmd&quot; /c &quot;del [PROJECTLOCATION]bin\td-agent-gem.bat&quot;"/>
+                  Value="&quot;cmd&quot; /c &quot;del [FLUENTPROJECTLOCATION]bin\td-agent-gem.bat&quot;"/>
     <CustomAction Id="DeleteCompatTdAgentGemBat"
                   BinaryKey="WixCA"
                   DllEntry="WixQuietExec64"


### PR DESCRIPTION
Before:
 c:\opt\td-agent\

After:
 c:\opt\fluent\

Note that the following files are not migrated yet:

c:\opt\td-agent\etc\td-agent.conf
c:\opt\td-agent\etc\plugin
c:\opt\td-agent\td-agent.log
c:\opt\td-agent\var\log\td-agent

Thus, most of files are placed under c:\opt\fluent, but these
files are remained for keeping compatibility.


