### PR TITLE
deb: switch package signing key

### DIFF
--- a/fluent-package/manage-fluent-repositories.sh
+++ b/fluent-package/manage-fluent-repositories.sh
@@ -34,7 +34,8 @@ if [ $# -eq 0 ]; then
 fi
 
 COMMAND=$1
-SIGNING_KEY=BEE682289B2217F45AF4CC3F901F9177AB97ACBE
+# Fluentd developers (Fluent Package Official Signing Key
+SIGNING_KEY=B40948B6A3B80E90F40E841F977D7A0943FA320E
 
 case $COMMAND in
     deb|rpm)


### PR DESCRIPTION
Switch signing key when fluent-apt-source package
was installed to most of machines.

As we can't measure such a metrics, just switch after a while. 
(It is important to determine "WHEN" we should switch to.

Before:

  Treasure Data, Inc (Treasure Agent Official Signing key)

After:

  Fluentd developers (Fluent Package Official Signing Key)

Closes: #579