### PR TITLE
deb: prevent Fluentd from running doubly

### DIFF
--- a/fluent-package/apt/systemd-test/update-from-v4.sh
+++ b/fluent-package/apt/systemd-test/update-from-v4.sh
@@ -28,6 +28,7 @@ systemctl status --no-pager fluentd
 (! systemctl status --no-pager td-agent)
 
 # Test: restoring td-agent service alias
+sudo systemctl stop fluentd
 sudo systemctl unmask td-agent
 sudo systemctl enable --now fluentd
 
@@ -56,6 +57,11 @@ test $(eval $env_vars && echo $FLUENT_CONF) = "/etc/fluent/td-agent.conf"
 test $(eval $env_vars && echo $FLUENT_PACKAGE_LOG_FILE) = "/var/log/fluent/td-agent.log"
 test $(eval $env_vars && echo $FLUENT_PLUGIN) = "/etc/fluent/plugin"
 test $(eval $env_vars && echo $FLUENT_SOCKET) = "/var/run/fluent/fluentd.sock"
+
+# Test: No error logs
+# (v4 default config outputs 'warn' log, so we should check only 'error' and 'fatal' logs)
+sleep 3
+(! grep -q -e '\[error\]' -e '\[fatal\]' /var/log/td-agent/td-agent.log)
 
 # Uninstall
 sudo apt remove -y fluent-package

--- a/fluent-package/yum/systemd-test/update-from-v4.sh
+++ b/fluent-package/yum/systemd-test/update-from-v4.sh
@@ -66,6 +66,11 @@ test $(eval $env_vars && echo $FLUENT_PACKAGE_LOG_FILE) = "/var/log/fluent/td-ag
 test $(eval $env_vars && echo $FLUENT_PLUGIN) = "/etc/fluent/plugin"
 test $(eval $env_vars && echo $FLUENT_SOCKET) = "/var/run/fluent/fluentd.sock"
 
+# Test: No error logs
+# (v4 default config outputs 'warn' log, so we should check only 'error' and 'fatal' logs)
+sleep 3
+(! grep -q -e '\[error\]' -e '\[fatal\]' /var/log/td-agent/td-agent.log)
+
 # Uninstall
 sudo $DNF remove -y fluent-package
 sudo systemctl daemon-reload


### PR DESCRIPTION
Without stopping before `unmask` and `enable`, sometimes Fluentd runs doubly.