### PR TITLE
Update target distributions

### DIFF
--- a/fluent-package/convert-artifacts-layout.sh
+++ b/fluent-package/convert-artifacts-layout.sh
@@ -15,9 +15,9 @@ case $1 in
     apt|deb)
 	REPOSITORY_TYPE=apt
 	REPOSITORY_PATH=$TD_AGENT_DIR/$REPOSITORY_TYPE/repositories
-	for d in buster bullseye bionic focal jammy; do
+	for d in bullseye bookworm focal jammy; do
 	    case $d in
-		buster|bullseye)
+		bullseye|bookworm)
 		    # e.g. mapping debian/pool/buster/main/t/td-agent/ => 5/debian/buster/pool/contrib/t/td-agent
 		    #      mapping debian/pool/buster/main/f/fluent-package/ => 5/debian/buster/pool/contrib/f/fluent-package
 		    mkdir -p $ARTIFACTS_DIR/5/debian/$d/pool/contrib/t/td-agent
@@ -25,7 +25,7 @@ case $1 in
 		    find $REPOSITORY_PATH/debian/pool/$d -name 'td-agent*.deb' -not -name '*dbgsym*' -exec cp {} $ARTIFACTS_DIR/5/debian/$d/pool/contrib/t/td-agent \;
 		    find $REPOSITORY_PATH/debian/pool/$d -name 'fluent-package*.deb' -not -name '*dbgsym*' -exec cp {} $ARTIFACTS_DIR/5/debian/$d/pool/contrib/f/fluent-package \;
 		    ;;
-		bionic|focal|jammy)
+		focal|jammy)
 		    # e.g. mapping ubuntu/pool/.../main/t/td-agent/ => 5/ubuntu/.../pool/contrib/t/td-agent
 		    #      mapping ubuntu/pool/.../main/f/fluent-package/ => 5/ubuntu/.../pool/contrib/f/fluent-package
 		    mkdir -p $ARTIFACTS_DIR/5/ubuntu/$d/pool/contrib/t/td-agent

--- a/fluent-package/manage-fluent-repositories.sh
+++ b/fluent-package/manage-fluent-repositories.sh
@@ -70,7 +70,7 @@ case $COMMAND in
 	   DRYRUN_OPTION=""
 	fi
 	for target in $TARGETS; do
-	    command="aws s3 sync $DRYRUN_OPTION --delete $FLUENT_RELEASE_DIR/4/$target s3://packages.treasuredata.com/4/$target --profile $FLUENT_RELEASE_PROFILE"
+	    command="aws s3 sync $DRYRUN_OPTION --delete $FLUENT_RELEASE_DIR/5/$target s3://packages.treasuredata.com/5/$target --profile $FLUENT_RELEASE_PROFILE"
 	    echo $command
 	    $command
 	done

--- a/fluent-package/manage-fluent-repositories.sh
+++ b/fluent-package/manage-fluent-repositories.sh
@@ -101,10 +101,10 @@ EOF
 	echo "Ready to type signing passphrase? (process starts in 10 seconds, Ctrl+C to abort)"
 	sleep 10
 	export GPG_TTY=$(tty)
-	for d in buster bullseye bionic focal jammy; do
+	for d in bullseye bookworm focal jammy; do
 	    aptly -config="$aptly_conf" repo create -distribution=$d -component=contrib fluent-package5-$d
 	    case $d in
-		buster|bullseye)
+		bullseye|bookworm)
 		    aptly -config="$aptly_conf" repo add fluent-package5-$d $FLUENT_RELEASE_DIR/5/debian/$d/
 		    aptly -config="$aptly_conf" snapshot create fluent-package5-$d-${FLUENT_PACKAGE_VERSION}-1 from repo fluent-package5-$d
 		    # publish snapshot with prefix, InRelease looks like (e.g. bullseye):
@@ -114,7 +114,7 @@ EOF
 		    # Place generated files, package files themselves are already in there
 		    tar cf - --exclude="td-agent_*.deb" --exclude="fluent-package_*.deb" -C "$aptly_rootdir/public" $d | tar xvf - -C $FLUENT_RELEASE_DIR/5/debian/
 		    ;;
-		bionic|focal|jammy)
+		focal|jammy)
 		    aptly -config="$aptly_conf" repo add fluent-package5-$d $FLUENT_RELEASE_DIR/5/ubuntu/$d/
 		    aptly -config="$aptly_conf" snapshot create fluent-package5-$d-${FLUENT_PACKAGE_VERSION}-1 from repo fluent-package5-$d
 		    # publish snapshot with prefix, InRelease looks like (e.g. focal):


### PR DESCRIPTION
Both of distributions are already removed from GitHub Actions.

* buster: EOL (2022-09-10), though LTS is still alive (2024-06-30)
* bionic: End of Standard Support (June 2023), EOL April 2028

See
    https://wiki.debian.org/DebianReleases
    https://wiki.ubuntu.com/Releases
