### PR TITLE
rpm: fix build failure on aarch64

### DIFF
--- a/fluent-package/yum/centos-7-aarch64/Dockerfile
+++ b/fluent-package/yum/centos-7-aarch64/Dockerfile
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ARG FROM=centos:7
+FROM ${FROM}
+
+COPY qemu-* /usr/bin/
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  yum update -y ${quiet} && \
+  yum install -y ${quiet} centos-release-scl && \
+  yum install -y ${quiet} epel-release && \
+  yum groupinstall -y ${quiet} "Development Tools" && \
+  # Use devtoolset-10 explicitly because devtoolset-11 lacks required gcc and so on
+  yum install -y ${quiet} \
+    devtoolset-10 \
+    rh-ruby26-ruby-devel \
+    rh-ruby26-rubygems \
+    rh-ruby26-rubygem-rake \
+    rh-ruby26-rubygem-bundler \
+    libedit-devel \
+    ncurses-devel \
+    libyaml-devel \
+    libffi-devel \
+    git \
+    cyrus-sasl-devel \
+    nss-softokn-freebl-devel \
+    pkg-config \
+    rpm-build \
+    rpmdevtools \
+    redhat-rpm-config \
+    openssl-devel \
+    tar \
+    zlib-devel \
+    rpmlint \
+    cmake3 && \
+  # raise IPv4 priority
+  echo "precedence ::ffff:0:0/96 100" > /etc/gai.conf && \
+  # enable multiplatform feature
+  source /opt/rh/rh-ruby26/enable && gem install --no-document --install-dir /opt/rh/rh-ruby26/root/usr/share/gems bundler builder && \
+  scl enable devtoolset-10 bash && \
+  yum clean ${quiet} all && \
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -115,12 +115,22 @@ The stable distribution of Fluentd, formerly known as td-agent.
 
 %build
 %if %{use_scl_gcc}
+%ifarch aarch64
+# Because of missing complete devtoolset-11-*, enable older devtoolset-10 (only for CentOS 7 aarch64)
+. /opt/rh/devtoolset-10/enable
+%else
 . /opt/rh/devtoolset-11/enable
+%endif
 %endif
 
 %install
 %if %{use_scl_gcc}
+%ifarch aarch64
+# Because of missing complete devtoolset-11-*, enable older devtoolset-10 (only for CentOS 7 aarch64)
+. /opt/rh/devtoolset-10/enable
+%else
 . /opt/rh/devtoolset-11/enable
+%endif
 %endif
 %if %{use_scl_ruby}
 . /opt/rh/rh-ruby%{scl_ruby_ver}/enable


### PR DESCRIPTION
Fix missing package issue on CentOS 7 aarch64.

   #7 150.6 ---> Package xz-devel.aarch64 0:5.2.2-2.el7_9 will be installed
   #7 150.8 --> Finished Dependency Resolution
   #7 150.8 Error: Package: devtoolset-11-toolchain-11.1-2.el7.aarch64 (centos-sclo-rh)
   #7 150.8            Requires: devtoolset-11-gcc-c++
   #7 150.8 Error: Package: devtoolset-11-toolchain-11.1-2.el7.aarch64 (centos-sclo-rh)
   #7 150.8            Requires: devtoolset-11-gcc
   #7 150.8 Error: Package: devtoolset-11-toolchain-11.1-2.el7.aarch64 (centos-sclo-rh)
   #7 150.8            Requires: devtoolset-11-gcc-gfortran
   #7 150.8 Error: Package: devtoolset-11-toolchain-11.1-2.el7.aarch64 (centos-sclo-rh)
   #7 150.8            Requires: devtoolset-11-gdb
   #7 150.8  You could try using --skip-broken to work around the problem
   #7 150.9  You could try running: rpm -Va --nofiles --nodigest

Closes: #543