### PR TITLE
migrate configuration files

### DIFF
--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -477,9 +477,11 @@ class BuildTask
 
       desc "Create td-agent configuration files from template"
       task :td_agent_config do
-        configs = [
-          "etc/#{COMPAT_PACKAGE_DIR}/#{COMPAT_SERVICE_NAME}.conf"
-        ]
+        configs = if windows?
+                    ["etc/#{COMPAT_PACKAGE_DIR}/#{COMPAT_SERVICE_NAME}.conf"]
+                  else
+                    ["etc/#{PACKAGE_DIR}/#{SERVICE_NAME}.conf"]
+                  end
         configs.concat([
           "etc/logrotate.d/#{COMPAT_SERVICE_NAME}",
           "opt/#{PACKAGE_DIR}/share/#{COMPAT_SERVICE_NAME}-ruby.conf",
@@ -487,7 +489,8 @@ class BuildTask
         ]) unless windows? || macos?
         configs.each do |config|
           src = template_path(config)
-          if config == "etc/#{COMPAT_PACKAGE_DIR}/#{COMPAT_SERVICE_NAME}.conf"
+          if config == "etc/#{PACKAGE_DIR}/#{SERVICE_NAME}.conf" or
+            config == "etc/#{COMPAT_PACKAGE_DIR}/#{COMPAT_SERVICE_NAME}.conf"
             src = template_path("opt/#{PACKAGE_DIR}/share/#{COMPAT_SERVICE_NAME}.conf.tmpl")
           end
           dest = File.join(STAGING_DIR, config)

--- a/fluent-package/apt/systemd-test/update-from-v4.sh
+++ b/fluent-package/apt/systemd-test/update-from-v4.sh
@@ -30,12 +30,12 @@ test $(systemctl status td-agent > /dev/null 2>&1; echo $?;) -eq 3
 # systemctl status fluentd
 
 # Test: config migration
-# test -L /etc/td-agent
-# test -e /etc/td-agent/td-agent.conf
+test -L /etc/td-agent
+test -e /etc/td-agent/td-agent.conf
 
 # Test: log file migration
-# test -L /var/log/td-agent
-# test -e /var/log/td-agent/td-agent.log
+test -L /var/log/td-agent
+test -e /var/log/td-agent/td-agent.log
 
 # Test: environmental variables
 pid=$(systemctl show fluentd --property=MainPID --value)

--- a/fluent-package/debian/fluent-package.install
+++ b/fluent-package/debian/fluent-package.install
@@ -3,6 +3,6 @@ usr/bin/*
 usr/sbin/*
 usr/lib/tmpfiles.d/*
 etc/logrotate.d/*
-etc/td-agent/*
+etc/fluent/*
 etc/default/*
 lib/systemd/system/*

--- a/fluent-package/dmg/resources/pkg/postinstall.erb
+++ b/fluent-package/dmg/resources/pkg/postinstall.erb
@@ -5,16 +5,16 @@
 
 # Create <%= service_name %> related directories and files
 
-if [ ! -e "/var/log/<%= compat_package_dir %>/" ]; then
-  mkdir -p /var/log/<%= compat_package_dir %>/
-  mkdir -p /var/log/<%= compat_package_dir %>/buffer/
+if [ ! -e "/var/log/<%= package_dir %>/" ]; then
+  mkdir -p /var/log/<%= package_dir %>/
+  mkdir -p /var/log/<%= package_dir %>/buffer/
 fi
 if [ ! -e "/var/run/<%= package_dir %>/" ]; then
   mkdir -p /var/run/<%= package_dir %>/
 fi
-if [ ! -e "/etc/<%= compat_package_dir %>/" ]; then
-  mkdir -p /etc/<%= compat_package_dir %>/
-  mkdir -p /etc/<%= compat_package_dir %>/plugin
+if [ ! -e "/etc/<%= package_dir %>/" ]; then
+  mkdir -p /etc/<%= package_dir %>/
+  mkdir -p /etc/<%= package_dir %>/plugin
 fi
 if [ ! -e "/tmp/<%= package_dir %>/" ]; then
   mkdir -p /tmp/<%= package_dir %>/

--- a/fluent-package/templates/etc/systemd/fluentd.erb
+++ b/fluent-package/templates/etc/systemd/fluentd.erb
@@ -1,1 +1,5 @@
 TD_AGENT_OPTIONS=""
+# The following environment variable will be modified via package maintainer's migration script
+FLUENT_CONF=/etc/<%= package_dir %>/<%= service_name %>.conf
+FLUENT_PLUGIN=/etc/<%= package_dir %>/plugin
+TD_AGENT_LOG_FILE=/var/log/<%= package_dir %>/<%= service_name %>.log

--- a/fluent-package/templates/etc/systemd/fluentd.service.erb
+++ b/fluent-package/templates/etc/systemd/fluentd.service.erb
@@ -16,10 +16,10 @@ LimitNOFILE=65536
 Environment=LD_PRELOAD=<%= install_path %>/lib/libjemalloc.so
 Environment=GEM_HOME=<%= gem_install_path %>/
 Environment=GEM_PATH=<%= gem_install_path %>/
-Environment=FLUENT_CONF=/etc/<%= compat_package_dir %>/<%= compat_service_name %>.conf
-Environment=FLUENT_PLUGIN=/etc/<%= compat_package_dir %>/plugin
+Environment=FLUENT_CONF=/etc/<%= package_dir %>/<%= service_name %>.conf
+Environment=FLUENT_PLUGIN=/etc/<%= package_dir %>/plugin
 Environment=FLUENT_SOCKET=/var/run/<%= package_dir %>/<%= compat_service_name %>.sock
-Environment=TD_AGENT_LOG_FILE=/var/log/<%= compat_package_dir %>/<%= compat_service_name %>.log
+Environment=TD_AGENT_LOG_FILE=/var/log/<%= package_dir %>/<%= service_name %>.log
 <% if pkg_type == 'deb' %>
 EnvironmentFile=-/etc/default/<%= service_name %>
 <% else %>

--- a/fluent-package/templates/fluentd.plist.erb
+++ b/fluent-package/templates/fluentd.plist.erb
@@ -10,7 +10,7 @@
   <array>
     <string>/opt/<%= package_dir %>/sbin/<%= service_name %></string>
     <string>--log</string>
-    <string>/var/log/<%= compat_package_dir %>/<%= service_name %>.log</string>
+    <string>/var/log/<%= package_dir %>/<%= service_name %>.log</string>
     <string>--use-v1-config</string>
   </array>
   <key>RunAtLoad</key>

--- a/fluent-package/templates/opt/fluent/share/td-agent.conf.tmpl
+++ b/fluent-package/templates/opt/fluent/share/td-agent.conf.tmpl
@@ -27,7 +27,7 @@
 <% if windows? %>
     path "#{ENV['TD_AGENT_TOPDIR']}/var/log/<%= compat_package_dir %>/buffer/td"
 <% else %>
-    path /var/log/<%= compat_package_dir %>/buffer/td
+    path /var/log/<%= package_dir %>/buffer/td
 <% end %>
   </buffer>
 
@@ -36,7 +36,7 @@
 <% if windows? %>
     path "#{ENV['TD_AGENT_TOPDIR']}/var/log/<%= compat_package_dir %>/failed_records"
 <% else %>
-    path /var/log/<%= compat_package_dir %>/failed_records
+    path /var/log/<%= package_dir %>/failed_records
 <% end %>
   </secondary>
 </match>
@@ -102,7 +102,7 @@
 #<match local.**>
 #  @type file
 #  @id output_file
-#  path /var/log/<%= compat_package_dir %>/access
+#  path /var/log/<%= package_dir %>/access
 #</match>
 
 ## Forwarding
@@ -133,11 +133,11 @@
 #    auto_create_table
 #    <buffer>
 #      @type file
-#      path /var/log/<%= compat_package_dir %>/buffer/td
+#      path /var/log/<%= package_dir %>/buffer/td
 #    </buffer>
 #  </store>
 #  <store>
 #    @type file
-#    path /var/log/<%= compat_package_dir %>/td-%Y-%m-%d/%H.log
+#    path /var/log/<%= package_dir %>/td-%Y-%m-%d/%H.log
 #  </store>
 #</match>

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postinst
@@ -22,38 +22,116 @@ add_system_user() {
     fi
 }
 
+v4migration=n
+v4migration_with_restart=n
+
 add_directories() {
     mkdir -p /var/run/<%= package_dir %>
-    mkdir -p /etc/<%= compat_package_dir %>
-    mkdir -p /etc/<%= compat_package_dir %>/plugin
-    mkdir -p /var/log/<%= compat_package_dir %>
+    mkdir -p /etc/<%= package_dir %>
+    mkdir -p /etc/<%= package_dir %>/plugin
+    mkdir -p /var/log/<%= package_dir %>
 }
 
 fixperms() {
-    # If statoverride entry exits, use --force-all to ensure statoverride-add will work.
-    # If statoverride entry doen't exit, no need to --force-all.
+    # If statoverride entry doesn't exit, set it.
     dpkg-statoverride --list /var/run/<%= package_dir %> >/dev/null || \
         dpkg-statoverride --update --add _<%= service_name %> _<%= service_name %> 0755 /var/run/<%= package_dir %>
-    dpkg-statoverride --list /var/run/<%= package_dir %> >/dev/null && \
-        dpkg-statoverride --force-all --update --add _<%= service_name %> _<%= service_name %> 0755 /var/run/<%= package_dir %>
-    dpkg-statoverride --list /etc/<%= compat_package_dir %> >/dev/null || \
-        dpkg-statoverride --update --add _<%= service_name %> _<%= service_name %> 0755 /etc/<%= compat_package_dir %>
-    dpkg-statoverride --list /etc/<%= compat_package_dir %> >/dev/null && \
-        dpkg-statoverride --force-all --update --add _<%= service_name %> _<%= service_name %> 0755 /etc/<%= compat_package_dir %>
-    dpkg-statoverride --list /var/log/<%= compat_package_dir %> >/dev/null || \
-        dpkg-statoverride --update --add _<%= service_name %> _<%= service_name %> 0755 /var/log/<%= compat_package_dir %>
-    dpkg-statoverride --list /var/log/<%= compat_package_dir %> >/dev/null && \
-        dpkg-statoverride --force-all --update --add _<%= service_name %> _<%= service_name %> 0755 /var/log/<%= compat_package_dir %>
-    # Cleanup /var/run/<%= compat_package_dir %>
-    dpkg-statoverride --force-all --remove /var/run/<%= compat_package_dir %>
+    dpkg-statoverride --list /etc/<%= package_dir %> >/dev/null || \
+        dpkg-statoverride --update --add _<%= service_name %> _<%= service_name %> 0755 /etc/<%= package_dir %>
+    dpkg-statoverride --list /var/log/<%= package_dir %> >/dev/null || \
+        dpkg-statoverride --update --add _<%= service_name %> _<%= service_name %> 0755 /var/log/<%= package_dir %>
+    # Remove obsolete statoverride
+    if dpkg-statoverride --list /var/run/<%= compat_package_dir %> >/dev/null; then
+        dpkg-statoverride --force-all --remove /var/run/<%= compat_package_dir %>
+    fi
+    if dpkg-statoverride --list /etc/<%= compat_package_dir %> >/dev/null; then
+        dpkg-statoverride --force-all --remove /etc/<%= compat_package_dir %>
+    fi
+    if dpkg-statoverride --list /var/log/<%= compat_package_dir %> >/dev/null; then
+        dpkg-statoverride --force-all --remove /var/log/<%= compat_package_dir %>
+    fi
+}
+
+migration_from_v4_main_process() {
+    # prevver can't be used to judge td-agent => fluent-package because it's empty.
+    if [ -d /etc/<%= compat_package_dir %> -a ! -h /etc/<%= compat_package_dir %> ]; then
+        v4migration=y
+        # /etc/<%= compat_package_dir %> migration from v4
+        if [ -d /etc/<%= compat_package_dir %>/plugin -a -n "$(ls /etc/<%= compat_package_dir %>/plugin)" ]; then
+            echo "Migrating from /etc/<%= compat_service_name %>/plugin/ to /etc/<%= package_dir %>/plugin/..."
+            mv -f /etc/<%= compat_service_name %>/plugin/* /etc/<%= package_dir %>/plugin/
+        fi
+        if [ -f /etc/<%= compat_package_dir %>/<%= compat_service_name %>.conf ]; then
+            echo "Migrating from /etc/<%= compat_package_dir %>/<%= compat_service_name %>.conf to /etc/<%= package_dir %>/<%= compat_service_name %>.conf"
+            cp -f /etc/<%= compat_package_dir %>/<%= compat_service_name %>.conf /etc/<%= package_dir %>/<%= compat_service_name %>.conf
+            echo "Refer previous configuration <%= compat_service_name %>.conf ..."
+            sed -i"" /etc/default/<%= service_name %> -e "/FLUENT_CONF/c FLUENT_CONF=/etc/<%= package_dir %>/<%= compat_service_name %>.conf"
+            for d in $(ls /etc/<%= compat_package_dir %>); do
+                if [ ! "$d" = "plugin" -a ! "$d" = "<%= compat_service_name %>.conf" ]; then
+                    # except managed under deb files must be migrated
+                    mv -f /etc/<%= compat_package_dir %>/$d /etc/<%= package_dir %>/
+                fi
+            done
+        fi
+    fi
+    if [ -h /etc/systemd/system/td-agent.service ]; then
+        if [ -x /usr/bin/systemctl ]; then
+            if ! systemctl is-active <%= compat_service_name %> >/dev/null; then
+                # Want to restart with new user/group here,
+                # but to avoid holding file descriptor under /var/log/<%= compat_package_dir %>/,
+                # delay restarting <%= service_name %> service.
+                systemctl stop <%= compat_service_name %>
+                touch $v4migration_with_restart
+           fi
+        fi
+    fi
+    if [ -d /var/log/<%= compat_package_dir %> -a ! -h /var/log/<%= compat_package_dir %> ]; then
+        # /var/log/<%= compat_package_dir %> migration from v4
+        if [ -d /var/log/<%= compat_package_dir %>/buffer ]; then
+            if [ -n "$(ls /var/log/<%= compat_package_dir %>/buffer)" ]; then
+                mv -f /var/log/<%= compat_package_dir %>/buffer/* /var/log/<%= package_dir %>/buffer/
+            fi
+        fi
+        if [ -f /var/log/<%= package_dir %>/<%= compat_service_name %>.log ]; then
+            echo "Keep logging to <%= compat_service_name %>.log ..."
+            sed -i"" /etc/default/<%= service_name %> -e "/TD_AGENT_LOG_FILE/c TD_AGENT_LOG_FILE=/var/log/<%= package_dir %>/<%= compat_service_name %>.log"
+        fi
+        for d in $(ls /var/log/<%= compat_package_dir %>); do
+            if [ ! "$d" = "buffer" ]; then
+                # except /var/log/<%= compat_package_dir %>/buffer must be migrated
+                mv -f /var/log/<%= compat_package_dir %>/$d /var/log/<%= package_dir %>/
+            fi
+        done
+    fi
+}
+
+migration_from_v4_post_process() {
+    if [ ! "$v4migration" = "y" ]; then
+       return
+    fi
+    if [ -d /etc/<%= compat_package_dir %> -a ! -h /etc/<%= compat_package_dir %> ]; then
+        rm -fr /etc/<%= compat_package_dir %>
+        ln -sf /etc/<%= package_dir %> /etc/<%= compat_package_dir %>
+    fi
+    if [ -d /var/log/<%= compat_package_dir %> -a ! -h /var/log/<%= compat_package_dir %> ]; then
+        rm -fr /var/log/<%= compat_package_dir %>
+        ln -sf /var/log/<%= package_dir %> /var/log/<%= compat_package_dir %>
+    fi
+    if [ "$v4migration_with_restart" = "y" ]; then
+        if [ -x /usr/bin/systemctl ]; then
+            systemctl restart <%= service_name %>
+        fi
+    fi
 }
 
 case "$1" in
     configure)
         add_system_user
         add_directories
+        migration_from_v4_main_process
         fixperms
-        ;;
+        migration_from_v4_post_process
+	;;
     abort-upgrade|abort-deconfigure|abort-remove)
         :
         ;;

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postinst
@@ -92,16 +92,16 @@ migration_from_v4_main_process() {
                 mv -f /var/log/<%= compat_package_dir %>/buffer/* /var/log/<%= package_dir %>/buffer/
             fi
         fi
-        if [ -f /var/log/<%= package_dir %>/<%= compat_service_name %>.log ]; then
-            echo "Keep logging to <%= compat_service_name %>.log ..."
-            sed -i"" /etc/default/<%= service_name %> -e "/TD_AGENT_LOG_FILE/c TD_AGENT_LOG_FILE=/var/log/<%= package_dir %>/<%= compat_service_name %>.log"
-        fi
         for d in $(ls /var/log/<%= compat_package_dir %>); do
             if [ ! "$d" = "buffer" ]; then
                 # except /var/log/<%= compat_package_dir %>/buffer must be migrated
                 mv -f /var/log/<%= compat_package_dir %>/$d /var/log/<%= package_dir %>/
             fi
         done
+        if [ -f /var/log/<%= package_dir %>/<%= compat_service_name %>.log ]; then
+            echo "Keep logging to <%= compat_service_name %>.log ..."
+            sed -i"" /etc/default/<%= service_name %> -e "/TD_AGENT_LOG_FILE/c TD_AGENT_LOG_FILE=/var/log/<%= package_dir %>/<%= compat_service_name %>.log"
+        fi
     fi
 }
 

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postinst
@@ -81,7 +81,7 @@ migration_from_v4_main_process() {
                 # but to avoid holding file descriptor under /var/log/<%= compat_package_dir %>/,
                 # delay restarting <%= service_name %> service.
                 systemctl stop <%= compat_service_name %>
-                touch $v4migration_with_restart
+                v4migration_with_restart=y
            fi
         fi
     fi

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postrm
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postrm
@@ -6,19 +6,30 @@ set -e
 
 if [ "$1" = "purge" ]; then
 	rm -f /etc/default/<%= compat_service_name %>
-	dpkg-statoverride --list /etc/<%= compat_package_dir %> > /dev/null && \
-		dpkg-statoverride --remove /etc/<%= compat_package_dir %>
-	rm -f /etc/<%= compat_package_dir %>/<%= compat_service_name %>.conf
-	rm -rf /etc/<%= compat_package_dir %>
+	rm -f /etc/default/<%= service_name %>
+	for target_dir in /etc/<%= compat_package_dir %> /etc/<%= package_dir %>; do
+  	    dpkg-statoverride --list $target_dir > /dev/null && \
+		dpkg-statoverride --remove $target_dir
+	    if [ "$target_dir" = "/etc/<%= compat_package_dir %>" ]; then
+		rm -f $target_dir/<%= compat_service_name %>.conf
+	    elif [ "$target_dir" = "/etc/<%= package_dir %>" ]; then
+		rm -f $target_dir/<%= service_name %>.conf
+	    fi
+	    rm -rf $target_dir
+	done
 	dpkg-statoverride --list /var/run/<%= package_dir %> > /dev/null && \
 		dpkg-statoverride --remove /var/run/<%= package_dir %>
 	rm -f /var/run/<%= package_dir %>/*
 	rm -rf /var/run/<%= package_dir %>
-	dpkg-statoverride --list /var/log/<%= compat_package_dir %> > /dev/null && \
-		dpkg-statoverride --remove /var/log/<%= compat_package_dir %>
-	rm -rf /var/log/<%= compat_package_dir %>/buffer
-	rm -rf /var/log/<%= compat_package_dir %>/*
-	rm -rf /var/log/<%= compat_package_dir %>
+	for target_dir in /var/log/<%= compat_package_dir %> /var/log/<%= package_dir %>; do
+  	    dpkg-statoverride --list $target_dir > /dev/null && \
+		dpkg-statoverride --remove $target_dir
+	    if [ "$target_dir" = "/var/log/<%= compat_package_dir %>" ]; then
+		rm -f $target_dir
+	    elif [ "$target_dir" = "/var/log/<%= package_dir %>" ]; then
+		rm -rf $target_dir
+	    fi
+	done
 
 	getent passwd _<%= service_name %> && userdel -r _<%= service_name %>
 fi

--- a/fluent-package/templates/usr/sbin/fluentd.erb
+++ b/fluent-package/templates/usr/sbin/fluentd.erb
@@ -1,9 +1,9 @@
 #!<%= install_path %>/bin/ruby
 ENV["GEM_HOME"]="<%= gem_install_path %>/"
 ENV["GEM_PATH"]="<%= gem_install_path %>/"
-ENV["FLUENT_CONF"]="/etc/<%= compat_package_dir %>/<%= compat_service_name %>.conf"
-ENV["FLUENT_PLUGIN"]="/etc/<%= compat_package_dir %>/plugin"
-ENV["FLUENT_SOCKET"]="/var/run/<%= package_dir %>/<%= compat_service_name %>.sock"
+ENV["FLUENT_CONF"]="/etc/<%= package_dir %>/<%= service_name %>.conf"
+ENV["FLUENT_PLUGIN"]="/etc/<%= package_dir %>/plugin"
+ENV["FLUENT_SOCKET"]="/var/run/<%= package_dir %>/<%= service_name %>.sock"
 if ARGV.include?("--version")
   require "<%= install_path %>/share/config"
   Dir.glob("<%= install_path %>/lib/ruby/**/gems/**/fluent/version.rb").each do |v|

--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -28,6 +28,8 @@
 # Omit check-rpath and brp-mangle-shebangs since we use our own Ruby
 %define __arch_install_post %{nil}
 %undefine __brp_mangle_shebangs
+%define v4migration /tmp/@PACKAGE_DIR@/.v4migration
+%define v4migration_with_restart /tmp/@PACKAGE_DIR@/.v4migration_with_restart
 
 %global __provides_exclude_from ^/opt/%{name}/.*\\.so.*
 %global __requires_exclude libjemalloc.*|libruby.*|/opt/%{name}/.*
@@ -132,9 +134,9 @@ done
 
 cd -
 mkdir -p %{buildroot}%{_localstatedir}/run/@PACKAGE_DIR@
-mkdir -p %{buildroot}%{_localstatedir}/log/@COMPAT_PACKAGE_DIR@
-mkdir -p %{buildroot}%{_localstatedir}/log/@COMPAT_PACKAGE_DIR@/buffer
-mkdir -p %{buildroot}%{_sysconfdir}/@COMPAT_PACKAGE_DIR@/plugin
+mkdir -p %{buildroot}%{_localstatedir}/log/@PACKAGE_DIR@
+mkdir -p %{buildroot}%{_localstatedir}/log/@PACKAGE_DIR@/buffer
+mkdir -p %{buildroot}%{_sysconfdir}/@PACKAGE_DIR@/plugin
 mkdir -p %{buildroot}/tmp/@PACKAGE_DIR@
 
 %pre
@@ -173,24 +175,56 @@ fi
 %post
 %systemd_post @SERVICE_NAME@.service
 if [ $1 -eq 1 ]; then
-    systemctl is-active @COMPAT_SERVICE_NAME@
-    if [ $? -eq 0 ]; then
-	if getent passwd @COMPAT_SERVICE_NAME@ >/dev/null; then
-	    if ! getent passwd @SERVICE_NAME@ >/dev/null; then
-		# usermod fails when user process is active, so
-		# postpone username migration step here. (During %pre
-		# stage, mismatch of user/group configuration cause
-		# restarting service failure.)
-		systemctl stop @COMPAT_SERVICE_NAME@.service
-		/usr/sbin/usermod --login @SERVICE_NAME@ @COMPAT_SERVICE_NAME@
-	    fi
-	fi
-	# When upgrading from v4, td-agent.service will be removed
-	# with %postun scriptlet. fluentd service also inactive even though
-	# td-agent.service is running before upgrade process. Try to
-	# keep running fluentd service, explicitly restart it.
-	systemctl restart @SERVICE_NAME@.service
+  if [ -d /etc/@COMPAT_PACKAGE_DIR@ -a ! -h /etc/@COMPAT_PACKAGE_DIR@ ]; then
+    touch %{v4migration}
+    # /etc/@COMPAT_PACKAGE_DIR@ migration from v4
+    if [ -d /etc/@COMPAT_PACKAGE_DIR@/plugin -a -n "$(ls /etc/@COMPAT_PACKAGE_DIR@/plugin)" ]; then
+      echo "Migrating from /etc/@COMPAT_PACKAGE_DIR@/plugin/ to /etc/@PACKAGE_DIR@/plugin/..."
+      mv -f /etc/@COMPAT_PACKAGE_DIR@/plugin/* /etc/@PACKAGE_DIR@/plugin/
     fi
+    if [ -f /etc/@COMPAT_PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.conf ]; then
+      for d in /etc/@COMPAT_PACKAGE_DIR@/*; do
+        if [ ! "$d" == "/etc/@COMPAT_PACKAGE_DIR@/plugin" ]; then
+          echo "Migrating from $d to /etc/@PACKAGE_DIR@/..."
+          mv -f $d /etc/@PACKAGE_DIR@/
+        fi
+      done
+      echo "Refer previous configuration @COMPAT_SERVICE_NAME@.conf ..."
+      %{__sed} -i"" %{_sysconfdir}/sysconfig/@SERVICE_NAME@ -e "/FLUENT_CONF/c FLUENT_CONF=/etc/@PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.conf"
+    fi
+  fi
+  if ! systemctl is-active @COMPAT_SERVICE_NAME@; then
+    if getent passwd @COMPAT_SERVICE_NAME@ >/dev/null; then
+      if ! getent passwd @SERVICE_NAME@ >/dev/null; then
+        # usermod fails when user process is active, so
+        # postpone username migration step here. (During %pre
+        # stage, mismatch of user/group configuration cause
+        # restarting service failure.)
+        systemctl stop @COMPAT_SERVICE_NAME@.service
+        /usr/sbin/usermod --login @SERVICE_NAME@ @COMPAT_SERVICE_NAME@
+      fi
+    fi
+    # Want to restart with new user/group here,
+    # but to avoid holding file descriptor under /var/log/@COMPAT_PACKAGE_DIR@/,
+    # delay restarting @SERVICE_NAME@ service.
+    touch %{v4migration_with_restart}
+  fi
+  if [ -d /var/log/@COMPAT_PACKAGE_DIR@ -a ! -h /var/log/@COMPAT_PACKAGE_DIR@ ]; then
+    # /var/log/@COMPAT_PACKAGE_DIR@ migration from v4
+    if [ -d /var/log/@COMPAT_PACKAGE_DIR@/buffer -a -n "$(ls /var/log/@COMPAT_PACKAGE_DIR@/buffer)" ]; then
+      mv -f /var/log/@COMPAT_PACKAGE_DIR@/buffer/* /var/log/@PACKAGE_DIR@/buffer/
+    fi
+    for d in /var/log/@COMPAT_PACKAGE_DIR@/*; do
+      if [ ! "$d" == "/var/log/@COMPAT_PACKAGE_DIR@/buffer" ]; then
+        # /var/log/@COMPAT_PACKAGE_DIR@/buffer will be removed from td-agent
+        mv -f $d /var/log/@PACKAGE_DIR@/
+      fi
+    done
+    if [ -f /var/log/@PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.log ]; then
+      echo "Keep logging to @COMPAT_SERVICE_NAME@.log ..."
+      %{__sed} -i"" %{_sysconfdir}/sysconfig/@SERVICE_NAME@ -e "/TD_AGENT_LOG_FILE/c TD_AGENT_LOG_FILE=/var/log/@PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.log"
+    fi
+  fi
 fi
 if [ -d "%{_sysconfdir}/prelink.conf.d/" ]; then
   # Drop prelink itself which is used until v4
@@ -220,6 +254,12 @@ fi
 if [ -f /usr/sbin/@COMPAT_SERVICE_NAME@-gem ]; then
   rm -f /usr/sbin/@COMPAT_SERVICE_NAME@-gem
 fi
+if [ -h /etc/@COMPAT_PACKAGE_DIR@ ]; then
+  rm -f /etc/@COMPAT_PACKAGE_DIR@
+fi
+if [ -h /var/log/@COMPAT_PACKAGE_DIR@ ]; then
+  rm -f /var/log/@COMPAT_PACKAGE_DIR@
+fi
 
 if [ $1 -eq 0 ]; then
    # Removing
@@ -235,12 +275,31 @@ fi
 
 %posttrans
 if [ ! -f /usr/sbin/@COMPAT_SERVICE_NAME@ ]; then
-  # provides /usr/sbin/td-agent for backward compatibility
+  echo "Provides /usr/sbin/td-agent symlink for backward compatibility"
   ln -sf /usr/sbin/@SERVICE_NAME@ /usr/sbin/@COMPAT_SERVICE_NAME@
 fi
 if [ ! -f /usr/sbin/@COMPAT_SERVICE_NAME@-gem ]; then
-  # provides /usr/sbin/td-agent-gem for backward compatibility
+  echo "Provides /usr/sbin/td-agent-gem symlink for backward compatibility"
   ln -sf /usr/sbin/fluent-gem /usr/sbin/@COMPAT_SERVICE_NAME@-gem
+fi
+if [ -f %{v4migration} ]; then
+  if [ ! -h /etc/@COMPAT_PACKAGE_DIR@ ]; then
+    echo "Provides /etc/td-agent symlink for backward compatibility"
+    ln -sf /etc/@PACKAGE_DIR@ /etc/@COMPAT_PACKAGE_DIR@
+  fi
+  if [ ! -h /var/log/@COMPAT_PACKAGE_DIR@ ]; then
+    echo "Provides /var/log/td-agent symlink for backward compatibility"
+    ln -sf /var/log/@PACKAGE_DIR@ /var/log/@COMPAT_PACKAGE_DIR@
+  fi
+  rm -f %{v4migration}
+  if [ -f %{v4migration_with_restart} ]; then
+    # When upgrading from v4, td-agent.service will be removed
+    # with %postun scriptlet. fluentd service also inactive even though
+    # td-agent.service is running before upgrade process. Try to
+    # keep running fluentd service, explicitly restart it.
+    systemctl restart @SERVICE_NAME@.service
+    rm -f %{v4migration_with_restart}
+  fi
 fi
 
 %files
@@ -259,12 +318,12 @@ fi
 %{_sbindir}/fluent-gem
 %{_mandir}/man1/td*
 %config(noreplace) %{_sysconfdir}/sysconfig/@SERVICE_NAME@
-%config(noreplace) %{_sysconfdir}/@COMPAT_PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.conf
+%config(noreplace) %{_sysconfdir}/@PACKAGE_DIR@/@SERVICE_NAME@.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/@COMPAT_SERVICE_NAME@
-%attr(0755,fluentd,fluentd) %dir %{_localstatedir}/log/@COMPAT_PACKAGE_DIR@
-%attr(0755,fluentd,fluentd) %dir %{_localstatedir}/log/@COMPAT_PACKAGE_DIR@/buffer
-%attr(0755,fluentd,fluentd) %dir %{_sysconfdir}/@COMPAT_PACKAGE_DIR@
-%attr(0755,fluentd,fluentd) %dir %{_sysconfdir}/@COMPAT_PACKAGE_DIR@/plugin
+%attr(0755,fluentd,fluentd) %dir %{_localstatedir}/log/@PACKAGE_DIR@
+%attr(0755,fluentd,fluentd) %dir %{_localstatedir}/log/@PACKAGE_DIR@/buffer
+%attr(0755,fluentd,fluentd) %dir %{_sysconfdir}/@PACKAGE_DIR@
+%attr(0755,fluentd,fluentd) %dir %{_sysconfdir}/@PACKAGE_DIR@/plugin
 # NOTE: %{_tmpfilesdir} is available since CentOS 7
 %attr(0755,fluentd,fluentd) %dir /tmp/@PACKAGE_DIR@
 %changelog

--- a/fluent-package/yum/pkgsize-test.sh
+++ b/fluent-package/yum/pkgsize-test.sh
@@ -60,7 +60,9 @@ for v in "${PREVIOUS_VERSIONS[@]}"; do
     BASE_NAME=td-agent-${v}-1.${DISTRO_VERSION_PREFIX}${DISTRO_VERSION}.${ARCH}.rpm
     PREVIOUS_RPM=${BASE_URI}/${ARCH}/${BASE_NAME}
     set +e
-    wget ${PREVIOUS_RPM}
+    if [ ! -f ${BASE_NAME} ]; then
+	wget ${PREVIOUS_RPM}
+    fi
     if [ $? -eq 0 ]; then
 	break
     fi


### PR DESCRIPTION


In the previous versions, there are some configuration files and
log files are still kept under old path for compatibility.
It is better migrating to /opt/fluent completely, but we
need to consider upgrading from v4, too.

During upgrading from v4, seamless migration can be done by using
environment variable to specify the actual path because there is
no need to embed specific path to .service itself.
It aims not to be confused which configuration file should be applied.

Before:
 * Use old path for compatibility.
   * /etc/td-agent/td-agent.conf
   * /etc/td-agent/plugin
   * /var/log/td-agent/

After:

 * Use /opt/fluent as possible.
 * Keep /opt/td-agent as possible (only upgrading)
   * Moving content under /etc/td-agent to /etc/fluent/
   * Moving content under /var/log/td-agent to /var/log/fluent
   * Making symlink from /opt/td-agent /opt/fluent
   * Making symlink from /var/log/td-agent to /var/log/fluent
 * Note that /etc/logrotate.d/td-agent is not changed
