### PR TITLE
Fix system user/group name in logrotate config

### DIFF
--- a/fluent-package/templates/etc/logrotate.d/fluentd
+++ b/fluent-package/templates/etc/logrotate.d/fluentd
@@ -4,7 +4,7 @@
   compress
   delaycompress
   notifempty
-  create 640 <%= service_name %> <%= service_name %>
+  create 640 _<%= service_name %> _<%= service_name %>
   sharedscripts
   postrotate
     pid=/var/run/<%= package_dir %>/<%= service_name %>.pid


### PR DESCRIPTION
Fix system user/group name in logrotate config

I had installed  `fluent-package` - `5.0.1-1` on ubuntu 22.04
```
ii  fluent-package 5.0.1-1      amd64        All in one package of Fluentd
```

With fluent-package v5 user/group name is changed to `_fluentd`
- https://github.com/fluent/fluent-package-builder/blob/v5.0.1/fluent-package/templates/package-scripts/fluent-package/deb/postinst#L13
- https://github.com/fluent/fluent-package-builder/blob/v5.0.1/fluent-package/templates/package-scripts/fluent-package/deb/postinst#L19

However user/group name in logrotate config is `fluentd`, which causes following failure
```
$ logrotate -f /etc/logrotate.d/fluentd
error: /etc/logrotate.d/fluentd:7 unknown user 'fluentd'
error: found error in /var/log/fluent/fluentd.log , skipping
```
I guess this change was introduced in - https://github.com/fluent/fluent-package-builder/pull/449