### PR TITLE
Remove td-agent-ruby.conf

### DIFF
--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -482,7 +482,6 @@ class BuildTask
         configs = [fluentd_conf]
         configs.concat([
           "etc/logrotate.d/#{SERVICE_NAME}",
-          "opt/#{PACKAGE_DIR}/share/#{COMPAT_SERVICE_NAME}-ruby.conf",
           fluentd_conf_default,
         ]) unless windows? || macos?
         configs.each do |config|

--- a/fluent-package/apt/install-test.sh
+++ b/fluent-package/apt/install-test.sh
@@ -13,13 +13,11 @@ apt install -V -y \
 td-agent --version
 test -e /etc/logrotate.d/fluentd
 test -e /opt/fluent/share/td-agent.conf.tmpl
-test -e /opt/fluent/share/td-agent-ruby.conf
 
 apt remove -y fluent-package
 
 test -e /etc/logrotate.d/fluentd
 ! test -e /opt/fluent/share/td-agent.conf.tmpl
-! test -e /opt/fluent/share/td-agent-ruby.conf
 
 if ! getent passwd _fluentd >/dev/null; then
     echo "_fluentd user must be kept"

--- a/fluent-package/templates/opt/fluent/share/td-agent-ruby.conf
+++ b/fluent-package/templates/opt/fluent/share/td-agent-ruby.conf
@@ -1,1 +1,0 @@
--b /opt/<%= package_dir %>/bin/ruby

--- a/fluent-package/yum/install-test.sh
+++ b/fluent-package/yum/install-test.sh
@@ -65,14 +65,12 @@ ${DNF} install -y \
 td-agent --version
 test -e /etc/logrotate.d/fluentd
 test -e /opt/fluent/share/td-agent.conf.tmpl
-test -e /opt/fluent/share/td-agent-ruby.conf
 
 echo "UNINSTALL TEST"
 ${DNF} remove -y fluent-package
 
 ! test -e /etc/logrotate.d/fluentd
 ! test -e /opt/fluent/share/td-agent.conf.tmpl
-! test -e /opt/fluent/share/td-agent-ruby.conf
 
 for conf_path in /etc/td-agent/td-agent.conf /etc/fluent/fluentd.conf; do
     if [ -e $conf_path ]; then


### PR DESCRIPTION
It was used for prelink.
We don't use it since 66116d55088b4c055579d2ea3b326b48f0cc4d24.