### PR TITLE
github: add missing bookworm as target

### DIFF
--- a/.github/workflows/apt-arm.yml
+++ b/.github/workflows/apt-arm.yml
@@ -9,12 +9,16 @@ jobs:
       matrix:
         label:
           - Debian GNU/Linux bullseye arm64
+          - Debian GNU/Linux bookworm arm64
           - Ubuntu Focal arm64
           - Ubuntu Jammy arm64
         include:
           - label: Debian GNU/Linux bullseye arm64
             rake-job: debian-bullseye
             test-docker-image: arm64v8/debian:bullseye
+          - label: Debian GNU/Linux bookworm arm64
+            rake-job: debian-bookworm
+            test-docker-image: arm64v8/debian:bookworm
           - label: Ubuntu Focal arm64
             rake-job: ubuntu-focal
             rake-options: LINTIAN=no

--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -13,12 +13,16 @@ jobs:
       matrix:
         label:
           - Debian GNU/Linux bullseye amd64
+          - Debian GNU/Linux bookworm amd64
           - Ubuntu Focal amd64
           - Ubuntu Jammy amd64
         include:
           - label: Debian GNU/Linux bullseye amd64
             rake-job: debian-bullseye
             test-docker-image: debian:bullseye
+          - label: Debian GNU/Linux bookworm amd64
+            rake-job: debian-bookworm
+            test-docker-image: debian:bookworm
           - label: Ubuntu Focal amd64
             rake-job: ubuntu-focal
             test-docker-image: ubuntu:focal
@@ -97,6 +101,7 @@ jobs:
       matrix:
         distribution:
           - debian-bullseye
+          - debian-bookworm
           - ubuntu-focal
           - ubuntu-jammy
     steps:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       :box => "bento/debian-11",
     },
     {
+      :id => "debian-bookworm",
+      :box => "bento/debian-12",
+    },
+    {
       :id => "ubuntu-focal",
       :box => "bento/ubuntu-20.04",
     },

--- a/fluent-package/apt/install-test.sh
+++ b/fluent-package/apt/install-test.sh
@@ -37,6 +37,10 @@ for conf_path in /etc/td-agent/td-agent.conf /etc/fluent/fluentd.conf; do
     fi
 done
 
+if [ "${code_name}" == "bookworm" ]; then
+    echo "As bookworm is not published for v4, so package upgrade install check for ${code_name} is disabled"
+    exit 0
+fi
 # TODO: Remove it when v5 repository was deployed
 apt install -y curl
 curl -O https://packages.treasuredata.com/4/${distribution}/${code_name}/pool/contrib/f/fluentd-apt-source/fluentd-apt-source_2020.8.25-1_all.deb

--- a/fluent-package/apt/piuparts-test.sh
+++ b/fluent-package/apt/piuparts-test.sh
@@ -25,6 +25,5 @@ echo "deb [signed-by=/usr/share/keyrings/td-agent-archive-keyring.gpg] https://p
 rm -rf $CHROOT/opt
 piuparts --distribution=${code_name} \
 	 --existing-chroot=${CHROOT} \
-	 --mirror="https://packages.treasuredata.com/5/${distribution}/${code_name}/ ${code_name} contrib" \
 	 --skip-logrotatefiles-test \
 	 /tmp/*_${architecture}.deb

--- a/fluent-package/apt/piuparts-test.sh
+++ b/fluent-package/apt/piuparts-test.sh
@@ -21,10 +21,10 @@ chmod 644 $CHROOT/usr/share/keyrings/td-agent-archive-keyring.gpg
 chroot $CHROOT apt install -V -y libyaml-0-2
 package=${repositories_dir}/${distribution}/pool/${code_name}/${channel}/*/*/*_${architecture}.deb
 cp ${package} /tmp
-echo "deb [signed-by=/usr/share/keyrings/td-agent-archive-keyring.gpg] https://packages.treasuredata.com/4/${distribution}/${code_name}/ ${code_name} contrib" | tee $CHROOT/etc/apt/sources.list.d/td.list
+echo "deb [signed-by=/usr/share/keyrings/td-agent-archive-keyring.gpg] https://packages.treasuredata.com/5/${distribution}/${code_name}/ ${code_name} contrib" | tee $CHROOT/etc/apt/sources.list.d/td.list
 rm -rf $CHROOT/opt
 piuparts --distribution=${code_name} \
 	 --existing-chroot=${CHROOT} \
-	 --mirror="https://packages.treasuredata.com/4/${distribution}/${code_name}/ ${code_name} contrib" \
+	 --mirror="https://packages.treasuredata.com/5/${distribution}/${code_name}/ ${code_name} contrib" \
 	 --skip-logrotatefiles-test \
 	 /tmp/*_${architecture}.deb

--- a/fluent-package/apt/pkgsize-test.sh
+++ b/fluent-package/apt/pkgsize-test.sh
@@ -32,11 +32,11 @@ done
 
 case ${DISTRIBUTION} in
     debian)
-	BASE_URI=http://packages.treasuredata.com.s3.amazonaws.com/4/debian/${CODE_NAME}
+	BASE_URI=https://packages.treasuredata.com/5/debian/${CODE_NAME}
 	CHANNEL=main
 	for v in "${PREVIOUS_VERSIONS[@]}"; do
-	    BASE_NAME=td-agent_${v}-1_${ARCH}.deb
-	    PREVIOUS_DEB=${BASE_URI}/pool/contrib/t/td-agent/${BASE_NAME}
+	    BASE_NAME=fluent-package_${v}-1_${ARCH}.deb
+	    PREVIOUS_DEB=${BASE_URI}/pool/contrib/f/fluent-package/${BASE_NAME}
 	    set +e
 	    wget ${PREVIOUS_DEB}
 	    if [ $? -eq 0 ]; then
@@ -45,11 +45,11 @@ case ${DISTRIBUTION} in
 	done
 	;;
     ubuntu)
-	BASE_URI=http://packages.treasuredata.com.s3.amazonaws.com/4/ubuntu/${CODE_NAME}
+	BASE_URI=https://packages.treasuredata.com/5/ubuntu/${CODE_NAME}
 	CHANNEL=universe
 	for v in "${PREVIOUS_VERSIONS[@]}"; do
-	    BASE_NAME=td-agent_${v}-1_${ARCH}.deb
-	    PREVIOUS_DEB=${BASE_URI}/pool/contrib/t/td-agent/${BASE_NAME}
+	    BASE_NAME=fluent-package_${v}-1_${ARCH}.deb
+	    PREVIOUS_DEB=${BASE_URI}/pool/contrib/f/fluent-package/${BASE_NAME}
 	    set +e
 	    wget ${PREVIOUS_DEB}
 	    if [ $? -eq 0 ]; then

--- a/fluent-package/apt/pkgsize-test.sh
+++ b/fluent-package/apt/pkgsize-test.sh
@@ -16,11 +16,6 @@ ARCH=$2
 
 REPOSITORIES_DIR=fluent-package/apt/repositories
 
-if [ "${code_name}" == "bookworm" ]; then
-    echo "As bookworm is not published yet, so package size check for ${code_name} is disabled"
-    exit 0
-fi
-
 if [ -f .git/shallow ]; then
     git fetch --unshallow
 fi

--- a/fluent-package/apt/systemd-test/install-newly.sh
+++ b/fluent-package/apt/systemd-test/install-newly.sh
@@ -25,5 +25,21 @@ test -e /var/log/fluent/fluentd.log
 
 sudo apt remove -y fluent-package
 
-test -h /etc/systemd/system/fluentd.service
+case ${code_name} in
+  bookworm)
+    # no dead fluentd.service symlink in /etc/systemd/system
+    (! test -h /etc/systemd/system/fluentd.service)
+    test -h /etc/systemd/system/multi-user.target.wants/fluentd.service
+    (! test -s /etc/systemd/system/multi-user.target.wants/fluentd.service)
+    ;;
+  *)
+    # dead fluentd.service symlink in /etc/systemd/system
+    test -h /etc/systemd/system/fluentd.service
+    (! test -s /etc/systemd/system/fluentd.service)
+    test -h /etc/systemd/system/multi-user.target.wants/fluentd.service
+    (! test -s /etc/systemd/system/multi-user.target.wants/fluentd.service)
+    ;;
+esac
+test -h /etc/systemd/system/td-agent.service
+(! test -s /etc/systemd/system/td-agent.service)
 (! systemctl status fluentd)

--- a/fluent-package/apt/systemd-test/test.sh
+++ b/fluent-package/apt/systemd-test/test.sh
@@ -19,10 +19,16 @@ fi
 set -eu
 
 test_filenames=(
-    update-from-v4.sh
     update-to-next-version.sh
-    update-to-next-version-with-backward-compat-for-v4.sh
 )
+
+if [ ! $vm = "debian-bookworm" ]; then
+    # As no bookworm package for v4, so execute upgrade test for other code name.
+    test_filenames+=(
+        update-from-v4.sh
+        update-to-next-version-with-backward-compat-for-v4.sh
+    )
+fi
 
 for apt_repo_type in local v5 lts; do
     echo -e "\nRun test: $apt_repo_type\n"

--- a/fluent-package/apt/systemd-test/update-from-v4.sh
+++ b/fluent-package/apt/systemd-test/update-from-v4.sh
@@ -72,4 +72,8 @@ sudo apt remove -y fluent-package
 (! systemctl status --no-pager fluentd)
 
 test -h /etc/systemd/system/td-agent.service
+(! test -s /etc/systemd/system/td-agent.service)
 test -h /etc/systemd/system/fluentd.service
+(! test -s /etc/systemd/system/fluentd.service)
+test -h /etc/systemd/system/multi-user.target.wants/fluentd.service
+(! test -s /etc/systemd/system/multi-user.target.wants/fluentd.service)


### PR DESCRIPTION
* github: drop redundant --mirror option

    Use pre-configured chroot apt-line, so --mirror is redundant.
    Without it, it causes the following error on bookworm:

      The following packages have unmet dependencies:
       fluent-package : Depends: libncurses6 (>= 6) but it is not installable
      W: Target Packages (contrib/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:2 and /etc/apt/sources.list.d
      W: Target Packages (contrib/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:2 and /etc/apt/sources.list.d/t
      W: Target Translations (contrib/i18n/Translation-en) is configured multiple times in /etc/apt/sources.list:2 and /etc/apt/sources.list

 github: add more .service check after removing

    After removing fluent-package, the status of service files seems
    different.

    bookworm:
      no /etc/systemd/system/fluentd.service
      dead symlink /etc/systemd/system/multi-user.target.wants/luentd.service
      dead /etc/systemd/system/td-agent.service

    bullseye:
      dead /etc/systemd/system/fluentd.service
      dead symlink /etc/systemd/system/multi-user.target.wants/luentd.service
      dead /etc/systemd/system/td-agent.service

