### PR TITLE
deb: set correct contact

### DIFF
--- a/fluent-apt-source/debian/copyright
+++ b/fluent-apt-source/debian/copyright
@@ -1,6 +1,6 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: Fluentd Project
-Upstream-Contact: Fluentd developers <fluentd@googlegroups.com>
+Upstream-Contact: https://github.com/fluent/fluentd
 
 Files: *
 Copyright: 2020 Kentaro Hayashi <hayashi@clear-code.com>

--- a/fluent-lts-apt-source/debian/copyright
+++ b/fluent-lts-apt-source/debian/copyright
@@ -1,6 +1,6 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: Fluentd Project
-Upstream-Contact: Fluentd developers <fluentd@googlegroups.com>
+Upstream-Contact: https://github.com/fluent/fluentd
 
 Files: *
 Copyright: 2020 Kentaro Hayashi <hayashi@clear-code.com>

--- a/fluent-package/templates/package-scripts/fluent-package/deb/copyright
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/copyright
@@ -1,5 +1,6 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: Fluentd Project
+Upstream-Contact: https://github.com/fluent/fluentd
 
 Files: *
 Copyright: 2019-2020 Treasure Data, Inc.


### PR DESCRIPTION
Upstream accepts URIs.

See https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/#upstream-contact-field