### PR TITLE
msi: fix wrong env path for Fluent Package Prompt

### DIFF
--- a/fluent-package/msi/assets/fluent-package-prompt.bat
+++ b/fluent-package/msi/assets/fluent-package-prompt.bat
@@ -1,4 +1,4 @@
 @echo off
-set PATH="%~dp0\bin";%PATH%
-set PATH="%~dp0";%PATH%
+set "PATH=%~dp0\bin;%PATH%"
+set "PATH=%~dp0;%PATH%"
 title Fluent Package Command Prompt


### PR DESCRIPTION
* fix https://github.com/fluent/fluent-package-builder/issues/605
* The current PATH includes `"`. It is unintended and causes some
  bugs. For example, fluent-diagtool does not work correctly
  because of this.
