### PR TITLE
rpm: changed to match Amazon 2023

### DIFF
--- a/fluent-package/manage-fluent-repositories.sh
+++ b/fluent-package/manage-fluent-repositories.sh
@@ -153,7 +153,7 @@ EOF
 	find $FLUENT_RELEASE_DIR/5 -name "*$FLUENT_PACKAGE_VERSION*.rpm" | xargs rpm -K
 
 	# update & sign rpm repository
-	repodirs=`find "${FLUENT_RELEASE_DIR}" -regex "^${FLUENT_RELEASE_DIR}/5/\(redhat\|amazon\)/[2789]/\(x86_64\|aarch64\)$"`
+	repodirs=`find "${FLUENT_RELEASE_DIR}" -regex "^${FLUENT_RELEASE_DIR}/5/\(redhat\|amazon\)/\([2789]\|2023\)/\(x86_64\|aarch64\)$"`
 	for repodir in $repodirs; do
 	    createrepo_c -v "${repodir}"
 


### PR DESCRIPTION
It should match amazon/2023/aarch64 and amazon/2023/x86_64.

  $ find td-agent-release/lts -regex "^td-agent-release/lts/5/\(redhat\|amazon\)/\([2789]\|2023\)/\(x86_64\|aarch64\)$"
  td-agent-release/lts/5/amazon/2023/aarch64
  td-agent-release/lts/5/amazon/2023/x86_64
  td-agent-release/lts/5/amazon/2/aarch64
  td-agent-release/lts/5/amazon/2/x86_64
  td-agent-release/lts/5/redhat/8/aarch64
  td-agent-release/lts/5/redhat/8/x86_64
  td-agent-release/lts/5/redhat/7/aarch64
  td-agent-release/lts/5/redhat/9/aarch64
  td-agent-release/lts/5/redhat/9/x86_64