### PR TITLE
deb: refine fluentd-apt-source 

### DIFF
--- a/fluent-package/debian/control
+++ b/fluent-package/debian/control
@@ -25,9 +25,10 @@ Pre-Depends: adduser
 Depends:
   ${misc:Depends},
   ${shlibs:Depends},
-Description: Treasure Agent: A data collector for Treasure Data
- Treasure Agent is all in one package which contains Fluentd and
- related gem packages.
+Description: All in one package of Fluentd
+ Fluent Package is all in one package which contains Fluentd and
+ related gem packages. This package was formerly known as
+ Treasure Agent.
  .
  It is installable alongside with system's gem packages separately.
 

--- a/fluentd-apt-source/debian/control
+++ b/fluentd-apt-source/debian/control
@@ -16,6 +16,6 @@ Depends:
   ${misc:Depends},
   apt-transport-https,
   gnupg
-Description: GnuPG archive key and APT source of the Treasure Agent archive
- The Treasure Agent project digitally signs its Release files. This
- package contains the archive key used for that.
+Description: GnuPG archive key and APT source of the Fluent Package archive
+ The Fluentd project digitally signs its Release files. This package
+ contains the archive key used for that.


### PR DESCRIPTION
* Update description fluentd-apt-source
* Drop dependency to deprecated transitional apt-transport-https.
  https support has been moved into the apt package.

