### PR TITLE
msi: support path which contains space or parenthesis

### DIFF
--- a/fluent-package/msi/assets/fluent-gem.bat
+++ b/fluent-package/msi/assets/fluent-gem.bat
@@ -1,12 +1,12 @@
 @echo off
 if "%~nx0" == "td-agent-gem.bat" (
-  set FLUENT_PACKAGE_TOPDIR=%~dp0..\
+  set "FLUENT_PACKAGE_TOPDIR=%~dp0..\"
 ) else (
-  set FLUENT_PACKAGE_TOPDIR=%~dp0
+  set "FLUENT_PACKAGE_TOPDIR=%~dp0"
 )
-set FLUENT_PACKAGE_BINDIR=%FLUENT_PACKAGE_TOPDIR%bin
-set PATH="%FLUENT_PACKAGE_BINDIR%";%PATH%
-for /f "usebackq" %%i in (`%FLUENT_PACKAGE_BINDIR%\ruby.exe -rrbconfig -e "print RbConfig::CONFIG['ruby_version']"`) do set RUBY_VERSION=%%i
-set GEM_HOME=%FLUENT_PACKAGE_TOPDIR%lib\ruby\gems\%RUBY_VERSION%
-set GEM_PATH=%FLUENT_PACKAGE_TOPDIR%lib\ruby\gems\%RUBY_VERSION%
-%FLUENT_PACKAGE_BINDIR%\fluent-gem %*
+set "FLUENT_PACKAGE_BINDIR=%FLUENT_PACKAGE_TOPDIR%bin"
+set PATH=%FLUENT_PACKAGE_BINDIR%;%PATH%
+for /f "usebackq" %%i in (`^""%FLUENT_PACKAGE_BINDIR%\ruby.exe" -rrbconfig -e "print RbConfig::CONFIG['ruby_version']"^"`) do set RUBY_VERSION=%%i
+set "GEM_HOME=%FLUENT_PACKAGE_TOPDIR%lib\ruby\gems\%RUBY_VERSION%"
+set "GEM_PATH=%FLUENT_PACKAGE_TOPDIR%lib\ruby\gems\%RUBY_VERSION%"
+"%FLUENT_PACKAGE_BINDIR%\fluent-gem" %*

--- a/fluent-package/msi/assets/fluentd.bat
+++ b/fluent-package/msi/assets/fluentd.bat
@@ -1,8 +1,8 @@
 @echo off
 if "%~nx0" == "td-agent.bat" (
-  set FLUENT_PACKAGE_TOPDIR=%~dp0..\
+  set "FLUENT_PACKAGE_TOPDIR=%~dp0..\"
 ) else (
-  set FLUENT_PACKAGE_TOPDIR=%~dp0
+  set "FLUENT_PACKAGE_TOPDIR=%~dp0"
 )
 
 @rem Convert path separator from backslash to forwardslash
@@ -11,9 +11,9 @@ set FLUENT_PACKAGE_TOPDIR=!FLUENT_PACKAGE_TOPDIR:\=/!
 
 set PATH=%FLUENT_PACKAGE_TOPDIR%bin;%PATH%
 set PATH=%FLUENT_PACKAGE_TOPDIR%;%PATH%
-set FLUENT_CONF=%FLUENT_PACKAGE_TOPDIR%/etc/fluent/fluentd.conf
-set FLUENT_PLUGIN=%FLUENT_PACKAGE_TOPDIR%/etc/fluent/plugin
-set FLUENT_PACKAGE_VERSION=%FLUENT_PACKAGE_TOPDIR%/bin/fluent-package-version.rb
+set "FLUENT_CONF=%FLUENT_PACKAGE_TOPDIR%/etc/fluent/fluentd.conf"
+set "FLUENT_PLUGIN=%FLUENT_PACKAGE_TOPDIR%/etc/fluent/plugin"
+set "FLUENT_PACKAGE_VERSION=%FLUENT_PACKAGE_TOPDIR%/bin/fluent-package-version.rb"
 for %%p in (%*) do (
     if "%%p"=="--version" (
         ruby "%FLUENT_PACKAGE_VERSION%"

--- a/fluent-package/msi/source.wxs
+++ b/fluent-package/msi/source.wxs
@@ -185,7 +185,7 @@
     <Property Id="InstallFluentdWinSvc" Value=" "/>
     <CustomAction Id="SetInstallFluentdWinSvcCommand"
                   Property="InstallFluentdWinSvc"
-                  Value="&quot;[FLUENTPROJECTLOCATION]fluentd.bat&quot; --reg-winsvc i --reg-winsvc-delay-start --reg-winsvc-fluentdopt &quot;-c [FLUENTPROJECTLOCATION]etc\fluent\fluentd.conf -o [FLUENTPROJECTLOCATION]fluentd.log&quot;"/>
+                  Value="&quot;[FLUENTPROJECTLOCATION]fluentd.bat&quot; --reg-winsvc i --reg-winsvc-delay-start --reg-winsvc-fluentdopt &quot;-c '[FLUENTPROJECTLOCATION]etc\fluent\fluentd.conf' -o '[FLUENTPROJECTLOCATION]fluentd.log'&quot;"/>
     <CustomAction Id="InstallFluentdWinSvc"
                   BinaryKey="WixCA"
                   DllEntry="WixQuietExec64"
@@ -196,7 +196,7 @@
     <Property Id="CreateCompatTdAgentBat" Value=" "/>
     <CustomAction Id="SetCreateCompatTdAgentBat"
                   Property="CreateCompatTdAgentBat"
-                  Value="&quot;cmd&quot; /c &quot;fsutil hardlink create [FLUENTPROJECTLOCATION]bin\td-agent.bat [FLUENTPROJECTLOCATION]fluentd.bat&quot;"/>
+                  Value="&quot;cmd&quot; /c &quot;fsutil hardlink create ^&quot;[FLUENTPROJECTLOCATION]bin\td-agent.bat^&quot; ^&quot;[FLUENTPROJECTLOCATION]fluentd.bat^&quot;&quot;"/>
     <CustomAction Id="CreateCompatTdAgentBat"
                   BinaryKey="WixCA"
                   DllEntry="WixQuietExec64"
@@ -206,7 +206,7 @@
     <Property Id="CreateCompatTdAgentGemBat" Value=" "/>
     <CustomAction Id="SetCreateCompatTdAgentGemBat"
                   Property="CreateCompatTdAgentGemBat"
-                  Value="&quot;cmd&quot; /c &quot;fsutil hardlink create [FLUENTPROJECTLOCATION]bin\td-agent-gem.bat [FLUENTPROJECTLOCATION]fluent-gem.bat&quot;"/>
+                  Value="&quot;cmd&quot; /c &quot;fsutil hardlink create ^&quot;[FLUENTPROJECTLOCATION]bin\td-agent-gem.bat^&quot; ^&quot;[FLUENTPROJECTLOCATION]fluent-gem.bat^&quot;&quot;"/>
     <CustomAction Id="CreateCompatTdAgentGemBat"
                   BinaryKey="WixCA"
                   DllEntry="WixQuietExec64"
@@ -217,7 +217,7 @@
     <Property Id="DeleteCompatTdAgentBat" Value=" "/>
     <CustomAction Id="SetDeleteCompatTdAgentBat"
                   Property="DeleteCompatTdAgentBat"
-                  Value="&quot;cmd&quot; /c &quot;del [FLUENTPROJECTLOCATION]bin\td-agent.bat&quot;"/>
+                  Value="&quot;cmd&quot; /c &quot;del ^&quot;[FLUENTPROJECTLOCATION]bin\td-agent.bat^&quot;&quot;"/>
     <CustomAction Id="DeleteCompatTdAgentBat"
                   BinaryKey="WixCA"
                   DllEntry="WixQuietExec64"
@@ -227,7 +227,7 @@
     <Property Id="DeleteCompatTdAgentGemBat" Value=" "/>
     <CustomAction Id="SetDeleteCompatTdAgentGemBat"
                   Property="DeleteCompatTdAgentGemBat"
-                  Value="&quot;cmd&quot; /c &quot;del [FLUENTPROJECTLOCATION]bin\td-agent-gem.bat&quot;"/>
+                  Value="&quot;cmd&quot; /c &quot;del ^&quot;[FLUENTPROJECTLOCATION]bin\td-agent-gem.bat^&quot;&quot;"/>
     <CustomAction Id="DeleteCompatTdAgentGemBat"
                   BinaryKey="WixCA"
                   DllEntry="WixQuietExec64"


### PR DESCRIPTION
When installing fluent-package to c:\Program Files, the space
character must be escaped correctly.

* sources.wxs
  * For xml, double quote (") must be &quot;
  * to escape double quote in literal, you must escape with ^&quote;
    it is treated as ^", so it is properly quoted to execute:

  "cmd" /c "fsutil ... "c:\Program Files .." "c:\Program Files...""

* fluentd.bat,fluent-gem.bat
  * set FOO="..." assign extra double quote, it's troublesome because
  extra double quote will be included when concatenating path.
  The only way to avoid this problem is set "FOO=..." to assign it.
  you can assign to FOO without extra double quote.
  * to get RUBY_VERSION, use "usebackq" and execute command with
    escaped command literal explicitly.
     passed `^""C:\..." ....^"` literal are evaluated ^""C:\..."^".
