### PR TITLE
CHANGELOG: fix OpenSSL version for v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,7 +129,8 @@ It is just modified to be a minimally buildable state, it is for testing purpose
 
 * ruby v3.2.2 (update)
 * jemalloc v3.6.0
-* OpenSSL 3.0.8 Windows & macOS
+* OpenSSL 3.1.0 Windows (update)
+* OpenSSL 3.0.8 macOS (update)
 * fluentd v1.16.2
 
 ### Core gems


### PR DESCRIPTION
OpenSSL 3.1.0 for Windows: https://github.com/oneclick/rubyinstaller2/blob/1037499985fcaff2c471e88ed254a7b698e508f6/CHANGELOG-3.2.md?plain=1#L5
