### PR TITLE
rpm: enable AlmaLinux 9 test case

### DIFF
--- a/fluent-package/yum/serverspec-test.sh
+++ b/fluent-package/yum/serverspec-test.sh
@@ -61,8 +61,8 @@ case ${distribution} in
     JAVA_JRE=java-17-openjdk
     case ${version} in
       9)
-        # FIXME: Enable it when the package is released
-        ENABLE_KAFKA_TEST=0
+        # FIXME: Accept SHA-1 signed confluent packages.
+        update-crypto-policies --set LEGACY
         ;;
     esac
     ;;

--- a/fluent-package/yum/systemd-test/install-newly.sh
+++ b/fluent-package/yum/systemd-test/install-newly.sh
@@ -32,7 +32,7 @@ SCRIPT
     sudo rpm --import https://packages.treasuredata.com/GPG-KEY-fluent-package
     sudo sh <<SCRIPT
     cat > /etc/yum.repos.d/fluent-package-lts.repo <<'EOF';
-[fluent-package]
+[fluent-package-lts]
 name=Fluentd Project
 baseurl=https://packages.treasuredata.com/lts/5/${DISTRIBUTION}/${DISTRIBUTION_VERSION}/\$basearch
 gpgcheck=1


### PR DESCRIPTION
Note that confluent-community-2.13 seems signed by deprecated SHA-1.

https://www.redhat.com/en/blog/rhel-security-sha-1-package-signatures-distrusted-rhel-9