### PR TITLE
msi: remove unnecessary path delimiter

### DIFF
--- a/fluent-package/msi/assets/fluent-package-prompt.bat
+++ b/fluent-package/msi/assets/fluent-package-prompt.bat
@@ -1,4 +1,4 @@
 @echo off
-set "PATH=%~dp0\bin;%PATH%"
+set "PATH=%~dp0bin;%PATH%"
 set "PATH=%~dp0;%PATH%"
 title Fluent Package Command Prompt


### PR DESCRIPTION
The last character of `%~dp0` is `\`, so we don't need add it.
(Though it appears it does not cause any problems.)