### PR TITLE
rpm: tweak tests

### DIFF
--- a/fluent-package/yum/install-test.sh
+++ b/fluent-package/yum/install-test.sh
@@ -71,30 +71,23 @@ test -e /opt/fluent/share/fluentd.conf
 echo "UNINSTALL TEST"
 ${DNF} remove -y fluent-package
 
-! test -e /etc/logrotate.d/fluentd
-! test -e /opt/fluent/share/fluentd.conf
+(! test -e /etc/logrotate.d/fluentd)
+(! test -e /opt/fluent/share/fluentd.conf)
 (! test -h /usr/sbin/td-agent)
 (! test -h /usr/sbin/td-agent-gem)
 
 for conf_path in /etc/td-agent/td-agent.conf /etc/fluent/fluentd.conf; do
     if [ -e $conf_path ]; then
-	echo "$conf_path must be removed"
-	exit 1
+        echo "$conf_path must be removed"
+        exit 1
     fi
 done
 
-if getent passwd fluentd >/dev/null; then
-    echo "fluentd user must be removed"
-    exit 1
-fi
-
-if getent group fluentd >/dev/null; then
-    echo "fluentd group must be removed"
-    exit 1
-fi
+(! getent passwd fluentd >/dev/null)
+(! getent group fluentd >/dev/null)
 
 if [ $ENABLE_UPGRADE_TEST -eq 1 ]; then
-    echo "UPGRADE TEST from v3"
+    echo "UPGRADE TEST from v4"
     rpm --import https://packages.treasuredata.com/GPG-KEY-td-agent
     case ${distribution} in
         amazon)
@@ -124,41 +117,18 @@ EOF
     ${DNF} install -y \
            ${repositories_dir}/${distribution}/${DISTRIBUTION_VERSION}/x86_64/Packages/*.rpm
 
-
-    if ! getent passwd td-agent >/dev/null; then
-        echo "td-agent user must exist"
-        exit 1
-    fi
-    if ! getent group td-agent >/dev/null; then
-        echo "td-agent group must exist"
-        exit 1
-    fi
-    if ! getent passwd fluentd >/dev/null; then
-        echo "fluentd user must exist"
-        exit 1
-    fi
-    if ! getent group fluentd >/dev/null; then
-        echo "fluentd group must exist"
-        exit 1
-    fi
-    if [ ! -h /var/log/td-agent ]; then
-        echo "/var/log/td-agent must be symlink"
-        exit 1
-    fi
-    if [ ! -h /etc/td-agent ]; then
-        echo "/etc/td-agent must be symlink"
-        exit 1
-    fi
+    getent passwd td-agent >/dev/null
+    getent group td-agent >/dev/null
+    getent passwd fluentd >/dev/null
+    getent group fluentd >/dev/null
+    test -h /var/log/td-agent
+    test -h /etc/td-agent
+    test -h /usr/sbin/td-agent
+    test -h /usr/sbin/td-agent-gem
 
     homedir=$(getent passwd fluentd | cut -d: -f6)
-    if [ "$homedir" != "/var/lib/fluent" ]; then
-	echo "fluentd must use /var/lib/fluent as home directory"
-	exit 1
-    fi
+    test "$homedir" = "/var/lib/fluent"
 
     loginshell=$(getent passwd fluentd | cut -d: -f7)
-    if [ "$loginshell" != "/sbin/nologin" ]; then
-	echo "fluentd must use nologin"
-	exit 1
-    fi
+    test "$loginshell" = "/sbin/nologin"
 fi

--- a/fluent-package/yum/systemd-test/update-from-v4.sh
+++ b/fluent-package/yum/systemd-test/update-from-v4.sh
@@ -39,8 +39,8 @@ sudo $DNF install -y \
     /vagrant/${distribution}/${DISTRIBUTION_VERSION}/x86_64/Packages/fluent-package-[0-9]*.rpm
 
 # Test: service status
+systemctl status --no-pager fluentd # Migration process starts the service automatically
 sudo systemctl enable --now fluentd
-systemctl status --no-pager fluentd
 systemctl status --no-pager td-agent
 
 # Test: config migration
@@ -50,6 +50,10 @@ test -e /etc/td-agent/td-agent.conf
 # Test: log file migration
 test -L /var/log/td-agent
 test -e /var/log/td-agent/td-agent.log
+
+# Test: bin file migration
+test -h /usr/sbin/td-agent
+test -h /usr/sbin/td-agent-gem
 
 # Test: environmental variables
 pid=$(eval $(systemctl show fluentd --property=MainPID) && echo $MainPID)

--- a/fluent-package/yum/systemd-test/update-to-next-version.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version.sh
@@ -39,6 +39,8 @@ systemctl status --no-pager fluentd
 (! test -e /etc/fluent/td-agent.conf)
 (! test -e /var/log/td-agent)
 (! test -e /var/log/fluent/td-agent.log)
+(! test -h /usr/sbin/td-agent)
+(! test -h /usr/sbin/td-agent-gem)
 
 # Test: environmental variables
 pid=$(eval $(systemctl show fluentd --property=MainPID) && echo $MainPID)


### PR DESCRIPTION
* Fix inverted tests using `!`, which has always succeeded.
* Simplifies.
* Add some test cases.