### PR TITLE
Update uri gem to suppress CVE-2023-36617

### DIFF
--- a/fluent-package/Gemfile
+++ b/fluent-package/Gemfile
@@ -22,6 +22,9 @@ gem "async", "1.31.0"
 gem "async-http", "0.60.2"
 gem "webrick", "1.8.1"
 
+# CVE-2023-36617: should be removed after we update Ruby to 3.2.3 or later
+gem "uri", "~> 0.12.2"
+
 if ENV["INSTALL_GEM_FROM_LOCAL_REPO"]
   # During build process, pre-built fluentd gem will be installed
   # from this local repository, this way is used to avoid embedding full-path

--- a/fluent-package/Gemfile.lock
+++ b/fluent-package/Gemfile.lock
@@ -243,6 +243,7 @@ GEM
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2023.3)
       tzinfo (>= 1.0.0)
+    uri (0.12.2)
     webhdfs (0.10.2)
       addressable
     webrick (1.8.1)
@@ -322,6 +323,7 @@ DEPENDENCIES
   td-client (= 1.0.8)
   tzinfo (= 2.0.6)
   tzinfo-data (= 1.2023.3)
+  uri (~> 0.12.2)
   webhdfs (= 0.10.2)
   webrick (= 1.8.1)
   win32-event (= 0.6.3)


### PR DESCRIPTION
ref: https://www.ruby-lang.org/en/news/2023/06/29/redos-in-uri-CVE-2023-36617/