### PR TITLE
rpm deb: add user as system user

### DIFF
--- a/fluent-package/templates/package-scripts/fluent-package/deb/postinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postinst
@@ -16,12 +16,12 @@ add_system_user() {
 	    # create _<%= service_name %> user/group with same uid/gid for compatibility easily.
 	    if getent group <%= compat_service_name %> >/dev/null; then
 		TD_GID=$(getent group <%= compat_service_name %> | cut -d':' -f3)
-		groupadd -g $TD_GID -o _<%= service_name %>
+		groupadd --gid $TD_GID --non-unique _<%= service_name %>
 	    fi
 	    if getent passwd <%= compat_service_name %> >/dev/null; then
 		TD_UID=$(id --user <%= compat_service_name %>)
 		TD_GID=$(getent group <%= compat_service_name %> | cut -d':' -f3)
-		useradd --system -u $TD_UID -g $TD_GID -o -d /var/lib/<%= package_dir %> -s /usr/sbin/nologin _<%= service_name %>
+		useradd --system --uid $TD_UID --gid $TD_GID --non-unique --home-dir /var/lib/<%= package_dir %> --shell /usr/sbin/nologin _<%= service_name %>
 	    fi
 	fi
     fi

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postinst
@@ -21,7 +21,7 @@ add_system_user() {
 	    if getent passwd <%= compat_service_name %> >/dev/null; then
 		TD_UID=$(id --user <%= compat_service_name %>)
 		TD_GID=$(getent group <%= compat_service_name %> | cut -d':' -f3)
-		useradd -u $TD_UID -g $TD_GID -o -d /var/lib/<%= package_dir %> -s /usr/sbin/nologin _<%= service_name %>
+		useradd --system -u $TD_UID -g $TD_GID -o -d /var/lib/<%= package_dir %> -s /usr/sbin/nologin _<%= service_name %>
 	    fi
 	fi
     fi

--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -175,7 +175,7 @@ else
         echo "Add user @SERVICE_NAME@ (same UID/GID with @COMPAT_SERVICE_NAME@)..."
         TD_UID=$(id --user @COMPAT_SERVICE_NAME@)
         TD_GID=$(getent group @COMPAT_SERVICE_NAME@ | cut -d':' -f3)
-        /usr/sbin/useradd -u $TD_UID -g $TD_GID -d %{_localstatedir}/lib/@PACKAGE_DIR@ -s /sbin/nologin -o @SERVICE_NAME@
+        /usr/sbin/useradd --system -u $TD_UID -g $TD_GID -d %{_localstatedir}/lib/@PACKAGE_DIR@ -s /sbin/nologin -o @SERVICE_NAME@
     fi
 fi
 

--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -153,21 +153,21 @@ mkdir -p %{buildroot}/tmp/@PACKAGE_DIR@
 %pre
 if ! getent group @COMPAT_SERVICE_NAME@ >/dev/null; then
     if ! getent group @SERVICE_NAME@ >/dev/null; then
-        /usr/sbin/groupadd -r @SERVICE_NAME@
+        /usr/sbin/groupadd --system @SERVICE_NAME@
     fi
 else
     if ! getent group @SERVICE_NAME@ >/dev/null; then
         echo "Add group @SERVICE_NAME@ (same GID with @COMPAT_SERVICE_NAME@)..."
         TD_GID=$(getent group @COMPAT_SERVICE_NAME@ | cut -d':' -f3)
-        /usr/sbin/groupadd -g $TD_GID -o @SERVICE_NAME@
+        /usr/sbin/groupadd --gid $TD_GID --non-unique @SERVICE_NAME@
     fi
 fi
 if ! getent passwd @COMPAT_SERVICE_NAME@ >/dev/null; then
     if ! getent passwd @SERVICE_NAME@ >/dev/null; then
 %if %{use_suse}
-        /usr/sbin/useradd -r -g @SERVICE_NAME@ -d %{_localstatedir}/lib/@PACKAGE_DIR@ -s /sbin/nologin -c '@SERVICE_NAME@' @SERVICE_NAME@
+        /usr/sbin/useradd --system --gid @SERVICE_NAME@ --home-dir %{_localstatedir}/lib/@PACKAGE_DIR@ --shell /sbin/nologin --comment '@SERVICE_NAME@' @SERVICE_NAME@
 %else
-        /usr/sbin/adduser -r -g @SERVICE_NAME@ -d %{_localstatedir}/lib/@PACKAGE_DIR@ -s /sbin/nologin -c '@SERVICE_NAME@' @SERVICE_NAME@
+        /usr/sbin/adduser --system --gid @SERVICE_NAME@ --home-dir %{_localstatedir}/lib/@PACKAGE_DIR@ --shell /sbin/nologin --comment '@SERVICE_NAME@' @SERVICE_NAME@
 %endif
     fi
 else
@@ -175,7 +175,7 @@ else
         echo "Add user @SERVICE_NAME@ (same UID/GID with @COMPAT_SERVICE_NAME@)..."
         TD_UID=$(id --user @COMPAT_SERVICE_NAME@)
         TD_GID=$(getent group @COMPAT_SERVICE_NAME@ | cut -d':' -f3)
-        /usr/sbin/useradd --system -u $TD_UID -g $TD_GID -d %{_localstatedir}/lib/@PACKAGE_DIR@ -s /sbin/nologin -o @SERVICE_NAME@
+        /usr/sbin/useradd --system --uid $TD_UID --gid $TD_GID --home-dir %{_localstatedir}/lib/@PACKAGE_DIR@ --shell /sbin/nologin --non-unique @SERVICE_NAME@
     fi
 fi
 


### PR DESCRIPTION
When upgrading from v4, there is a possibility that fluentd user is not  created as system user.

Before:
      Without --system, /var/lib/fluent will be created

 After:
      With --system, /var/lib/fluent will NOT be created

NOTE: Not to overlook it, use long option explicitly.

UID itself is kept in range of system user (td-agent), so not accessed via normal user. 