### PR TITLE
rpm: update kafka related test case

### DIFF
--- a/fluent-package/yum/serverspec-test.sh
+++ b/fluent-package/yum/serverspec-test.sh
@@ -92,7 +92,7 @@ enabled=1
 
 [Confluent-Clients]
 name=Confluent Clients repository
-baseurl=https://packages.confluent.io/clients/rpm/centos/$releasever/$basearch
+baseurl=https://packages.confluent.io/clients/rpm/centos/\$releasever/\$basearch
 gpgcheck=1
 gpgkey=https://packages.confluent.io/clients/rpm/archive.key
 enabled=1


### PR DESCRIPTION
Before:

* confluent 6.x series are already reaches EOL.
  See https://docs.confluent.io/platform/current/installation/versions-interoperability.html

After:

* Switch to confluent 7.4, it will be supported until May 3, 2025.
* Use newer jdk for testing to avoid issue which is derived exception from
  obsolete one.
* Use newer command line option for kafka-topics. (--zookeeper option
is deprecated)

