### PR TITLE
msi: Disable auto start after install

### DIFF
--- a/fluent-package/msi/install-test.ps1
+++ b/fluent-package/msi/install-test.ps1
@@ -4,6 +4,7 @@ $msi = ((Get-Item "C:\\fluentd\\fluent-package\\msi\\repositories\\fluent-packag
 Write-Host "Installing ${msi} ..."
 
 Start-Process msiexec -ArgumentList "/i", $msi, "/quiet" -Wait -NoNewWindow
+Start-Service fluentdwinsvc
 
 $ENV:PATH="C:\\opt\\fluent\\bin;" + $ENV:PATH
 $ENV:PATH="C:\\opt\\fluent;" + $ENV:PATH

--- a/fluent-package/msi/serverspec-test.ps1
+++ b/fluent-package/msi/serverspec-test.ps1
@@ -4,6 +4,7 @@ $msi = ((Get-Item "C:\\fluentd\\fluent-package\\msi\\repositories\\fluent-packag
 Write-Host "Installing ${msi} ..."
 
 Start-Process msiexec -ArgumentList "/i", $msi, "/quiet" -Wait -NoNewWindow
+Start-Service fluentdwinsvc
 
 $ENV:PATH="C:\\opt\\fluent\\bin;" + $ENV:PATH
 $ENV:PATH="C:\\opt\\fluent;" + $ENV:PATH

--- a/fluent-package/msi/source.wxs
+++ b/fluent-package/msi/source.wxs
@@ -177,7 +177,7 @@
     <Property Id="InstallFluentdWinSvc" Value=" "/>
     <CustomAction Id="SetInstallFluentdWinSvcCommand"
                   Property="InstallFluentdWinSvc"
-                  Value="&quot;[FLUENTPROJECTLOCATION]fluentd.bat&quot; --reg-winsvc i --reg-winsvc-delay-start --reg-winsvc-auto-start --reg-winsvc-fluentdopt &quot;-c [PROJECTLOCATION]etc\td-agent\td-agent.conf -o [PROJECTLOCATION]td-agent.log&quot;"/>
+                  Value="&quot;[FLUENTPROJECTLOCATION]fluentd.bat&quot; --reg-winsvc i --reg-winsvc-delay-start --reg-winsvc-fluentdopt &quot;-c [PROJECTLOCATION]etc\td-agent\td-agent.conf -o [PROJECTLOCATION]td-agent.log&quot;"/>
     <CustomAction Id="InstallFluentdWinSvc"
                   BinaryKey="WixCA"
                   DllEntry="WixQuietExec64"


### PR DESCRIPTION
Many users would be happier if it didn't start automatically:

* No one would be happy to start Fluentd with the default settings.
* It opens some ports by default. It is undesirable from a security point of view.

In addition, we should make sure that the service starts after all install actions are completed.
To achieve it, this is preferable for now.
