### PR TITLE
Migrate path of logrotate.d configration

### DIFF
--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -483,7 +483,7 @@ class BuildTask
                     ["etc/#{PACKAGE_DIR}/#{SERVICE_NAME}.conf"]
                   end
         configs.concat([
-          "etc/logrotate.d/#{COMPAT_SERVICE_NAME}",
+          "etc/logrotate.d/#{SERVICE_NAME}",
           "opt/#{PACKAGE_DIR}/share/#{COMPAT_SERVICE_NAME}-ruby.conf",
           "opt/#{PACKAGE_DIR}/share/#{COMPAT_SERVICE_NAME}.conf.tmpl"
         ]) unless windows? || macos?

--- a/fluent-package/apt/install-test.sh
+++ b/fluent-package/apt/install-test.sh
@@ -80,19 +80,21 @@ if [ ! -h /etc/td-agent ]; then
     exit 1
 fi
 
+# Note: As td-agent and _fluentd use same UID/GID,
+# it is regarded as preceding name (td-agent)
 owner=$(stat --format "%U/%G" /etc/fluent)
-if [ "$owner" != "_fluentd/_fluentd" ]; then
-    echo "/etc/fluent must be owned by _fluentd/_fluentd"
+if [ "$owner" != "td-agent/td-agent" ]; then
+    echo "/etc/fluent must be owned by td-agent/td-agent"
     exit 1
 fi
 owner=$(stat --format "%U/%G" /var/log/fluent)
-if [ "$owner" != "_fluentd/_fluentd" ]; then
-    echo "/var/log/fluent must be owned by _fluentd/_fluentd"
+if [ "$owner" != "td-agent/td-agent" ]; then
+    echo "/var/log/fluent must be owned by td-agent/td-agent"
     exit 1
 fi
 owner=$(stat --format "%U/%G" /var/run/fluent)
-if [ "$owner" != "_fluentd/_fluentd" ]; then
-    echo "/var/run/fluent must be owned by _fluentd/_fluentd"
+if [ "$owner" != "td-agent/td-agent" ]; then
+    echo "/var/run/fluent must be owned by td-agent/td-agent"
     exit 1
 fi
 

--- a/fluent-package/apt/install-test.sh
+++ b/fluent-package/apt/install-test.sh
@@ -51,13 +51,13 @@ apt install -V -y \
   ${repositories_dir}/${distribution}/pool/${code_name}/${channel}/*/*/*_${architecture}.deb
 
 
-if getent passwd td-agent >/dev/null; then
-    echo "td-agent user must be removed"
+if ! getent passwd td-agent >/dev/null; then
+    echo "td-agent user must exist"
     exit 1
 fi
 
-if getent group td-agent >/dev/null; then
-    echo "td-agent group must be removed"
+if ! getent group td-agent >/dev/null; then
+    echo "td-agent group must exist"
     exit 1
 fi
 

--- a/fluent-package/templates/etc/logrotate.d/fluentd
+++ b/fluent-package/templates/etc/logrotate.d/fluentd
@@ -1,4 +1,4 @@
-/var/log/<%= compat_package_dir %>/<%= service_name %>.log {
+/var/log/<%= package_dir %>/<%= service_name %>.log {
   daily
   rotate 30
   compress

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postinst
@@ -107,6 +107,10 @@ migration_from_v4_main_process() {
             echo "Keep logging to <%= compat_service_name %>.log ..."
             sed -i"" /etc/default/<%= service_name %> -e "/TD_AGENT_LOG_FILE/c TD_AGENT_LOG_FILE=/var/log/<%= package_dir %>/<%= compat_service_name %>.log"
         fi
+        if [ -f /etc/logrotate.d/<%= compat_service_name %> ]; then
+            echo "Migrating path of pid ..."
+            sed -i"" /etc/logrotate.d/<%= compat_service_name %> -e "s,/var/run/<%= compat_package_dir %>/<%= compat_service_name %>.pid,/var/run/<%= package_dir %>/<%= service_name %>.pid,"
+        fi
     fi
 }
 

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postinst
@@ -12,11 +12,16 @@ add_system_user() {
 	    # With underscore prefix, need to disable NAME_REGEX restriction
 	    adduser --group --system --force-badname --home /var/lib/<%= package_dir %> _<%= service_name %>
 	else
+	    # When upgrading from v4, keep <%= compat_service_name %> user/group and 
+	    # create _<%= service_name %> user/group with same uid/gid for compatibility easily.
 	    if getent group <%= compat_service_name %> >/dev/null; then
-		groupmod --new-name _<%= service_name %> <%= compat_service_name %>
+		TD_GID=$(getent group <%= compat_service_name %> | cut -d':' -f3)
+		groupadd -g $TD_GID -o _<%= service_name %>
 	    fi
 	    if getent passwd <%= compat_service_name %> >/dev/null; then
-		usermod --login _<%= service_name %> <%= compat_service_name %>
+		TD_UID=$(id --user <%= compat_service_name %>)
+		TD_GID=$(getent group <%= compat_service_name %> | cut -d':' -f3)
+		useradd -u $TD_UID -g $TD_GID -o _<%= service_name %>
 	    fi
 	fi
     fi

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postrm
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postrm
@@ -31,7 +31,12 @@ if [ "$1" = "purge" ]; then
 	    fi
 	done
 
-	getent passwd _<%= service_name %> && userdel -r _<%= service_name %>
+	if getent passwd _<%= service_name %>; then
+	    userdel --remove --force _<%= service_name %>
+	fi
+	if getent passwd <%= compat_service_name %>; then
+	    userdel --remove --force <%= compat_service_name %>
+	fi
 fi
 
 #DEBHELPER#

--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -146,8 +146,9 @@ if ! getent group @COMPAT_SERVICE_NAME@ >/dev/null; then
     fi
 else
     if ! getent group @SERVICE_NAME@ >/dev/null; then
-       echo "Migrate group @COMPAT_SERVICE_NAME@ to @SERVICE_NAME@..."
-       /usr/sbin/groupmod --new-name @SERVICE_NAME@ @COMPAT_SERVICE_NAME@
+        echo "Add group @SERVICE_NAME@ (same GID with @COMPAT_SERVICE_NAME@)..."
+        TD_GID=$(getent group @COMPAT_SERVICE_NAME@ | cut -d':' -f3)
+        /usr/sbin/groupadd -g $TD_GID -o @SERVICE_NAME@
     fi
 fi
 if ! getent passwd @COMPAT_SERVICE_NAME@ >/dev/null; then
@@ -160,12 +161,10 @@ if ! getent passwd @COMPAT_SERVICE_NAME@ >/dev/null; then
     fi
 else
     if ! getent passwd @SERVICE_NAME@ >/dev/null; then
-       systemctl is-active @COMPAT_SERVICE_NAME@
-       if [ $? -ne 0 ]; then
-           # As service is down, renaming user here.
-	   echo "Migrate user @COMPAT_SERVICE_NAME@ to @SERVICE_NAME@..."
-           /usr/sbin/usermod --login @SERVICE_NAME@ @COMPAT_SERVICE_NAME@
-       fi
+        echo "Add user @SERVICE_NAME@ (same UID/GID with @COMPAT_SERVICE_NAME@)..."
+        TD_UID=$(id --user @COMPAT_SERVICE_NAME@)
+        TD_GID=$(getent group @COMPAT_SERVICE_NAME@ | cut -d':' -f3)
+        /usr/sbin/useradd -u $TD_UID -g $TD_GID -o @SERVICE_NAME@
     fi
 fi
 
@@ -201,7 +200,9 @@ if [ $1 -eq 1 ]; then
         # stage, mismatch of user/group configuration cause
         # restarting service failure.)
         systemctl stop @COMPAT_SERVICE_NAME@.service
-        /usr/sbin/usermod --login @SERVICE_NAME@ @COMPAT_SERVICE_NAME@
+        TD_UID=$(id --user @COMPAT_SERVICE_NAME@)
+        TD_GID=$(getent group @COMPAT_SERVICE_NAME@ | cut -d':' -f3)
+        /usr/sbin/useradd -u $TD_UID -g $TD_GID -o @SERVICE_NAME@
       fi
     fi
     # Want to restart with new user/group here,
@@ -271,6 +272,14 @@ if [ $1 -eq 0 ]; then
        echo "Removing @SERVICE_NAME@ group..."
        /usr/sbin/groupdel @SERVICE_NAME@
    fi
+   if getent passwd @COMPAT_SERVICE_NAME@ >/dev/null; then
+       echo "Removing @COMPAT_SERVICE_NAME@ user..."
+       /usr/sbin/userdel --remove @COMPAT_SERVICE_NAME@
+   fi
+   if getent group @COMPAT_SERVICE_NAME@ >/dev/null; then
+       echo "Removing @COMPAT_SERVICE_NAME@ group..."
+       /usr/sbin/groupdel @COMPAT_SERVICE_NAME@
+   fi
 fi
 
 %posttrans
@@ -320,7 +329,7 @@ fi
 %{_mandir}/man1/fluent*
 %config(noreplace) %{_sysconfdir}/sysconfig/@SERVICE_NAME@
 %config(noreplace) %{_sysconfdir}/@PACKAGE_DIR@/@SERVICE_NAME@.conf
-%config(noreplace) %{_sysconfdir}/logrotate.d/@COMPAT_SERVICE_NAME@
+%config(noreplace) %{_sysconfdir}/logrotate.d/@SERVICE_NAME@
 %attr(0755,fluentd,fluentd) %dir %{_localstatedir}/log/@PACKAGE_DIR@
 %attr(0755,fluentd,fluentd) %dir %{_localstatedir}/log/@PACKAGE_DIR@/buffer
 %attr(0755,fluentd,fluentd) %dir %{_sysconfdir}/@PACKAGE_DIR@

--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -300,6 +300,10 @@ if [ -f %{v4migration} ]; then
     echo "Provides /var/log/td-agent symlink for backward compatibility"
     ln -sf /var/log/@PACKAGE_DIR@ /var/log/@COMPAT_PACKAGE_DIR@
   fi
+  if [ -f /etc/logrotate.d/@COMPAT_SERVICE_NAME@ ]; then
+     echo "Migrating path of pid ..."
+     sed -i"" /etc/logrotate.d/@COMPAT_SERVICE_NAME@ -e "s,/var/run/@COMPAT_PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.pid,/var/run/@PACKAGE_DIR@/@SERVICE_NAME@.pid,"
+  fi
   rm -f %{v4migration}
   if [ -f %{v4migration_with_restart} ]; then
     # When upgrading from v4, td-agent.service will be removed

--- a/fluent-package/yum/install-test.sh
+++ b/fluent-package/yum/install-test.sh
@@ -116,12 +116,12 @@ EOF
            ${repositories_dir}/${distribution}/${DISTRIBUTION_VERSION}/x86_64/Packages/*.rpm
 
 
-    if getent passwd td-agent >/dev/null; then
-        echo "td-agent user must be removed"
+    if ! getent passwd td-agent >/dev/null; then
+        echo "td-agent user must exist"
         exit 1
     fi
-    if getent group td-agent >/dev/null; then
-        echo "td-agent group must be removed"
+    if ! getent group td-agent >/dev/null; then
+        echo "td-agent group must exist"
         exit 1
     fi
     if ! getent passwd fluentd >/dev/null; then


### PR DESCRIPTION
    Before: /etc/logrotate.d/td-agent
      If td-agent user/group exists, renaming td-agent
      to fluent user/group then rewrite logrotate.d configuration.
      But, it may fail if user modify that configuration unexpected
      way.

    After: /etc/logrotate.d/fluentd

      If td-agent user/group exists (e.g upgrading from v4), create
      _fluent user/group as same uid/gid. If not, just create new _fluent
      user/group (no td-agent user/group).

      This approach make easy to migrate /etc/logrotate.d/td-agent
      configuration file without modification.

    Additionally, rewrite /etc/logrotate.d/td-agent path of pid
    because the pid file will be dynamically created/destroyed.
