### PR TITLE
 rpm: do not delete system account

### DIFF
--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -284,26 +284,6 @@ if [ $1 -eq 0 ]; then
   fi
 fi
 
-if [ $1 -eq 0 ]; then
-   # Removing
-   if getent passwd @SERVICE_NAME@ >/dev/null; then
-       echo "Removing @SERVICE_NAME@ user..."
-       /usr/sbin/userdel --remove @SERVICE_NAME@
-   fi
-   if getent group @SERVICE_NAME@ >/dev/null; then
-       echo "Removing @SERVICE_NAME@ group..."
-       /usr/sbin/groupdel @SERVICE_NAME@
-   fi
-   if getent passwd @COMPAT_SERVICE_NAME@ >/dev/null; then
-       echo "Removing @COMPAT_SERVICE_NAME@ user..."
-       /usr/sbin/userdel --remove @COMPAT_SERVICE_NAME@
-   fi
-   if getent group @COMPAT_SERVICE_NAME@ >/dev/null; then
-       echo "Removing @COMPAT_SERVICE_NAME@ group..."
-       /usr/sbin/groupdel @COMPAT_SERVICE_NAME@
-   fi
-fi
-
 %posttrans
 if [ -f %{v4migration} ]; then
   if [ ! -f /usr/sbin/@COMPAT_SERVICE_NAME@ ]; then

--- a/fluent-package/yum/install-test.sh
+++ b/fluent-package/yum/install-test.sh
@@ -83,8 +83,8 @@ for conf_path in /etc/td-agent/td-agent.conf /etc/fluent/fluentd.conf; do
     fi
 done
 
-(! getent passwd fluentd >/dev/null)
-(! getent group fluentd >/dev/null)
+getent passwd fluentd >/dev/null
+getent group fluentd >/dev/null
 
 if [ $ENABLE_UPGRADE_TEST -eq 1 ]; then
     echo "UPGRADE TEST from v4"

--- a/fluent-package/yum/systemd-test/install-newly.sh
+++ b/fluent-package/yum/systemd-test/install-newly.sh
@@ -46,9 +46,18 @@ test -e /var/log/fluent/fluentd.log
 sudo $DNF remove -y fluent-package
 sudo systemctl daemon-reload
 
-getent passwd fluentd >/dev/null
-getent group fluentd >/dev/null
-
+case $1 in
+  local)
+    getent passwd fluentd >/dev/null
+    getent group fluentd >/dev/null
+    ;;
+  *)
+    # TODO: Remove this branch after the following fix is applied to the latest release.
+    # https://github.com/fluent/fluent-package-builder/pull/598
+    (! getent passwd fluentd >/dev/null)
+    (! getent group fluentd >/dev/null)
+    ;;
+esac
 # `sudo systemctl daemon-reload` clears the service completely.
 #   (The result of `systemctl status` will be `unfound`)
 # Note: RPM does not leave links like `@/etc/systemd/system/fluentd.service`.

--- a/fluent-package/yum/systemd-test/install-newly.sh
+++ b/fluent-package/yum/systemd-test/install-newly.sh
@@ -46,6 +46,9 @@ test -e /var/log/fluent/fluentd.log
 sudo $DNF remove -y fluent-package
 sudo systemctl daemon-reload
 
+getent passwd fluentd >/dev/null
+getent group fluentd >/dev/null
+
 # `sudo systemctl daemon-reload` clears the service completely.
 #   (The result of `systemctl status` will be `unfound`)
 # Note: RPM does not leave links like `@/etc/systemd/system/fluentd.service`.

--- a/fluent-package/yum/systemd-test/update-from-v4.sh
+++ b/fluent-package/yum/systemd-test/update-from-v4.sh
@@ -78,6 +78,11 @@ test -e /var/log/fluent/fluentd.log
 sudo $DNF remove -y fluent-package
 sudo systemctl daemon-reload
 
+getent passwd td-agent >/dev/null
+getent group td-agent >/dev/null
+getent passwd fluentd >/dev/null
+getent group fluentd >/dev/null
+
 # `sudo systemctl daemon-reload` clears the service completely.
 #   (The result of `systemctl status` will be `unfound`)
 # Note: RPM does not leave links like `@/etc/systemd/system/fluentd.service`.

--- a/fluent-package/yum/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
@@ -97,3 +97,9 @@ test -e /var/log/fluent/fluentd.log
 sudo $DNF remove -y fluent-package
 (! systemctl status --no-pager td-agent)
 (! systemctl status --no-pager fluentd)
+
+getent passwd td-agent >/dev/null
+getent group td-agent >/dev/null
+getent passwd fluentd >/dev/null
+getent group fluentd >/dev/null
+

--- a/fluent-package/yum/systemd-test/update-to-next-version.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version.sh
@@ -62,6 +62,11 @@ test -e /var/log/fluent/fluentd.log
 sudo $DNF remove -y fluent-package
 sudo systemctl daemon-reload
 
+(! getent passwd td-agent >/dev/null)
+(! getent group td-agent >/dev/null)
+getent passwd fluentd >/dev/null
+getent group fluentd >/dev/null
+
 # `sudo systemctl daemon-reload` clears the service completely.
 #   (The result of `systemctl status` will be `unfound`)
 # Note: RPM does not leave links like `@/etc/systemd/system/fluentd.service`.


### PR DESCRIPTION
In the previous versions (5.0.0, 5.0.1), when fluent-package was
removed, system account (user and group are intended to be removed)

But there is a case that it fails to remove fluentd group because of
compatible GID is assigned for td-agent and fluentd when
fluent-package was introduced with upgrading from td-agent v4.

  Removing fluentd user...
  userdel: group fluentd is the primary group of another user and is not removed.
  Removing fluentd group...
  groupdel: cannot remove the primary group of user 'td-agent'
  Removing td-agent user...
  userdel: td-agent mail spool (/var/spool/mail/td-agent) not found
  userdel: td-agent home directory (/var/lib/td-agent) not found

This is a bug of fluent-package apparently.

This kind of inconsistency causes maintainer script error when
reinstalling td-agent or fluent-package again.

And moreover, if system account (user and group) was removed
completely, there is a case that no user can access generated logs
when user re-installed td-agent or fluent-package. (mismatch of
UID/GID which is newly created)

This case also should be considered.
(Keep system account after removing package)
