### PR TITLE
deb: ensure to reload unit file before restarting

### DIFF
--- a/fluent-package/apt/systemd-test/install-newly.sh
+++ b/fluent-package/apt/systemd-test/install-newly.sh
@@ -11,4 +11,13 @@ systemctl status --no-pager fluentd
 
 sudo apt remove -y fluent-package
 
+if [ ! -e /etc/systemd/system/td-agent.service ]; then
+    echo "td-agent.service must exist"
+    exit 1
+fi
+if [ ! -e /etc/systemd/system/fluentd.service ]; then
+    echo "fluentd.service must exist"
+    exit 1
+fi
+
 ! systemctl status fluentd

--- a/fluent-package/apt/systemd-test/install-newly.sh
+++ b/fluent-package/apt/systemd-test/install-newly.sh
@@ -11,13 +11,5 @@ systemctl status --no-pager fluentd
 
 sudo apt remove -y fluent-package
 
-if [ ! -e /etc/systemd/system/td-agent.service ]; then
-    echo "td-agent.service must exist"
-    exit 1
-fi
-if [ ! -e /etc/systemd/system/fluentd.service ]; then
-    echo "fluentd.service must exist"
-    exit 1
-fi
-
+test -h /etc/systemd/system/fluentd.service
 ! systemctl status fluentd

--- a/fluent-package/apt/systemd-test/update-from-v4.sh
+++ b/fluent-package/apt/systemd-test/update-from-v4.sh
@@ -27,8 +27,6 @@ sudo apt install -V -y \
 systemctl status --wait --no-pager fluentd
 ! systemctl status --wait --no-pager td-agent
 
-# TODO: There are some tests being commented out. They will be supported by future fixes.
-
 # Test: restoring td-agent service alias
 sudo systemctl unmask td-agent
 sudo systemctl enable --now fluentd

--- a/fluent-package/apt/systemd-test/update-from-v4.sh
+++ b/fluent-package/apt/systemd-test/update-from-v4.sh
@@ -55,3 +55,6 @@ test $(eval $env_vars && echo $FLUENT_PACKAGE_LOG_FILE) = "/var/log/fluent/td-ag
 sudo apt remove -y fluent-package
 ! systemctl status --wait --no-pager td-agent
 ! systemctl status --wait --no-pager fluentd
+
+test -h /etc/systemd/system/td-agent.service
+test -h /etc/systemd/system/fluentd.service

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postinst
@@ -128,6 +128,7 @@ migration_from_v4_post_process() {
     fi
     if [ "$v4migration_with_restart" = "y" ]; then
         if [ -n "$(command -v systemctl)" ]; then
+            systemctl daemon-reload
             systemctl restart <%= service_name %>
         fi
     fi


### PR DESCRIPTION
It fixes the following case:

      Failed to restart fluentd.service: Unit fluentd.service not found.
      dpkg: error processing package fluent-package (--configure):
       installed fluent-package package post-installation script subprocess returned error exit status 5
