### PR TITLE
rpm: fix logrotate config migration

### DIFF
--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -30,6 +30,7 @@
 %undefine __brp_mangle_shebangs
 %define v4migration /tmp/@PACKAGE_DIR@/.v4migration
 %define v4migration_with_restart /tmp/@PACKAGE_DIR@/.v4migration_with_restart
+%define v4migration_old_rotate_config_saved /tmp/@PACKAGE_DIR@/.old_rotate_config
 
 %global __provides_exclude_from ^/opt/%{name}/.*\\.so.*
 %global __requires_exclude libjemalloc.*|libruby.*|/opt/%{name}/.*
@@ -224,6 +225,10 @@ if [ $1 -eq 1 ]; then
     if [ -f /var/log/@PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.log ]; then
       echo "Keep logging to @COMPAT_SERVICE_NAME@.log ..."
       %{__sed} -i"" %{_sysconfdir}/sysconfig/@SERVICE_NAME@ -e "/FLUENT_PACKAGE_LOG_FILE/c FLUENT_PACKAGE_LOG_FILE=/var/log/@PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.log"
+      # Backup the config since RPM removes the file if it is not edited.
+      if [ -f /etc/logrotate.d/@COMPAT_SERVICE_NAME@ ]; then
+        cp /etc/logrotate.d/@COMPAT_SERVICE_NAME@ %{v4migration_old_rotate_config_saved}
+      fi
     fi
   fi
 fi
@@ -301,8 +306,20 @@ if [ -f %{v4migration} ]; then
     ln -sf /var/log/@PACKAGE_DIR@ /var/log/@COMPAT_PACKAGE_DIR@
   fi
   if [ -f /etc/logrotate.d/@COMPAT_SERVICE_NAME@ ]; then
-     echo "Migrating path of pid ..."
-     sed -i"" /etc/logrotate.d/@COMPAT_SERVICE_NAME@ -e "s,/var/run/@COMPAT_PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.pid,/var/run/@PACKAGE_DIR@/@SERVICE_NAME@.pid,"
+    # Perhaps this case is impossible.
+    echo "Found /etc/logrotate.d/@COMPAT_SERVICE_NAME@"
+  elif [ -f /etc/logrotate.d/@COMPAT_SERVICE_NAME@.rpmsave ]; then
+    # When the file is edited:
+    echo "Restores logrotate config from rpmsave"
+    mv -f /etc/logrotate.d/@COMPAT_SERVICE_NAME@.rpmsave /etc/logrotate.d/@COMPAT_SERVICE_NAME@
+  elif [ -f %{v4migration_old_rotate_config_saved} ]; then
+    # When the file is not edited:
+    echo "Restores logrotate config from backup"
+    mv -f %{v4migration_old_rotate_config_saved} /etc/logrotate.d/@COMPAT_SERVICE_NAME@
+  fi
+  if [ -f /etc/logrotate.d/@COMPAT_SERVICE_NAME@ ]; then
+    echo "Migrating path of pid in the logrotate config /etc/logrotate.d/@COMPAT_SERVICE_NAME@ ..."
+    %{__sed} -i"" /etc/logrotate.d/@COMPAT_SERVICE_NAME@ -e "s,/var/run/@COMPAT_PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.pid,/var/run/@PACKAGE_DIR@/@SERVICE_NAME@.pid,"
   fi
   rm -f %{v4migration}
   if [ -f %{v4migration_with_restart} ]; then

--- a/fluent-package/yum/systemd-test/test.sh
+++ b/fluent-package/yum/systemd-test/test.sh
@@ -22,6 +22,7 @@ test_filenames=(
     install-newly.sh
     update-from-v4.sh
     update-to-next-version.sh
+    update-from-v4-logrotation-config-edited.sh
 )
 
 for test_filename in ${test_filenames[@]}; do

--- a/fluent-package/yum/systemd-test/update-from-v4-logrotation-config-edited.sh
+++ b/fluent-package/yum/systemd-test/update-from-v4-logrotation-config-edited.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -exu
+
+. $(dirname $0)/commonvar.sh
+
+# Install v4
+sudo rpm --import https://packages.treasuredata.com/GPG-KEY-td-agent
+case ${distribution} in
+    amazon)
+        cat > td.repo <<'EOF';
+[treasuredata]
+name=TreasureData
+baseurl=https://packages.treasuredata.com/4/amazon/$releasever/$basearch
+gpgcheck=1
+gpgkey=https://packages.treasuredata.com/GPG-KEY-td-agent
+EOF
+        sudo mv td.repo /etc/yum.repos.d/
+        ;;
+    *)
+        cat > td.repo <<'EOF';
+[treasuredata]
+name=TreasureData
+baseurl=https://packages.treasuredata.com/4/redhat/$releasever/$basearch
+gpgcheck=1
+gpgkey=https://packages.treasuredata.com/GPG-KEY-td-agent
+EOF
+        sudo mv td.repo /etc/yum.repos.d/
+        ;;
+esac
+sudo $DNF update -y
+sudo $DNF install -y td-agent-4.5.0-1.*.x86_64
+sudo systemctl enable --now td-agent
+systemctl status --no-pager td-agent
+
+# Edit the logrotate config
+test -e /etc/logrotate.d/td-agent
+sudo sed -i"" /etc/logrotate.d/td-agent -e "s/rotate 30/rotate 40/g"
+
+# Install the current
+sudo $DNF install -y \
+    /vagrant/${distribution}/${DISTRIBUTION_VERSION}/x86_64/Packages/fluent-package-[0-9]*.rpm
+systemctl status --no-pager fluentd
+
+# Test: logrotate config migration
+#   RPM renames '/etc/logrotate.d/td-agent' to '/etc/logrotate.d/td-agent.rpmsave'.
+#   Migration process restores '/etc/logrotate.d/td-agent' from the rpmsave and update the pid file path.
+test -e /etc/logrotate.d/td-agent
+test -e /var/log/fluent/td-agent.log
+
+sudo $DNF install -y logrotate # rockylinux-8 needs to install logrotate
+sleep 1
+sudo logrotate -f /etc/logrotate.d/td-agent
+sleep 1
+
+test -e /var/log/fluent/td-agent.log.1
+sudo cp /var/log/fluent/td-agent.log.1 saved_rotated_logfile
+sudo systemctl stop fluentd
+# Check that SIGUSR1 is sent to Fluentd and Fluentd reopens the logfile
+# not to log to the rotated old file.
+sudo diff --report-identical-files /var/log/fluent/td-agent.log.1 saved_rotated_logfile

--- a/fluent-package/yum/systemd-test/update-from-v4.sh
+++ b/fluent-package/yum/systemd-test/update-from-v4.sh
@@ -71,6 +71,21 @@ test $(eval $env_vars && echo $FLUENT_SOCKET) = "/var/run/fluent/fluentd.sock"
 sleep 3
 (! grep -q -e '\[error\]' -e '\[fatal\]' /var/log/td-agent/td-agent.log)
 
+# Test: logrotate config migration
+test -e /etc/logrotate.d/td-agent
+test -e /var/log/fluent/td-agent.log
+
+sudo $DNF install -y logrotate # rockylinux-8 needs to install logrotate
+sudo logrotate -f /etc/logrotate.d/td-agent
+sleep 1
+
+test -e /var/log/fluent/td-agent.log.1
+sudo cp /var/log/fluent/td-agent.log.1 saved_rotated_logfile
+sudo systemctl stop td-agent
+# Check that SIGUSR1 is sent to Fluentd and Fluentd reopens the logfile
+# not to log to the rotated old file.
+sudo diff --report-identical-files /var/log/fluent/td-agent.log.1 saved_rotated_logfile
+
 # Uninstall
 sudo $DNF remove -y fluent-package
 sudo systemctl daemon-reload


### PR DESCRIPTION
We need to support these cases.

* When the file is edited, RPM renames it to `td-agent.rpmsave`.
* When the file is not edited, RPM removes it.