### PR TITLE
deb: test with systemd

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           name: packages-apt-source-${{ matrix.rake-job }}
           path: fluentd-apt-source/apt/repositories
+      # TODO move the following steps to "Test" job
       - name: Check Package Size
         run: |
           fluent-package/apt/pkgsize-test.sh ${{ matrix.rake-job }} amd64
@@ -85,3 +86,27 @@ jobs:
           --volume ${PWD}:/fluentd:ro \
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/binstubs-test.sh
+  test:
+    name: Test
+    needs: build
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distribution:
+          - debian-bullseye
+          - ubuntu-focal
+          - ubuntu-jammy
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/download-artifact@master
+        with:
+          name: packages-${{ matrix.distribution }}
+      - name: Run VM
+        run: vagrant up ${{ matrix.distribution }}
+      - name: Run Test
+        run: |
+          vagrant \
+            ssh ${{ matrix.distribution }} \
+            -- \
+            /vagrant/fluent-package/apt/install-with-systemd-test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .bundle/
+.vagrant/
 /vendor/
 /fluent-package/staging/
 /fluent-package/debian/post*

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,49 +7,26 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   vms = [
     {
-      :id => "debian-buster-amd64",
-      :box => "debian/buster64",
+      :id => "debian-bullseye",
+      :box => "bento/debian-11",
     },
     {
-      :id => "ubuntu-16.04-x86_64",
-      :box => "ubuntu/xenial64",
+      :id => "ubuntu-focal",
+      :box => "bento/ubuntu-20.04",
     },
     {
-      :id => "ubuntu-18.04-x86_64",
-      :box => "ubuntu/bionic64",
-    },
-    {
-      :id => "ubuntu-20.04-x86_64",
-      :box => "ubuntu/focal64",
-    },
-    {
-      :id => "centos-6-x86_64",
-      :box => "centos/6",
-    },
-    {
-      :id => "centos-7-x86_64",
-      :box => "centos/7",
-    },
-    {
-      :id => "centos-8-x86_64",
-      :box => "centos/8",
+      :id => "ubuntu-jammy",
+      :box => "bento/ubuntu-22.04",
     },
   ]
 
-  vm_id_prefix = ENV["BOX_ID_PREFIX"]
   n_cpus = ENV["BOX_N_CPUS"]&.to_i || 2
   memory = ENV["BOX_MEMORY"]&.to_i || 2048
   vms.each_with_index do |vm, idx|
     id = vm[:id]
     box = vm[:box] || id
-    id = "#{vm_id_prefix}#{id}" if vm_id_prefix
     config.vm.define(id) do |node|
       node.vm.box = box
-      node.vm.box_url = vm[:box_url]
-      node.vm.network "private_network", ip: "192.168.35.#{100 + idx}"
-      node.vm.synced_folder ".", "/vagrant", type: "nfs",
-                            linux__nfs_options: ['rw','no_subtree_check','all_squash','async']
-
       node.vm.provider("virtualbox") do |virtual_box|
         virtual_box.cpus = n_cpus if n_cpus
         virtual_box.memory = memory if memory

--- a/fluent-package/apt/install-with-systemd-test.sh
+++ b/fluent-package/apt/install-with-systemd-test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -exu
+
+sudo apt update
+sudo apt install -V -y lsb-release
+
+. $(dirname $0)/commonvar.sh
+
+sudo apt install -V -y \
+  /vagrant/${distribution}/pool/${code_name}/${channel}/*/*/*_${architecture}.deb
+
+systemctl status fluentd
+
+sudo apt remove -y fluent-package
+
+! systemctl status fluentd


### PR DESCRIPTION
This adds a test for deb packages to confirm the package works correctly with systemd.

There are still some points that need more refactoring, but it is better to have such a test as soon as possible.

The current `Vagrantfile` is just for manual operation and is not used recently, so I fixed it entirely for CI.
