### PR TITLE
dmg: migrate changed path

### DIFF
--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -477,9 +477,11 @@ class BuildTask
 
       desc "Create td-agent configuration files from template"
       task :td_agent_config do
-        configs = [
-          "etc/#{COMPAT_PACKAGE_DIR}/#{COMPAT_SERVICE_NAME}.conf"
-        ]
+        configs = if windows?
+                    ["etc/#{COMPAT_PACKAGE_DIR}/#{COMPAT_SERVICE_NAME}.conf"]
+                  else
+                    ["etc/#{PACKAGE_DIR}/#{SERVICE_NAME}.conf"]
+                  end
         configs.concat([
           "etc/logrotate.d/#{COMPAT_SERVICE_NAME}",
           "opt/#{PACKAGE_DIR}/share/#{COMPAT_SERVICE_NAME}-ruby.conf",
@@ -487,7 +489,8 @@ class BuildTask
         ]) unless windows? || macos?
         configs.each do |config|
           src = template_path(config)
-          if config == "etc/#{COMPAT_PACKAGE_DIR}/#{COMPAT_SERVICE_NAME}.conf"
+          if config == "etc/#{PACKAGE_DIR}/#{SERVICE_NAME}.conf" or
+            config == "etc/#{COMPAT_PACKAGE_DIR}/#{COMPAT_SERVICE_NAME}.conf"
             src = template_path("opt/#{PACKAGE_DIR}/share/#{COMPAT_SERVICE_NAME}.conf.tmpl")
           end
           dest = File.join(STAGING_DIR, config)

--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -503,7 +503,11 @@ class BuildTask
         configs.each do |config|
           src = template_path(config)
           dest = File.join(STAGING_DIR, config)
-          render_template(dest, src, template_params)
+          if File.readlines("/etc/os-release").any? { |entry| ["ID=debian", "ID=ubuntu"].include?(entry.chomp) }
+            render_template(dest, src, template_params({ pkg_type: "deb"}))
+          else
+            render_template(dest, src, template_params({ pkg_type: "rpm"}))
+          end
         end
       end
 

--- a/fluent-package/apt/install-test.sh
+++ b/fluent-package/apt/install-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -exu
+set -xu
 
 apt update
 apt install -V -y lsb-release
@@ -14,13 +14,14 @@ td-agent --version
 
 apt remove -y fluent-package
 
-conf_path=/etc/td-agent/td-agent.conf
-if [ ! -f $conf_path ]; then
-    echo "td-agent.conf must be exist: <${conf_path}>"
+getent passwd _fluentd >/dev/null
+if [ $? -ne 0 ]; then
+    echo "_fluentd user must be kept"
     exit 1
 fi
-if [ ! -s $conf_path ]; then
-    echo "td-agent.conf size must not be zero: <${conf_path}>"
+getent group _fluentd >/dev/null
+if [ $? -ne 0 ]; then
+    echo "_fluentd group must be kept"
     exit 1
 fi
 
@@ -28,11 +29,12 @@ echo "fluentd-apt-source test"
 apt_source_repositories_dir=/fluentd/fluentd-apt-source/apt/repositories
 apt purge -y fluent-package
 
-conf_path=/etc/td-agent/td-agent.conf
-if [ -e $conf_path ]; then
-    echo "td-agent.conf must be purged: <${conf_path}>"
-    exit 1
-fi
+for conf_path in /etc/td-agent/td-agent.conf /etc/fluent/fluentd.conf; do
+    if [ -e $conf_path ]; then
+	echo "$conf_path must be removed"
+	exit 1
+    fi
+done
 
 if [ ${code_name} = "jammy" ]; then
     # TODO: Remove when repository for jammy has been deployed
@@ -44,3 +46,37 @@ apt_source_package=${apt_source_repositories_dir}/${distribution}/pool/${code_na
 apt install -V -y ${apt_source_package} ca-certificates
 apt update
 apt install -V -y td-agent
+
+apt install -V -y \
+  ${repositories_dir}/${distribution}/pool/${code_name}/${channel}/*/*/*_${architecture}.deb
+
+getent passwd td-agent >/dev/null
+if [ $? -eq 0 ]; then
+    echo "td-agent user must be removed"
+    exit 1
+fi
+getent group td-agent >/dev/null
+if [ $? -eq 0 ]; then
+    echo "td-agent group must be removed"
+    exit 1
+fi
+getent passwd _fluentd >/dev/null
+if [ $? -ne 0 ]; then
+    echo "_fluentd user must exist"
+    exit 1
+fi
+getent group _fluentd >/dev/null
+if [ $? -ne 0 ]; then
+    echo "_fluentd group must exist"
+    exit 1
+fi
+
+if [ ! -s /var/log/td-agent ]; then
+    echo "/var/log/td-agent must be symlink"
+    exit 1
+fi
+if [ ! -s /etc/td-agent ]; then
+    echo "/etc/td-agent must be symlink"
+    exit 1
+fi
+

--- a/fluent-package/debian/fluent-package.install
+++ b/fluent-package/debian/fluent-package.install
@@ -3,6 +3,6 @@ usr/bin/*
 usr/sbin/*
 usr/lib/tmpfiles.d/*
 etc/logrotate.d/*
-etc/td-agent/*
+etc/fluent/*
 etc/default/*
 lib/systemd/system/*

--- a/fluent-package/dmg/resources/pkg/postinstall.erb
+++ b/fluent-package/dmg/resources/pkg/postinstall.erb
@@ -5,16 +5,60 @@
 
 # Create <%= service_name %> related directories and files
 
-if [ ! -e "/var/log/<%= compat_package_dir %>/" ]; then
-  mkdir -p /var/log/<%= compat_package_dir %>/
-  mkdir -p /var/log/<%= compat_package_dir %>/buffer/
+if [ ! -e "/var/log/<%= package_dir %>/" ]; then
+    mkdir -p /var/log/<%= package_dir %>/
+    mkdir -p /var/log/<%= package_dir %>/buffer/
+fi
+if [ -d "/var/log/<%= compat_package_dir %>/" ]; then
+    if [ -d /var/log/<%= compat_package_dir %> -a ! -h /var/log/<%= compat_package_dir %> ]; then
+        # /var/log/<%= compat_package_dir %> migration from v4
+        if [ -d /var/log/<%= compat_package_dir %>/buffer -a -n "$(ls /var/log/<%= compat_package_dir %>/buffer)" ]; then
+            mv -f /var/log/<%= compat_package_dir %>/buffer/* /var/log/<%= compat_package_dir %>/buffer/
+        fi
+        for d in /var/log/<%= compat_package_dir %>/*; do
+            if [ ! "$d" == "/var/log/<%= compat_package_dir %>/buffer" ]; then
+                # /var/log/<%= compat_package_dir %>/buffer will be removed from td-agent
+                mv -f $d /var/log/<%= compat_package_dir %>/
+            fi
+        done
+        if [ -f /var/log/<%= compat_package_dir %>/<%= compat_service_name %>.log ]; then
+            echo "Moving log to /var/log/<%= package_dir %>..."
+            mv -f /var/log/<%= compat_package_dir %>/<%= compat_service_name %>.log /var/log/<%= package_dir %>/<%= compat_service_name %>.log
+        fi
+    fi
+    rm -fr /var/log/<%= compat_package_dir %>
+    ln -sf /var/log/<%= package_dir %> /var/log/<%= compat_package_dir %>
 fi
 if [ ! -e "/var/run/<%= package_dir %>/" ]; then
   mkdir -p /var/run/<%= package_dir %>/
 fi
-if [ ! -e "/etc/<%= compat_package_dir %>/" ]; then
-  mkdir -p /etc/<%= compat_package_dir %>/
-  mkdir -p /etc/<%= compat_package_dir %>/plugin
+if [ ! -e "/etc/<%= package_dir %>/" ]; then
+  mkdir -p /etc/<%= package_dir %>/
+  mkdir -p /etc/<%= package_dir %>/plugin
+fi
+if [ -d "/etc/<%= compat_package_dir %>/" ]; then
+    # /etc/<%= compat_package_dir %> migration from v4
+    if [ -d /etc/<%= compat_package_dir %>/plugin -a -n "$(ls /etc/<%= compat_package_dir %>/plugin)" ]; then
+        echo "Migrating from /etc/<%= compat_package_dir %>/plugin/ to /etc/<%= compat_package_dir %>/plugin/..."
+        mv -f /etc/<%= compat_package_dir %>/plugin/* /etc/<%= package_dir %>/plugin/
+    fi
+    if [ -f /etc/<%= compat_package_dir %>/<%= service_name %>.conf ]; then
+        # Avoid conflict with packaged version
+        echo "#"
+        echo "# Migrating from /etc/<%= compat_package_dir %>/<%= service_name %>.conf to /etc/<%= package_dir %>/<%= service_name %>.conf.moved"
+        echo "#"
+        mv -f /etc/<%= compat_package_dir %>/<%= service_name %>.conf /etc/<%= package_dir %>/<%= service_name %>.conf.moved
+    fi
+    if [ -f /etc/<%= compat_package_dir %>/<%= compat_service_name %>.conf ]; then
+        echo "Migrating from /etc/<%= compat_package_dir %>/<%= compat_service_name %>.conf to /etc/<%= package_dir %>/<%= compat_service_name %>.conf"
+        cp -f /etc/<%= compat_package_dir %>/<%= compat_service_name %>.conf /etc/<%= package_dir %>/<%= compat_service_name %>.conf
+    fi
+    for d in /etc/<%= compat_package_dir %>/*; do
+	echo "Migrating from $d to /etc/<%= package_dir %>..."
+        mv -f $d /etc/<%= package_dir %>/
+    done
+    rm -fr /etc/<%= compat_package_dir %>
+    ln -sf /etc/<%= package_dir %> /etc/<%= compat_package_dir %>
 fi
 if [ ! -e "/tmp/<%= package_dir %>/" ]; then
   mkdir -p /tmp/<%= package_dir %>/

--- a/fluent-package/templates/etc/systemd/fluentd.erb
+++ b/fluent-package/templates/etc/systemd/fluentd.erb
@@ -1,1 +1,5 @@
 TD_AGENT_OPTIONS=""
+# The following environment variable will be modified via package maintainer's migration script
+FLUENT_CONF=/etc/<%= package_dir %>/<%= service_name %>.conf
+FLUENT_PLUGIN=/etc/<%= package_dir %>/plugin
+TD_AGENT_LOG_FILE=/var/log/<%= package_dir %>/<%= service_name %>.log

--- a/fluent-package/templates/etc/systemd/fluentd.service.erb
+++ b/fluent-package/templates/etc/systemd/fluentd.service.erb
@@ -16,10 +16,7 @@ LimitNOFILE=65536
 Environment=LD_PRELOAD=<%= install_path %>/lib/libjemalloc.so
 Environment=GEM_HOME=<%= gem_install_path %>/
 Environment=GEM_PATH=<%= gem_install_path %>/
-Environment=FLUENT_CONF=/etc/<%= compat_package_dir %>/<%= compat_service_name %>.conf
-Environment=FLUENT_PLUGIN=/etc/<%= compat_package_dir %>/plugin
 Environment=FLUENT_SOCKET=/var/run/<%= package_dir %>/<%= compat_service_name %>.sock
-Environment=TD_AGENT_LOG_FILE=/var/log/<%= compat_package_dir %>/<%= compat_service_name %>.log
 <% if pkg_type == 'deb' %>
 EnvironmentFile=-/etc/default/<%= service_name %>
 <% else %>

--- a/fluent-package/templates/etc/systemd/fluentd.service.erb
+++ b/fluent-package/templates/etc/systemd/fluentd.service.erb
@@ -5,8 +5,13 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-User=<%= Shellwords.shellescape(compat_service_name) %>
-Group=<%= Shellwords.shellescape(compat_service_name) %>
+<% if pkg_type == 'deb' %>
+User=_<%= Shellwords.shellescape(service_name) %>
+Group=_<%= Shellwords.shellescape(service_name) %>
+<% else %>
+User=<%= Shellwords.shellescape(service_name) %>
+Group=<%= Shellwords.shellescape(service_name) %>
+<% end %>
 LimitNOFILE=65536
 Environment=LD_PRELOAD=<%= install_path %>/lib/libjemalloc.so
 Environment=GEM_HOME=<%= gem_install_path %>/

--- a/fluent-package/templates/fluentd.plist.erb
+++ b/fluent-package/templates/fluentd.plist.erb
@@ -10,7 +10,7 @@
   <array>
     <string>/opt/<%= package_dir %>/sbin/<%= service_name %></string>
     <string>--log</string>
-    <string>/var/log/<%= compat_package_dir %>/<%= service_name %>.log</string>
+    <string>/var/log/<%= package_dir %>/<%= service_name %>.log</string>
     <string>--use-v1-config</string>
   </array>
   <key>RunAtLoad</key>

--- a/fluent-package/templates/opt/fluent/share/td-agent.conf.tmpl
+++ b/fluent-package/templates/opt/fluent/share/td-agent.conf.tmpl
@@ -27,7 +27,7 @@
 <% if windows? %>
     path "#{ENV['TD_AGENT_TOPDIR']}/var/log/<%= compat_package_dir %>/buffer/td"
 <% else %>
-    path /var/log/<%= compat_package_dir %>/buffer/td
+    path /var/log/<%= package_dir %>/buffer/td
 <% end %>
   </buffer>
 
@@ -36,7 +36,7 @@
 <% if windows? %>
     path "#{ENV['TD_AGENT_TOPDIR']}/var/log/<%= compat_package_dir %>/failed_records"
 <% else %>
-    path /var/log/<%= compat_package_dir %>/failed_records
+    path /var/log/<%= package_dir %>/failed_records
 <% end %>
   </secondary>
 </match>
@@ -102,7 +102,7 @@
 #<match local.**>
 #  @type file
 #  @id output_file
-#  path /var/log/<%= compat_package_dir %>/access
+#  path /var/log/<%= package_dir %>/access
 #</match>
 
 ## Forwarding
@@ -133,11 +133,11 @@
 #    auto_create_table
 #    <buffer>
 #      @type file
-#      path /var/log/<%= compat_package_dir %>/buffer/td
+#      path /var/log/<%= package_dir %>/buffer/td
 #    </buffer>
 #  </store>
 #  <store>
 #    @type file
-#    path /var/log/<%= compat_package_dir %>/td-%Y-%m-%d/%H.log
+#    path /var/log/<%= package_dir %>/td-%Y-%m-%d/%H.log
 #  </store>
 #</match>

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postinst
@@ -7,25 +7,43 @@ set -e
 prevver="$2"
 
 add_system_user() {
-    if ! getent passwd <%= compat_service_name %> >/dev/null; then
-        adduser --group --system --home /var/lib/<%= package_dir %> <%= compat_service_name %>
+    if ! getent passwd _<%= service_name %> >/dev/null; then
+	if ! getent passwd <%= compat_service_name %> >/dev/null; then
+	    # With underscore prefix, need to disable NAME_REGEX restriction
+	    adduser --group --system --force-badname --home /var/lib/<%= package_dir %> _<%= service_name %>
+	else
+	    if getent group <%= compat_service_name %> >/dev/null; then
+		groupmod --new-name _<%= service_name %> <%= compat_service_name %>
+	    fi
+	    if getent passwd <%= compat_service_name %> >/dev/null; then
+		usermod --login _<%= service_name %> <%= compat_service_name %>
+	    fi
+	fi
     fi
 }
 
 add_directories() {
     mkdir -p /var/run/<%= package_dir %>
-    mkdir -p /etc/<%= package_dir %>
-    mkdir -p /etc/<%= package_dir %>/plugin
-    mkdir -p /var/log/<%= package_dir %>
+    mkdir -p /etc/<%= compat_package_dir %>
+    mkdir -p /etc/<%= compat_package_dir %>/plugin
+    mkdir -p /var/log/<%= compat_package_dir %>
 }
 
 fixperms() {
+    # If statoverride entry exits, use --force-all to ensure statoverride-add will work.
+    # If statoverride entry doen't exit, no need to --force-all.
     dpkg-statoverride --list /var/run/<%= package_dir %> >/dev/null || \
-        dpkg-statoverride --update --add <%= compat_service_name %> <%= compat_service_name %> 0755 /var/run/<%= package_dir %>
-    dpkg-statoverride --list /etc/<%= package_dir %> >/dev/null || \
-        dpkg-statoverride --update --add <%= compat_service_name %> <%= compat_service_name %> 0755 /etc/<%= package_dir %>
-    dpkg-statoverride --list /var/log/<%= package_dir %> >/dev/null || \
-        dpkg-statoverride --update --add <%= compat_service_name %> <%= compat_service_name %> 0755 /var/log/<%= package_dir %>
+        dpkg-statoverride --update --add _<%= service_name %> _<%= service_name %> 0755 /var/run/<%= package_dir %>
+    dpkg-statoverride --list /var/run/<%= package_dir %> >/dev/null && \
+        dpkg-statoverride --force-all --update --add _<%= service_name %> _<%= service_name %> 0755 /var/run/<%= package_dir %>
+    dpkg-statoverride --list /etc/<%= compat_package_dir %> >/dev/null || \
+        dpkg-statoverride --update --add _<%= service_name %> _<%= service_name %> 0755 /etc/<%= compat_package_dir %>
+    dpkg-statoverride --list /etc/<%= compat_package_dir %> >/dev/null && \
+        dpkg-statoverride --force-all --update --add _<%= service_name %> _<%= service_name %> 0755 /etc/<%= compat_package_dir %>
+    dpkg-statoverride --list /var/log/<%= compat_package_dir %> >/dev/null || \
+        dpkg-statoverride --update --add _<%= service_name %> _<%= service_name %> 0755 /var/log/<%= compat_package_dir %>
+    dpkg-statoverride --list /var/log/<%= compat_package_dir %> >/dev/null && \
+        dpkg-statoverride --force-all --update --add _<%= service_name %> _<%= service_name %> 0755 /var/log/<%= compat_package_dir %>
 }
 
 case "$1" in

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postinst
@@ -44,6 +44,8 @@ fixperms() {
         dpkg-statoverride --update --add _<%= service_name %> _<%= service_name %> 0755 /var/log/<%= compat_package_dir %>
     dpkg-statoverride --list /var/log/<%= compat_package_dir %> >/dev/null && \
         dpkg-statoverride --force-all --update --add _<%= service_name %> _<%= service_name %> 0755 /var/log/<%= compat_package_dir %>
+    # Cleanup /var/run/<%= compat_package_dir %>
+    dpkg-statoverride --force-all --remove /var/run/<%= compat_package_dir %>
 }
 
 case "$1" in

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postinst
@@ -1,7 +1,5 @@
 #! /bin/sh
 
-set -e
-
 . /usr/share/debconf/confmodule
 
 prevver="$2"
@@ -22,11 +20,68 @@ add_system_user() {
     fi
 }
 
+v4migration=/tmp/.<%= project_name %>_v4migration
+v4migration_with_restart=/tmp/.<%= project_name %>_v4migration_with_restart
+
 add_directories() {
     mkdir -p /var/run/<%= package_dir %>
-    mkdir -p /etc/<%= compat_package_dir %>
-    mkdir -p /etc/<%= compat_package_dir %>/plugin
-    mkdir -p /var/log/<%= compat_package_dir %>
+    mkdir -p /etc/<%= package_dir %>
+    mkdir -p /etc/<%= package_dir %>/plugin
+    mkdir -p /var/log/<%= package_dir %>
+    if [ -d /etc/<%= compat_package_dir %> -a ! -h /etc/<%= compat_package_dir %> ]; then
+	touch $v4migration
+	# /etc/<%= compat_package_dir %> migration from v4
+	if [ -d /etc/<%= compat_package_dir %>/plugin -a -n "$(ls /etc/<%= compat_package_dir %>/plugin)" ]; then
+	    echo "Migrating from /etc/<%= compat_service_name %>/plugin/ to /etc/<%= package_dir %>/plugin/..."
+	    mv -f /etc/<%= compat_service_name %>/plugin/* /etc/<%= package_dir %>/plugin/
+	fi
+	if [ -f /etc/<%= compat_package_dir %>/<%= service_name %>.conf ]; then
+	    # Avoid conflict with packaged version
+	    echo "#"
+	    echo "# Migrating from /etc/<%= compat_package_dir %>/<%= service_name %>.conf to /etc/<%= package_dir %>/<%= service_name %>.conf.rpmmoved"
+	    echo "#"
+	    mv -f /etc/<%= compat_package_dir %>/<%= service_name %>.conf /etc/<%= package_dir %>/<%= service_name %>.conf.dpkg-old
+	fi
+	if [ -f /etc/<%= compat_package_dir %>/<%= compat_service_name %>.conf ]; then
+	    echo "Migrating from /etc/<%= compat_package_dir %>/<%= compat_service_name %>.conf to /etc/<%= package_dir %>/<%= compat_service_name %>.conf"
+	    cp -f /etc/<%= compat_package_dir %>/<%= compat_service_name %>.conf /etc/<%= package_dir %>/<%= compat_service_name %>.conf
+	    for d in $(ls /etc/<%= compat_package_dir %>); do
+		if [ ! "$d" = "plugin" -a ! "$d" = "<%= compat_service_name %>.conf" ]; then
+		    # /etc/<%= compat_package_dir %>/plugin will be removed from td-agent
+		    mv -f /etc/<%= compat_package_dir %>/$d /etc/<%= package_dir %>/
+		fi
+	    done
+	    echo "Refer previous configuration <%= compat_service_name %>.conf ..."
+	    sed -i"" /etc/default/<%= service_name %> -e "/FLUENT_CONF/c FLUENT_CONF=/etc/<%= package_dir %>/<%= compat_service_name %>.conf"
+	fi
+    fi
+    if [ -h /etc/systemd/system/td-agent.service ]; then
+	systemctl is-active <%= compat_service_name %> >/dev/null
+	if [ $? -eq 0 ]; then
+	    # Want to restart with new user/group here,
+	    # but to avoid holding file descriptor under /var/log/<%= compat_package_dir %>/,
+	    # delay restarting <%= service_name %> service.
+	    touch $v4migration_with_restart
+	fi
+    fi
+    if [ -d /var/log/<%= compat_package_dir %> -a ! -h /var/log/<%= compat_package_dir %> ]; then
+	# /var/log/<%= compat_package_dir %> migration from v4
+	if [ -d /var/log/<%= compat_package_dir %>/buffer ]; then
+	    if [ -n "$(ls /var/log/<%= compat_package_dir %>/buffer)" ]; then
+		mv -f /var/log/<%= compat_package_dir %>/buffer/* /var/log/<%= package_dir %>/buffer/
+	    fi
+	fi
+	for d in $(ls /var/log/<%= compat_package_dir %>); do
+	    if [ ! "$d" = "buffer" ]; then
+		# /var/log/<%= compat_package_dir %>/buffer will be removed from td-agent
+		mv -f $d /var/log/<%= package_dir %>/
+	    fi
+	done
+	if [ -f /var/log/<%= package_dir %>/<%= compat_service_name %>.log ]; then
+	    echo "Keep logging to <%= compat_service_name %>.log ..."
+	    sed -i"" /etc/default/<%= service_name %> -e "/TD_AGENT_LOG_FILE/c TD_AGENT_LOG_FILE=/var/log/<%= compat_package_dir %>/<%= compat_service_name %>.log"
+	fi
+    fi
 }
 
 fixperms() {
@@ -48,12 +103,32 @@ fixperms() {
     dpkg-statoverride --force-all --remove /var/run/<%= compat_package_dir %>
 }
 
+fixconditions() {
+    if [ -f $v4migration ]; then
+	if [ -d /etc/<%= compat_package_dir %> ]; then
+	    rm -fr /etc/<%= compat_package_dir %>
+	    ln -sf /etc/<%= package_dir %> /etc/<%= compat_package_dir %>
+	fi
+	if [ -d /var/log/<%= compat_package_dir %> ]; then
+	    rm -fr /var/log/<%= compat_package_dir %>
+	    ln -sf /var/log/<%= package_dir %> /var/log/<%= compat_package_dir %>
+	fi
+	rm -f $v4migration
+    fi
+    if [ -f $v4migration_with_restart ]; then
+	systemctl restart <%= service_name %>
+	rm -f $v4migration_with_restart
+    fi
+}
+
+
 case "$1" in
     configure)
         add_system_user
         add_directories
         fixperms
-        ;;
+        fixconditions
+	;;
     abort-upgrade|abort-deconfigure|abort-remove)
         :
         ;;

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postrm
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postrm
@@ -6,21 +6,21 @@ set -e
 
 if [ "$1" = "purge" ]; then
 	rm -f /etc/default/<%= compat_service_name %>
-	dpkg-statoverride --list /etc/<%= package_dir %> > /dev/null && \
-		dpkg-statoverride --remove /etc/<%= package_dir %>
-	rm -f /etc/<%= package_dir %>/<%= compat_service_name %>.conf
-	rm -rf /etc/<%= package_dir %>
+	dpkg-statoverride --list /etc/<%= compat_package_dir %> > /dev/null && \
+		dpkg-statoverride --remove /etc/<%= compat_package_dir %>
+	rm -f /etc/<%= compat_package_dir %>/<%= compat_service_name %>.conf
+	rm -rf /etc/<%= compat_package_dir %>
 	dpkg-statoverride --list /var/run/<%= package_dir %> > /dev/null && \
 		dpkg-statoverride --remove /var/run/<%= package_dir %>
 	rm -f /var/run/<%= package_dir %>/*
 	rm -rf /var/run/<%= package_dir %>
-	dpkg-statoverride --list /var/log/<%= package_dir %> > /dev/null && \
-		dpkg-statoverride --remove /var/log/<%= package_dir %>
-	rm -rf /var/log/<%= package_dir %>/buffer
-	rm -rf /var/log/<%= package_dir %>/*
-	rm -rf /var/log/<%= package_dir %>
+	dpkg-statoverride --list /var/log/<%= compat_package_dir %> > /dev/null && \
+		dpkg-statoverride --remove /var/log/<%= compat_package_dir %>
+	rm -rf /var/log/<%= compat_package_dir %>/buffer
+	rm -rf /var/log/<%= compat_package_dir %>/*
+	rm -rf /var/log/<%= compat_package_dir %>
 
-	getent passwd <%= compat_service_name %> && userdel -r <%= compat_service_name %>
+	getent passwd _<%= service_name %> && userdel -r _<%= service_name %>
 fi
 
 #DEBHELPER#

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postrm
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postrm
@@ -6,10 +6,17 @@ set -e
 
 if [ "$1" = "purge" ]; then
 	rm -f /etc/default/<%= compat_service_name %>
-	dpkg-statoverride --list /etc/<%= compat_package_dir %> > /dev/null && \
-		dpkg-statoverride --remove /etc/<%= compat_package_dir %>
-	rm -f /etc/<%= compat_package_dir %>/<%= compat_service_name %>.conf
-	rm -rf /etc/<%= compat_package_dir %>
+	rm -f /etc/default/<%= service_name %>
+	for target_dir in /etc/<%= compat_package_dir %> /etc/<%= package_dir %>; do
+  	    dpkg-statoverride --list $target_dir > /dev/null && \
+		dpkg-statoverride --remove $target_dir
+	    if [ "$target_dir" = "/etc/<%= compat_package_dir %>" ]; then
+		rm -f $target_dir/<%= compat_service_name %>.conf
+	    elif [ "$target_dir" = "/etc/<%= package_dir %>" ]; then
+		rm -f $target_dir/<%= service_name %>.conf
+	    fi
+	    rm -rf $target_dir
+	done
 	dpkg-statoverride --list /var/run/<%= package_dir %> > /dev/null && \
 		dpkg-statoverride --remove /var/run/<%= package_dir %>
 	rm -f /var/run/<%= package_dir %>/*
@@ -19,6 +26,15 @@ if [ "$1" = "purge" ]; then
 	rm -rf /var/log/<%= compat_package_dir %>/buffer
 	rm -rf /var/log/<%= compat_package_dir %>/*
 	rm -rf /var/log/<%= compat_package_dir %>
+	for target_dir in /var/log/<%= compat_package_dir %> /var/log/<%= package_dir %>; do
+  	    dpkg-statoverride --list $target_dir > /dev/null && \
+		dpkg-statoverride --remove $target_dir
+	    if [ "$target_dir" = "/var/log/<%= compat_package_dir %>" ]; then
+		rm -f $target_dir
+	    elif [ "$target_dir" = "/var/log/<%= package_dir %>" ]; then
+		rm -rf $target_dir
+	    fi
+	done
 
 	getent passwd _<%= service_name %> && userdel -r _<%= service_name %>
 fi

--- a/fluent-package/templates/usr/lib/tmpfiles.d/fluentd.conf
+++ b/fluent-package/templates/usr/lib/tmpfiles.d/fluentd.conf
@@ -1,9 +1,21 @@
-d /tmp/<%= package_dir %> 0755 <%= compat_service_name %> <%= compat_service_name %> - -
-<% if ENV["NO_VAR_RUN"] %>
-d /run/<%= package_dir %> 0755 <%= compat_service_name %> <%= compat_service_name %> - -
+<% if pkg_type == "deb" %>
+d /tmp/<%= package_dir %> 0755 _<%= service_name %> _<%= service_name %> - -
 <% else %>
-d /var/run/<%= package_dir %> 0755 <%= compat_service_name %> <%= compat_service_name %> - -
+d /tmp/<%= package_dir %> 0755 <%= service_name %> <%= service_name %> - -
+<% end %>
+<% if pkg_type == "deb" %>
+<% if ENV["NO_VAR_RUN"] %>
+d /run/<%= package_dir %> 0755 _<%= service_name %> _<%= service_name %> - -
+<% else %>
+d /var/run/<%= package_dir %> 0755 _<%= service_name %> _<%= service_name %> - -
+<% end %>
+<% else %>
+<% if ENV["NO_VAR_RUN"] %>
+d /run/<%= package_dir %> 0755 <%= service_name %> <%= service_name %> - -
+<% else %>
+d /var/run/<%= package_dir %> 0755 <%= service_name %> <%= service_name %> - -
+<% end %>
 <% end %>
 
-# Exclude td-agent
+# Exclude <%= service_name %>
 x /tmp/<%= package_dir %>

--- a/fluent-package/templates/usr/sbin/fluentd.erb
+++ b/fluent-package/templates/usr/sbin/fluentd.erb
@@ -1,9 +1,9 @@
 #!<%= install_path %>/bin/ruby
 ENV["GEM_HOME"]="<%= gem_install_path %>/"
 ENV["GEM_PATH"]="<%= gem_install_path %>/"
-ENV["FLUENT_CONF"]="/etc/<%= compat_package_dir %>/<%= compat_service_name %>.conf"
-ENV["FLUENT_PLUGIN"]="/etc/<%= compat_package_dir %>/plugin"
-ENV["FLUENT_SOCKET"]="/var/run/<%= package_dir %>/<%= compat_service_name %>.sock"
+ENV["FLUENT_CONF"]="/etc/<%= package_dir %>/<%= service_name %>.conf"
+ENV["FLUENT_PLUGIN"]="/etc/<%= package_dir %>/plugin"
+ENV["FLUENT_SOCKET"]="/var/run/<%= package_dir %>/<%= service_name %>.sock"
 if ARGV.include?("--version")
   require "<%= install_path %>/share/config"
   Dir.glob("<%= install_path %>/lib/ruby/**/gems/**/fluent/version.rb").each do |v|

--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -28,6 +28,8 @@
 # Omit check-rpath and brp-mangle-shebangs since we use our own Ruby
 %define __arch_install_post %{nil}
 %undefine __brp_mangle_shebangs
+%define v4migration /tmp/@PACKAGE_DIR@/.v4migration
+%define v4migration_with_restart /tmp/@PACKAGE_DIR@/.v4migration_with_restart
 
 %global __provides_exclude_from ^/opt/%{name}/.*\\.so.*
 %global __requires_exclude libjemalloc.*|libruby.*|/opt/%{name}/.*
@@ -132,9 +134,9 @@ done
 
 cd -
 mkdir -p %{buildroot}%{_localstatedir}/run/@PACKAGE_DIR@
-mkdir -p %{buildroot}%{_localstatedir}/log/@COMPAT_PACKAGE_DIR@
-mkdir -p %{buildroot}%{_localstatedir}/log/@COMPAT_PACKAGE_DIR@/buffer
-mkdir -p %{buildroot}%{_sysconfdir}/@COMPAT_PACKAGE_DIR@/plugin
+mkdir -p %{buildroot}%{_localstatedir}/log/@PACKAGE_DIR@
+mkdir -p %{buildroot}%{_localstatedir}/log/@PACKAGE_DIR@/buffer
+mkdir -p %{buildroot}%{_sysconfdir}/@PACKAGE_DIR@/plugin
 mkdir -p %{buildroot}/tmp/@PACKAGE_DIR@
 
 %pre
@@ -173,6 +175,33 @@ fi
 %post
 %systemd_post @SERVICE_NAME@.service
 if [ $1 -eq 1 ]; then
+    if [ -d /etc/@COMPAT_PACKAGE_DIR@ -a ! -h /etc/@COMPAT_PACKAGE_DIR@ ]; then
+	touch %{v4migration}
+	# /etc/@COMPAT_PACKAGE_DIR@ migration from v4
+	if [ -d /etc/@COMPAT_PACKAGE_DIR@/plugin -a -n "$(ls /etc/@COMPAT_PACKAGE_DIR@/plugin)" ]; then
+	    echo "Migrating from /etc/@COMPAT_PACKAGE_DIR@/plugin/ to /etc/@PACKAGE_DIR@/plugin/..."
+	    mv -f /etc/@COMPAT_PACKAGE_DIR@/plugin/* /etc/@PACKAGE_DIR@/plugin/
+	fi
+	if [ -f /etc/@COMPAT_PACKAGE_DIR@/@SERVICE_NAME@.conf ]; then
+	    # Avoid conflict with packaged version
+	    echo "#"
+	    echo "# Migrating from /etc/@COMPAT_PACKAGE_DIR@/@SERVICE_NAME@.conf to /etc/@PACKAGE_DIR@/@SERVICE_NAME@.conf.rpmmoved"
+	    echo "#"
+	    mv -f /etc/@COMPAT_PACKAGE_DIR@/@SERVICE_NAME@.conf /etc/@PACKAGE_DIR@/@SERVICE_NAME@.conf.rpmmoved
+	fi
+	if [ -f /etc/@COMPAT_PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.conf ]; then
+	    echo "Migrating from /etc/@COMPAT_PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.conf to /etc/@PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.conf"
+	    cp -f /etc/@COMPAT_PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.conf /etc/@PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.conf
+	    for d in /etc/@COMPAT_PACKAGE_DIR@/*; do
+		if [ ! "$d" == "/etc/@COMPAT_PACKAGE_DIR@/plugin" -a ! "$d" == "/etc/@COMPAT_PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.conf" ]; then
+		    # /etc/@COMPAT_PACKAGE_DIR@/plugin will be removed from td-agent
+		    mv -f $d /etc/@PACKAGE_DIR@/
+		fi
+	    done
+	    echo "Refer previous configuration @COMPAT_SERVICE_NAME@.conf ..."
+	    %{__sed} -i"" %{_sysconfdir}/sysconfig/@SERVICE_NAME@ -e "/FLUENT_CONF/c FLUENT_CONF=/etc/@PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.conf"
+	fi
+    fi
     systemctl is-active @COMPAT_SERVICE_NAME@
     if [ $? -eq 0 ]; then
 	if getent passwd @COMPAT_SERVICE_NAME@ >/dev/null; then
@@ -185,11 +214,26 @@ if [ $1 -eq 1 ]; then
 		/usr/sbin/usermod --login @SERVICE_NAME@ @COMPAT_SERVICE_NAME@
 	    fi
 	fi
-	# When upgrading from v4, td-agent.service will be removed
-	# with %postun scriptlet. fluentd service also inactive even though
-	# td-agent.service is running before upgrade process. Try to
-	# keep running fluentd service, explicitly restart it.
-	systemctl restart @SERVICE_NAME@.service
+	# Want to restart with new user/group here,
+	# but to avoid holding file descriptor under /var/log/@COMPAT_PACKAGE_DIR@/,
+	# delay restarting @SERVICE_NAME@ service.
+	touch %{v4migration_with_restart}
+    fi
+    if [ -d /var/log/@COMPAT_PACKAGE_DIR@ -a ! -h /var/log/@COMPAT_PACKAGE_DIR@ ]; then
+	# /var/log/@COMPAT_PACKAGE_DIR@ migration from v4
+	if [ -d /var/log/@COMPAT_PACKAGE_DIR@/buffer -a -n "$(ls /var/log/@COMPAT_PACKAGE_DIR@/buffer)" ]; then
+	    mv -f /var/log/@COMPAT_PACKAGE_DIR@/buffer/* /var/log/@PACKAGE_DIR@/buffer/
+	fi
+	for d in /var/log/@COMPAT_PACKAGE_DIR@/*; do
+	    if [ ! "$d" == "/var/log/@COMPAT_PACKAGE_DIR@/buffer" ]; then
+		# /var/log/@COMPAT_PACKAGE_DIR@/buffer will be removed from td-agent
+		mv -f $d /var/log/@PACKAGE_DIR@/
+	    fi
+	done
+	if [ -f /var/log/@PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.log ]; then
+	    echo "Keep logging to @COMPAT_SERVICE_NAME@.log ..."
+	    %{__sed} -i"" %{_sysconfdir}/sysconfig/@SERVICE_NAME@ -e "/TD_AGENT_LOG_FILE/c TD_AGENT_LOG_FILE=/var/log/@COMPAT_PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.log"
+	fi
     fi
 fi
 if [ -d "%{_sysconfdir}/prelink.conf.d/" ]; then
@@ -220,6 +264,12 @@ fi
 if [ -f /usr/sbin/@COMPAT_SERVICE_NAME@-gem ]; then
   rm -f /usr/sbin/@COMPAT_SERVICE_NAME@-gem
 fi
+if [ -h /etc/@COMPAT_PACKAGE_DIR@ ]; then
+  rm -f /etc/@COMPAT_PACKAGE_DIR@
+fi
+if [ -h /var/log/@COMPAT_PACKAGE_DIR@ ]; then
+  rm -f /var/log/@COMPAT_PACKAGE_DIR@
+fi
 
 if [ $1 -eq 0 ]; then
    # Removing
@@ -235,12 +285,31 @@ fi
 
 %posttrans
 if [ ! -f /usr/sbin/@COMPAT_SERVICE_NAME@ ]; then
-  # provides /usr/sbin/td-agent for backward compatibility
+  echo "Provides /usr/sbin/td-agent symlink for backward compatibility"
   ln -sf /usr/sbin/@SERVICE_NAME@ /usr/sbin/@COMPAT_SERVICE_NAME@
 fi
 if [ ! -f /usr/sbin/@COMPAT_SERVICE_NAME@-gem ]; then
-  # provides /usr/sbin/td-agent-gem for backward compatibility
+  echo "Provides /usr/sbin/td-agent-gem symlink for backward compatibility"
   ln -sf /usr/sbin/fluent-gem /usr/sbin/@COMPAT_SERVICE_NAME@-gem
+fi
+if [ -f %{v4migration} ]; then
+    if [ ! -h /etc/@COMPAT_PACKAGE_DIR@ ]; then
+	echo "Provides /etc/td-agent symlink for backward compatibility"
+	ln -sf /etc/@PACKAGE_DIR@ /etc/@COMPAT_PACKAGE_DIR@
+    fi
+    if [ ! -h /var/log/@COMPAT_PACKAGE_DIR@ ]; then
+	echo "Provides /var/log/td-agent symlink for backward compatibility"
+	ln -sf /var/log/@PACKAGE_DIR@ /var/log/@COMPAT_PACKAGE_DIR@
+    fi
+    rm -f %{v4migration}
+    if [ -f %{v4migration_with_restart} ]; then
+	# When upgrading from v4, td-agent.service will be removed
+	# with %postun scriptlet. fluentd service also inactive even though
+	# td-agent.service is running before upgrade process. Try to
+	# keep running fluentd service, explicitly restart it.
+	systemctl restart @SERVICE_NAME@.service
+	rm -f %{v4migration_with_restart}
+    fi
 fi
 
 %files
@@ -259,12 +328,12 @@ fi
 %{_sbindir}/fluent-gem
 %{_mandir}/man1/td*
 %config(noreplace) %{_sysconfdir}/sysconfig/@SERVICE_NAME@
-%config(noreplace) %{_sysconfdir}/@COMPAT_PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.conf
+%config(noreplace) %{_sysconfdir}/@PACKAGE_DIR@/@SERVICE_NAME@.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/@COMPAT_SERVICE_NAME@
-%attr(0755,fluentd,fluentd) %dir %{_localstatedir}/log/@COMPAT_PACKAGE_DIR@
-%attr(0755,fluentd,fluentd) %dir %{_localstatedir}/log/@COMPAT_PACKAGE_DIR@/buffer
-%attr(0755,fluentd,fluentd) %dir %{_sysconfdir}/@COMPAT_PACKAGE_DIR@
-%attr(0755,fluentd,fluentd) %dir %{_sysconfdir}/@COMPAT_PACKAGE_DIR@/plugin
+%attr(0755,fluentd,fluentd) %dir %{_localstatedir}/log/@PACKAGE_DIR@
+%attr(0755,fluentd,fluentd) %dir %{_localstatedir}/log/@PACKAGE_DIR@/buffer
+%attr(0755,fluentd,fluentd) %dir %{_sysconfdir}/@PACKAGE_DIR@
+%attr(0755,fluentd,fluentd) %dir %{_sysconfdir}/@PACKAGE_DIR@/plugin
 # NOTE: %{_tmpfilesdir} is available since CentOS 7
 %attr(0755,fluentd,fluentd) %dir /tmp/@PACKAGE_DIR@
 %changelog

--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -139,14 +139,32 @@ mkdir -p %{buildroot}/tmp/@PACKAGE_DIR@
 
 %pre
 if ! getent group @COMPAT_SERVICE_NAME@ >/dev/null; then
-    /usr/sbin/groupadd -r @COMPAT_SERVICE_NAME@
+    if ! getent group @SERVICE_NAME@ >/dev/null; then
+        /usr/sbin/groupadd -r @SERVICE_NAME@
+    fi
+else
+    if ! getent group @SERVICE_NAME@ >/dev/null; then
+       echo "Migrate group @COMPAT_SERVICE_NAME@ to @SERVICE_NAME@..."
+       /usr/sbin/groupmod --new-name @SERVICE_NAME@ @COMPAT_SERVICE_NAME@
+    fi
 fi
 if ! getent passwd @COMPAT_SERVICE_NAME@ >/dev/null; then
+    if ! getent passwd @SERVICE_NAME@ >/dev/null; then
 %if %{use_suse}
-    /usr/sbin/useradd -r -g @COMPAT_SERVICE_NAME@ -d %{_localstatedir}/lib/@PACKAGE_DIR@ -s /sbin/nologin -c '@COMPAT_SERVICE_NAME@' @COMPAT_SERVICE_NAME@
+        /usr/sbin/useradd -r -g @SERVICE_NAME@ -d %{_localstatedir}/lib/@PACKAGE_DIR@ -s /sbin/nologin -c '@SERVICE_NAME@' @SERVICE_NAME@
 %else
-    /usr/sbin/adduser -r -g @COMPAT_SERVICE_NAME@ -d %{_localstatedir}/lib/@PACKAGE_DIR@ -s /sbin/nologin -c '@COMPAT_SERVICE_NAME@' @COMPAT_SERVICE_NAME@
+        /usr/sbin/adduser -r -g @SERVICE_NAME@ -d %{_localstatedir}/lib/@PACKAGE_DIR@ -s /sbin/nologin -c '@SERVICE_NAME@' @SERVICE_NAME@
 %endif
+    fi
+else
+    if ! getent passwd @SERVICE_NAME@ >/dev/null; then
+       systemctl is-active @COMPAT_SERVICE_NAME@
+       if [ $? -ne 0 ]; then
+           # As service is down, renaming user here.
+	   echo "Migrate user @COMPAT_SERVICE_NAME@ to @SERVICE_NAME@..."
+           /usr/sbin/usermod --login @SERVICE_NAME@ @COMPAT_SERVICE_NAME@
+       fi
+    fi
 fi
 
 %preun
@@ -157,6 +175,16 @@ fi
 if [ $1 -eq 1 ]; then
     systemctl is-active @COMPAT_SERVICE_NAME@
     if [ $? -eq 0 ]; then
+	if getent passwd @COMPAT_SERVICE_NAME@ >/dev/null; then
+	    if ! getent passwd @SERVICE_NAME@ >/dev/null; then
+		# usermod fails when user process is active, so
+		# postpone username migration step here. (During %pre
+		# stage, mismatch of user/group configuration cause
+		# restarting service failure.)
+		systemctl stop @COMPAT_SERVICE_NAME@.service
+		/usr/sbin/usermod --login @SERVICE_NAME@ @COMPAT_SERVICE_NAME@
+	    fi
+	fi
 	# When upgrading from v4, td-agent.service will be removed
 	# with %postun scriptlet. fluentd service also inactive even though
 	# td-agent.service is running before upgrade process. Try to
@@ -221,12 +249,12 @@ fi
 %config(noreplace) %{_sysconfdir}/sysconfig/@SERVICE_NAME@
 %config(noreplace) %{_sysconfdir}/@COMPAT_PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/@COMPAT_SERVICE_NAME@
-%attr(0755,td-agent,td-agent) %dir %{_localstatedir}/log/@COMPAT_PACKAGE_DIR@
-%attr(0755,td-agent,td-agent) %dir %{_localstatedir}/log/@COMPAT_PACKAGE_DIR@/buffer
-%attr(0755,td-agent,td-agent) %dir %{_sysconfdir}/@COMPAT_PACKAGE_DIR@
-%attr(0755,td-agent,td-agent) %dir %{_sysconfdir}/@COMPAT_PACKAGE_DIR@/plugin
+%attr(0755,fluentd,fluentd) %dir %{_localstatedir}/log/@COMPAT_PACKAGE_DIR@
+%attr(0755,fluentd,fluentd) %dir %{_localstatedir}/log/@COMPAT_PACKAGE_DIR@/buffer
+%attr(0755,fluentd,fluentd) %dir %{_sysconfdir}/@COMPAT_PACKAGE_DIR@
+%attr(0755,fluentd,fluentd) %dir %{_sysconfdir}/@COMPAT_PACKAGE_DIR@/plugin
 # NOTE: %{_tmpfilesdir} is available since CentOS 7
-%attr(0755,td-agent,td-agent) %dir /tmp/@PACKAGE_DIR@
+%attr(0755,fluentd,fluentd) %dir /tmp/@PACKAGE_DIR@
 %changelog
 * Tue Jan 17 2023 Takuro Ashie <ashie@clear-code.com> - 5.0.0-1
 - New upstream release.

--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -221,6 +221,18 @@ if [ -f /usr/sbin/@COMPAT_SERVICE_NAME@-gem ]; then
   rm -f /usr/sbin/@COMPAT_SERVICE_NAME@-gem
 fi
 
+if [ $1 -eq 0 ]; then
+   # Removing
+   if getent passwd @SERVICE_NAME@ >/dev/null; then
+       echo "Removing @SERVICE_NAME@ user..."
+       /usr/sbin/userdel --remove @SERVICE_NAME@
+   fi
+   if getent group @SERVICE_NAME@ >/dev/null; then
+       echo "Removing @SERVICE_NAME@ group..."
+       /usr/sbin/groupdel @SERVICE_NAME@
+   fi
+fi
+
 %posttrans
 if [ ! -f /usr/sbin/@COMPAT_SERVICE_NAME@ ]; then
   # provides /usr/sbin/td-agent for backward compatibility

--- a/fluent-package/yum/pkgsize-test.sh
+++ b/fluent-package/yum/pkgsize-test.sh
@@ -60,7 +60,9 @@ for v in "${PREVIOUS_VERSIONS[@]}"; do
     BASE_NAME=td-agent-${v}-1.${DISTRO_VERSION_PREFIX}${DISTRO_VERSION}.${ARCH}.rpm
     PREVIOUS_RPM=${BASE_URI}/${ARCH}/${BASE_NAME}
     set +e
-    wget ${PREVIOUS_RPM}
+    if [ ! -f ${BASE_NAME} ]; then
+	wget ${PREVIOUS_RPM}
+    fi
     if [ $? -eq 0 ]; then
 	break
     fi

--- a/serverspec/linux/td-agent.rb
+++ b/serverspec/linux/td-agent.rb
@@ -7,13 +7,24 @@ describe package("fluent-package") do
   it { should be_installed }
 end
 
-describe user("td-agent") do
-  it { should exist }
-  it { should belong_to_group "td-agent" }
-end
+if os[:family] == 'redhat'
+  describe user("fluentd") do
+    it { should exist }
+    it { should belong_to_group "fluentd" }
+  end
 
-describe group("td-agent") do
-  it { should exist }
+  describe group("fluentd") do
+    it { should exist }
+  end
+else
+  describe user("_fluentd") do
+    it { should exist }
+    it { should belong_to_group "_fluentd" }
+  end
+
+  describe group("_fluentd") do
+    it { should exist }
+  end
 end
 
 describe "gem files" do


### PR DESCRIPTION
This is follow-up #489. it should be rebased with #475, #489.

Before:

* Use old path for compatibility.
  * /etc/td-agent/td-agent.conf
  * /var/log/td-agent/

After:

* Use /etc/fluent and /var/log/fluent by default.
* Keep /etc/td-agent, /var/log/td-agent as possible (only upgrading)
  * Moving content under /etc/td-agent to /etc/fluent/
  * Moving content under /var/log/td-agent to /var/log/fluent
  * Making symlink from /var/log/td-agent /var/log/fluent
  * Making symlink from /etc/td-agent to /etc/fluent
