### PR TITLE
msi: migration to c:\opt\fluent

### DIFF
--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -546,6 +546,7 @@ class BuildTask
         ensure_directory(staging_bindir)
         cp("msi/assets/#{PACKAGE_NAME}-prompt.bat", td_agent_staging_dir)
         cp("msi/assets/#{PACKAGE_NAME}-post-install.bat", staging_bindir)
+        cp("msi/assets/#{PACKAGE_NAME}-post-migration.bat", staging_bindir)
         cp("msi/assets/#{SERVICE_NAME}.bat", td_agent_staging_dir)
         cp("msi/assets/fluent-gem.bat", td_agent_staging_dir)
         cp("msi/assets/#{PACKAGE_NAME}-version.rb", staging_bindir)

--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -477,11 +477,7 @@ class BuildTask
 
       desc "Create td-agent configuration files from template"
       task :td_agent_config do
-        configs = if windows?
-                    ["etc/#{COMPAT_PACKAGE_DIR}/#{COMPAT_SERVICE_NAME}.conf"]
-                  else
-                    ["etc/#{PACKAGE_DIR}/#{SERVICE_NAME}.conf"]
-                  end
+        configs = ["etc/#{PACKAGE_DIR}/#{SERVICE_NAME}.conf"]
         configs.concat([
           "etc/logrotate.d/#{SERVICE_NAME}",
           "opt/#{PACKAGE_DIR}/share/#{COMPAT_SERVICE_NAME}-ruby.conf",
@@ -489,8 +485,7 @@ class BuildTask
         ]) unless windows? || macos?
         configs.each do |config|
           src = template_path(config)
-          if config == "etc/#{PACKAGE_DIR}/#{SERVICE_NAME}.conf" or
-            config == "etc/#{COMPAT_PACKAGE_DIR}/#{COMPAT_SERVICE_NAME}.conf"
+          if config == "etc/#{PACKAGE_DIR}/#{SERVICE_NAME}.conf"
             src = template_path("opt/#{PACKAGE_DIR}/share/#{COMPAT_SERVICE_NAME}.conf.tmpl")
           end
           dest = File.join(STAGING_DIR, config)

--- a/fluent-package/msi/assets/fluent-package-post-install.bat
+++ b/fluent-package/msi/assets/fluent-package-post-install.bat
@@ -1,5 +1,5 @@
 @echo off
-title Td-agent post install script
+title Fluent-package post install script
 if not "%~dp0" == "C:\opt\fluent\bin\" (
    "%~dp0gem" pristine --only-executables --all
 )

--- a/fluent-package/msi/assets/fluent-package-post-migration.bat
+++ b/fluent-package/msi/assets/fluent-package-post-migration.bat
@@ -1,0 +1,51 @@
+@echo on
+title Fluent-package post migration script
+
+if exist "%~dp0..\..\td-agent" (
+  setlocal enabledelayedexpansion
+  sc query state=inactive | findstr fluentdwinsvc
+  if !ERRORLEVEL! == 1 (
+    @rem NOTE: If the service is not stopped here, it is a BUG.
+    @rem This state can cause fatal problems with the installation, so we should cancel this process.
+    @rem (If trying to stop it by the command such as `$ net stop fluentdwinsvc`, it can fail as "The service is starting or stopping.  Please try again later.".)
+    echo "WARN: Active fluentdwinsvc service is detected. This is unexpected. Migration process has been canceled."
+    exit /b 1
+  )
+  endlocal
+
+  if not exist "%~dp0..\etc\fluent" (
+    echo "Create c:\opt\fluent\etc\fluent directory"
+    mkdir "%~dp0..\etc\fluent"
+  )
+
+  if exist "%~dp0..\..\td-agent\etc\td-agent\td-agent.conf" (
+    echo "Migrate c:\opt\td-agent\etc\td-agent.conf"
+    move /Y "%~dp0..\..\td-agent\etc\td-agent\td-agent.conf" "%~dp0..\etc\fluent\td-agent.conf"
+    echo "Migrate td-agent.conf to c:\opt\fluent\etc\fluent\fluentd.conf"
+    copy /Y "%~dp0..\etc\fluent\td-agent.conf" "%~dp0..\etc\fluent\fluentd.conf"
+  )
+
+  @rem NOTE: do not migrate log files not to lose log accidentally
+
+  echo "Migrate c:\opt\td-agent\etc\td-agent\* files"
+  for %%f in (%~dp0..\..\td-agent\etc\td-agent\*) do (
+    move /Y %%f "%~dp0..\etc\fluent\"
+  )
+  if not exist "%~dp0..\etc\fluent\plugin" (
+    mkdir "%~dp0..\etc\fluent\plugin"
+  )
+  echo "Migrate c:\opt\td-agent\etc\plugin directory"
+  for /d %%d in (%~dp0..\..\td-agent\etc\plugin\*) do (
+    move /Y %%d "%~dp0..\etc\fluent\plugin\"
+  )
+
+  echo "Ensure remaining files under td-agent"
+  tree %~dp0..\..\td-agent
+
+  @rem create symbolic link to c:\opt\fluent (we can't use hardlink for directory)
+  if exist "%~dp0..\..\td-agent\etc\td-agent" (
+    rmdir /S /Q "%~dp0..\..\td-agent\etc\td-agent"
+  )
+  echo "Create symlink c:\opt\td-agent\etc\td-agent to c:\opt\fluent\etc\fluent"
+  mklink /D %~dp0..\..\td-agent\etc\td-agent %~dp0..\..\fluent\etc\fluent
+)

--- a/fluent-package/msi/assets/fluent-package-post-migration.bat
+++ b/fluent-package/msi/assets/fluent-package-post-migration.bat
@@ -40,7 +40,7 @@ if exist "%~dp0..\..\td-agent" (
   )
 
   echo "Ensure remaining files under td-agent"
-  tree %~dp0..\..\td-agent
+  tree /F %~dp0..\..\td-agent
 
   @rem create symbolic link to c:\opt\fluent (we can't use hardlink for directory)
   if exist "%~dp0..\..\td-agent\etc\td-agent" (

--- a/fluent-package/msi/assets/fluentd.bat
+++ b/fluent-package/msi/assets/fluentd.bat
@@ -7,7 +7,7 @@ if "%~nx0" == "td-agent.bat" (
 
 @rem Convert path separator from backslash to forwardslash
 setlocal enabledelayedexpansion
-set FLUENT_PACKAGE_TOPDIR=FLUENT_PACKAGE_TOPDIR=!FLUENT_PACKAGE_TOPDIR:\=/!
+set FLUENT_PACKAGE_TOPDIR=!FLUENT_PACKAGE_TOPDIR:\=/!
 
 set PATH=%FLUENT_PACKAGE_TOPDIR%bin;%PATH%
 set PATH=%FLUENT_PACKAGE_TOPDIR%;%PATH%

--- a/fluent-package/msi/assets/fluentd.bat
+++ b/fluent-package/msi/assets/fluentd.bat
@@ -1,22 +1,19 @@
 @echo off
 if "%~nx0" == "td-agent.bat" (
   set FLUENT_PACKAGE_TOPDIR=%~dp0..\
-  set TD_AGENT_TOPDIR=%~dp0..\..\td-agent
 ) else (
   set FLUENT_PACKAGE_TOPDIR=%~dp0
-  set TD_AGENT_TOPDIR=%~dp0..\td-agent
 )
 
 @rem Convert path separator from backslash to forwardslash
 setlocal enabledelayedexpansion
 set FLUENT_PACKAGE_TOPDIR="FLUENT_PACKAGE_TOPDIR=!FLUENT_PACKAGE_TOPDIR:\=/!"
-set TD_AGENT_TOPDIR="TD_AGENT_TOPDIR=!TD_AGENT_TOPDIR:\=/!"
 endlocal
 
 set PATH=%FLUENT_PACKAGE_TOPDIR%bin;%PATH%
 set PATH=%FLUENT_PACKAGE_TOPDIR%;%PATH%
-set FLUENT_CONF=%TD_AGENT_TOPDIR%/etc/td-agent/td-agent.conf
-set FLUENT_PLUGIN=%TD_AGENT_TOPDIR%/etc/td-agent/plugin
+set FLUENT_CONF=%FLUENT_PACKAGE_TOPDIR%/etc/fluent/fluentd.conf
+set FLUENT_PLUGIN=%FLUENT_PACKAGE_TOPDIR%/etc/fluent/plugin
 set FLUENT_PACKAGE_VERSION=%FLUENT_PACKAGE_TOPDIR%/bin/fluent-package-version.rb
 for %%p in (%*) do (
     if "%%p"=="--version" (

--- a/fluent-package/msi/assets/fluentd.bat
+++ b/fluent-package/msi/assets/fluentd.bat
@@ -6,17 +6,24 @@ if "%~nx0" == "td-agent.bat" (
   set FLUENT_PACKAGE_TOPDIR=%~dp0
   set TD_AGENT_TOPDIR=%~dp0..\td-agent
 )
+
+@rem Convert path separator from backslash to forwardslash
+setlocal enabledelayedexpansion
+set FLUENT_PACKAGE_TOPDIR="FLUENT_PACKAGE_TOPDIR=!FLUENT_PACKAGE_TOPDIR:\=/!"
+set TD_AGENT_TOPDIR="TD_AGENT_TOPDIR=!TD_AGENT_TOPDIR:\=/!"
+endlocal
+
 set PATH=%FLUENT_PACKAGE_TOPDIR%bin;%PATH%
 set PATH=%FLUENT_PACKAGE_TOPDIR%;%PATH%
-set FLUENT_CONF=%TD_AGENT_TOPDIR%\etc\td-agent\td-agent.conf
-set FLUENT_PLUGIN=%TD_AGENT_TOPDIR%\etc\td-agent\plugin
-set FLUENT_PACKAGE_VERSION=%FLUENT_PACKAGE_TOPDIR%\bin\fluent-package-version.rb
+set FLUENT_CONF=%TD_AGENT_TOPDIR%/etc/td-agent/td-agent.conf
+set FLUENT_PLUGIN=%TD_AGENT_TOPDIR%/etc/td-agent/plugin
+set FLUENT_PACKAGE_VERSION=%FLUENT_PACKAGE_TOPDIR%/bin/fluent-package-version.rb
 for %%p in (%*) do (
     if "%%p"=="--version" (
         ruby "%FLUENT_PACKAGE_VERSION%"
         goto last
     )
 )
-"%FLUENT_PACKAGE_TOPDIR%\bin\fluentd" %*
+"%FLUENT_PACKAGE_TOPDIR%/bin/fluentd" %*
 
 :last

--- a/fluent-package/msi/assets/fluentd.bat
+++ b/fluent-package/msi/assets/fluentd.bat
@@ -7,8 +7,7 @@ if "%~nx0" == "td-agent.bat" (
 
 @rem Convert path separator from backslash to forwardslash
 setlocal enabledelayedexpansion
-set FLUENT_PACKAGE_TOPDIR="FLUENT_PACKAGE_TOPDIR=!FLUENT_PACKAGE_TOPDIR:\=/!"
-endlocal
+set FLUENT_PACKAGE_TOPDIR=FLUENT_PACKAGE_TOPDIR=!FLUENT_PACKAGE_TOPDIR:\=/!
 
 set PATH=%FLUENT_PACKAGE_TOPDIR%bin;%PATH%
 set PATH=%FLUENT_PACKAGE_TOPDIR%;%PATH%
@@ -22,5 +21,6 @@ for %%p in (%*) do (
     )
 )
 "%FLUENT_PACKAGE_TOPDIR%/bin/fluentd" %*
+endlocal
 
 :last

--- a/fluent-package/msi/exclude-files.xslt
+++ b/fluent-package/msi/exclude-files.xslt
@@ -20,7 +20,7 @@
     <!-- Exclude patterns -->
     <xsl:key
         name="conf-search"
-        match="wix:Component[wix:File/@Source = '$(var.ProjectSourceDir)\etc\td-agent\td-agent.conf']"
+        match="wix:Component[wix:File/@Source = '$(var.ProjectSourceDir)\etc\fluent\fluentd.conf']"
         use="@Id" />
     <xsl:template match="*[self::wix:Component or self::wix:ComponentRef][key('conf-search', @Id)]" />
     <xsl:key

--- a/fluent-package/msi/install-test.ps1
+++ b/fluent-package/msi/install-test.ps1
@@ -21,18 +21,18 @@ if ($exitcode -ne 0) {
 }
 Write-Host "Succeeded to uninstall ${name}"
 
-# td-agent.conf should not be removed
-$conf = (Get-ChildItem -Path "c:\\opt" -Filter "td-agent.conf" -Recurse -Name)
-if ($conf -ne "td-agent\etc\td-agent\td-agent.conf") {
-  Write-Host "Failed to find td-agent.conf: <${conf}>"
+# fluentd.conf should not be removed
+$conf = (Get-ChildItem -Path "c:\\opt" -Filter "fluentd.conf" -Recurse -Name)
+if ($conf -ne "fluent\etc\fluent\fluentd.conf") {
+  Write-Host "Failed to find fluentd.conf: <${conf}>"
   [Environment]::Exit(1)
 }
-Write-Host "Succeeded to find td-agent.conf"
+Write-Host "Succeeded to find fluentd.conf"
 
-# td-agent-0.log should not be removed
-$conf = (Get-ChildItem -Path "c:\\opt" -Filter "td-agent-0.log" -Recurse -Name)
-if ($conf -ne "td-agent\td-agent-0.log") {
-  Write-Host "Failed to find td-agent-0.log: <${conf}>"
+# fluentd-0.log should not be removed
+$conf = (Get-ChildItem -Path "c:\\opt" -Filter "fluentd-0.log" -Recurse -Name)
+if ($conf -ne "fluent\fluentd-0.log") {
+  Write-Host "Failed to find fluentd-0.log: <${conf}>"
   [Environment]::Exit(1)
 }
-Write-Host "Succeeded to find td-agent-0.log"
+Write-Host "Succeeded to find fluentd-0.log"

--- a/fluent-package/msi/source.wxs
+++ b/fluent-package/msi/source.wxs
@@ -117,7 +117,7 @@
                      Permanent="no"
                      Part="all"
                      System="yes"
-                     Name="TD_AGENT_TOPDIR"
+                     Name="FLUENT_PACKAGE_TOPDIR"
                      Value="[FLUENTPROJECTLOCATION]"/>
       </Component>
     </DirectoryRef>

--- a/fluent-package/msi/source.wxs
+++ b/fluent-package/msi/source.wxs
@@ -26,8 +26,8 @@
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="WINDOWSVOLUME">
         <Directory Id="OPTLOCATION" Name="opt">
-          <Directory Id="PROJECTLOCATION" Name="td-agent">
-            <Component Id="TDAgentAcl" Guid="b0504030-258a-0139-ba33-7085c2f4281d">
+          <Directory Id="FLUENTPROJECTLOCATION" Name="fluent">
+            <Component Id="FluentAcl" Guid="c2bba014-c3c1-4817-a0c6-096dbd95991d">
               <CreateFolder>
                 <!--
                   The following ACL will be set by Sddl=
@@ -73,13 +73,6 @@
               </CreateFolder>
             </Component>
           </Directory>
-          <Directory Id="FLUENTPROJECTLOCATION" Name="fluent">
-            <Component Id="FluentAcl" Guid="c2bba014-c3c1-4817-a0c6-096dbd95991d">
-              <CreateFolder>
-                <PermissionEx Sddl="D:(A;OICI;0x1200a9;;;BU)(A;OICI;FA;;;BA)(A;OICI;FA;;;S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464)(A;OICI;FA;;;CO)(A;OICI;FA;;;SY)"/>
-              </CreateFolder>
-            </Component>
-          </Directory>
         </Directory>
       </Directory>
       <Directory Id="ProgramMenuFolder">
@@ -87,22 +80,19 @@
       </Directory>
     </Directory>
 
-    <DirectoryRef Id="PROJECTLOCATION">
-      <Directory Id="TDAgentEtcDir" Name="etc">
-        <Directory Id="TDAgentConfDir" Name="td-agent">
-          <Component Id="TDAgentConf"
-                     Guid="534F3E10-B04E-4C17-9DAA-A390068BA8EB"
+    <DirectoryRef Id="FLUENTPROJECTLOCATION">
+      <Directory Id="FluentEtcDir" Name="etc">
+        <Directory Id="FluentConfDir" Name="fluent">
+          <Component Id="FluentConf"
+                     Guid="340cc0a1-83cc-42df-bb66-290264c6c37b"
                      Permanent="yes"
                      NeverOverwrite="yes">
-            <File Id="TDAgentConf"
-                  Name="td-agent.conf"
-                  Source="$(var.ProjectSourceDir)\etc\td-agent\td-agent.conf" />
+            <File Id="FluentConf"
+                  Name="fluentd.conf"
+                  Source="$(var.ProjectSourceDir)\etc\fluent\fluentd.conf" />
           </Component>
         </Directory>
       </Directory>
-    </DirectoryRef>
-
-    <DirectoryRef Id="FLUENTPROJECTLOCATION">
       <Component Id="FluentdBat" Guid="261158e8-7b22-48ff-b7eb-9f8296f30236">
         <File Name="fluentd.bat"
               KeyPath="yes"
@@ -136,8 +126,7 @@
     <Feature Id="ProjectFeature" Title="!(loc.FeatureMainName)" Absent="disallow" AllowAdvertise="no" Level="1" ConfigurableDirectory="OPTLOCATION">
       <ComponentGroupRef Id="ProjectDir" />
       <ComponentRef Id="ApplicationShortcut" />
-      <ComponentRef Id="TDAgentConf" />
-      <ComponentRef Id="TDAgentAcl" />
+      <ComponentRef Id="FluentConf" />
       <ComponentRef Id="FluentAcl" />
       <ComponentRef Id="FluentdBat" />
     </Feature>
@@ -177,7 +166,7 @@
     <Property Id="InstallFluentdWinSvc" Value=" "/>
     <CustomAction Id="SetInstallFluentdWinSvcCommand"
                   Property="InstallFluentdWinSvc"
-                  Value="&quot;[FLUENTPROJECTLOCATION]fluentd.bat&quot; --reg-winsvc i --reg-winsvc-delay-start --reg-winsvc-fluentdopt &quot;-c [PROJECTLOCATION]etc\td-agent\td-agent.conf -o [PROJECTLOCATION]td-agent.log&quot;"/>
+                  Value="&quot;[FLUENTPROJECTLOCATION]fluentd.bat&quot; --reg-winsvc i --reg-winsvc-delay-start --reg-winsvc-fluentdopt &quot;-c [FLUENTPROJECTLOCATION]etc\fluent\fluentd.conf -o [FLUENTPROJECTLOCATION]fluentd.log&quot;"/>
     <CustomAction Id="InstallFluentdWinSvc"
                   BinaryKey="WixCA"
                   DllEntry="WixQuietExec64"

--- a/fluent-package/msi/source.wxs
+++ b/fluent-package/msi/source.wxs
@@ -163,6 +163,18 @@
                   Execute="deferred"
                   Return="check"
                   Impersonate="no" />
+
+    <Property Id="PostMigration" Value=" "/>
+    <CustomAction Id="SetPostMigrationCommand"
+                  Property="PostMigration"
+                  Value="&quot;[FLUENTPROJECTLOCATION]bin\fluent-package-post-migration.bat&quot;"/>
+    <CustomAction Id="PostMigration"
+                  BinaryKey="WixCA"
+                  DllEntry="WixQuietExec64"
+                  Execute="deferred"
+                  Return="check"
+                  Impersonate="no" />
+
     <Property Id="InstallFluentdWinSvc" Value=" "/>
     <CustomAction Id="SetInstallFluentdWinSvcCommand"
                   Property="InstallFluentdWinSvc"
@@ -219,6 +231,10 @@
     <InstallExecuteSequence>
       <Custom Action="SetPostInstallCommand" After="InstallFiles">NOT Installed</Custom>
       <Custom Action="PostInstall" After="SetPostInstallCommand">NOT Installed</Custom>
+
+      <Custom Action="SetPostMigrationCommand" Before="PostMigration">WIX_UPGRADE_DETECTED</Custom>
+      <Custom Action="PostMigration" Before="StartServices">WIX_UPGRADE_DETECTED</Custom>
+
       <Custom Action="SetInstallFluentdWinSvcCommand" After="InstallFiles">NOT Installed</Custom>
       <Custom Action="InstallFluentdWinSvc" After="SetInstallFluentdWinSvcCommand">NOT Installed</Custom>
 

--- a/fluent-package/templates/opt/fluent/share/td-agent.conf.tmpl
+++ b/fluent-package/templates/opt/fluent/share/td-agent.conf.tmpl
@@ -25,7 +25,7 @@
   <buffer>
     @type file
 <% if windows? %>
-    path "#{ENV['TD_AGENT_TOPDIR']}/var/log/<%= compat_package_dir %>/buffer/td"
+    path "#{ENV['FLUENT_PACKAGE_TOPDIR']}/var/log/<%= compat_package_dir %>/buffer/td"
 <% else %>
     path /var/log/<%= package_dir %>/buffer/td
 <% end %>
@@ -34,7 +34,7 @@
   <secondary>
     @type file
 <% if windows? %>
-    path "#{ENV['TD_AGENT_TOPDIR']}/var/log/<%= compat_package_dir %>/failed_records"
+    path "#{ENV['FLUENT_PACKAGE_TOPDIR']}/var/log/<%= compat_package_dir %>/failed_records"
 <% else %>
     path /var/log/<%= package_dir %>/failed_records
 <% end %>


### PR DESCRIPTION
msi: migrate to c:\opt\fluent

Before:

* Configuration c:\opt\td-agent\etc\td-agent\td-agent.conf
* Log files: c:\opt\td-agent

After:

* Move configuration to c:\opt\fluent\etc\fluent\td-agent.conf
* Create symbolic link to c:\opt\fluent\etc\fluent from c:\opt\td-agent\etc\td-agent.
* Overwrite c:\opt\fluent\etc\fluentd.conf with td-agent.conf (when upgrade)
* Migrate to FLUENT_PACKAGE_TOPDIR environment variable.
* Keep old logs as is: