### PR TITLE
deb: drop compatible symlink when no upgrade mode

### DIFF
--- a/fluent-package/templates/package-scripts/fluent-package/deb/postrm
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postrm
@@ -38,11 +38,13 @@ if [ "$1" = "purge" ]; then
 	    userdel --remove --force <%= compat_service_name %>
 	fi
 fi
-if [ -h /usr/sbin/<%= compat_service_name %> ]; then
-    rm -f /usr/sbin/<%= compat_service_name %>
-fi
-if [ -h /usr/sbin/<%= compat_service_name %>-gem ]; then
-    rm -f /usr/sbin/<%= compat_service_name %>-gem
+if [ ! "$1" = "upgrade" ]; then
+	if [ -h /usr/sbin/<%= compat_service_name %> ]; then
+	    rm -f /usr/sbin/<%= compat_service_name %>
+	fi
+	if [ -h /usr/sbin/<%= compat_service_name %>-gem ]; then
+	    rm -f /usr/sbin/<%= compat_service_name %>-gem
+	fi
 fi
 
 #DEBHELPER#


### PR DESCRIPTION
Before:

v4 => v5 => upgrading... it will remove cpmpatible symlinks => v5.x

After:

v4 => v5 => upgrading... do not remove compatible symlinks => v5.x