### PR TITLE
rpm: take over enabled state of systemd service from v4

### DIFF
--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -31,6 +31,7 @@
 %define v4migration /tmp/@PACKAGE_DIR@/.v4migration
 %define v4migration_with_restart /tmp/@PACKAGE_DIR@/.v4migration_with_restart
 %define v4migration_old_rotate_config_saved /tmp/@PACKAGE_DIR@/.old_rotate_config
+%define v4migration_enabled_service /tmp/@PACKAGE_DIR@/.v4migration_enabled_service
 
 %global __provides_exclude_from ^/opt/%{name}/.*\\.so.*
 %global __requires_exclude libjemalloc.*|libruby.*|/opt/%{name}/.*
@@ -207,6 +208,11 @@ if [ $1 -eq 1 ]; then
       ln -sf /etc/@PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.conf /etc/@PACKAGE_DIR@/@SERVICE_NAME@.conf
     fi
   fi
+  if systemctl is-enabled @COMPAT_SERVICE_NAME@; then
+    # It is not enough to systemctl enable fluentd here for taking over enabled service status
+    # because td-agent %preun disables td-agent so fluentd is also disabled.
+    touch %{v4migration_enabled_service}
+  fi
   if systemctl is-active @COMPAT_SERVICE_NAME@; then
     if getent passwd @COMPAT_SERVICE_NAME@ >/dev/null; then
       if ! getent passwd @SERVICE_NAME@ >/dev/null; then
@@ -313,6 +319,12 @@ if [ -f %{v4migration} ]; then
     # When the file is not edited:
     echo "Restores logrotate config from backup"
     mv -f %{v4migration_old_rotate_config_saved} /etc/logrotate.d/@COMPAT_SERVICE_NAME@
+  fi
+  if [ -f %{v4migration_enabled_service} ]; then
+    # Explicitly enable service here not to be disabled during td-agent's %preun scriptlet.
+    echo "@COMPAT_SERVICE_NAME@ was enabled. Take over enabled service status ..."
+    systemctl enable @SERVICE_NAME@
+    rm -f %{v4migration_enabled_service}
   fi
   rm -f %{v4migration}
   if [ -f %{v4migration_with_restart} ]; then

--- a/fluent-package/yum/systemd-test/update-from-v4.sh
+++ b/fluent-package/yum/systemd-test/update-from-v4.sh
@@ -38,6 +38,9 @@ systemctl status --no-pager td-agent
 sudo $DNF install -y \
     /host/${distribution}/${DISTRIBUTION_VERSION}/x86_64/Packages/fluent-package-[0-9]*.rpm
 
+# Test: take over enabled state
+systemctl is-enabled fluentd
+
 # Test: service status
 systemctl status --no-pager fluentd # Migration process starts the service automatically
 sudo systemctl enable --now fluentd

--- a/fluent-package/yum/systemd-test/update-from-v4.sh
+++ b/fluent-package/yum/systemd-test/update-from-v4.sh
@@ -43,7 +43,7 @@ systemctl is-enabled fluentd
 
 # Test: service status
 systemctl status --no-pager fluentd # Migration process starts the service automatically
-sudo systemctl enable --now fluentd
+sudo systemctl enable fluentd # Enable the unit name alias
 systemctl status --no-pager td-agent
 
 # Test: config migration

--- a/fluent-package/yum/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
@@ -42,7 +42,7 @@ systemctl status --no-pager fluentd # Migration process starts the service autom
 # Test: take over enabled state
 systemctl is-enabled fluentd
 
-sudo systemctl enable --now fluentd
+sudo systemctl enable fluentd # Enable the unit name alias
 systemctl status --no-pager td-agent
 
 # Make a dummy pacakge for the next version

--- a/fluent-package/yum/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
@@ -38,6 +38,10 @@ systemctl status --no-pager td-agent
 package="/host/${distribution}/${DISTRIBUTION_VERSION}/x86_64/Packages/fluent-package-[0-9]*.rpm"
 sudo $DNF install -y $package
 systemctl status --no-pager fluentd # Migration process starts the service automatically
+
+# Test: take over enabled state
+systemctl is-enabled fluentd
+
 sudo systemctl enable --now fluentd
 systemctl status --no-pager td-agent
 

--- a/fluent-package/yum/systemd-test/update-to-next-version.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version.sh
@@ -42,7 +42,6 @@ next_package=$(find rpmbuild -name "*.rpm")
 sudo $DNF install -y ./$next_package
 # Test: take over enabled state
 systemctl is-enabled fluentd
-sudo systemctl enable --now fluentd
 systemctl status --no-pager fluentd
 
 # Test: migration process from v4 must not be done

--- a/fluent-package/yum/systemd-test/update-to-next-version.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version.sh
@@ -40,6 +40,8 @@ next_package=$(find rpmbuild -name "*.rpm")
 
 # Install the dummy package of the next version
 sudo $DNF install -y ./$next_package
+# Test: take over enabled state
+systemctl is-enabled fluentd
 sudo systemctl enable --now fluentd
 systemctl status --no-pager fluentd
 


### PR DESCRIPTION
In the previous versions, the enabled service status of td-agent was not migrated.

This commit try to take over existing td-agent service status.

Note that if systemctl enable fluentd is executed in %post section, it was reverted in td-agent's %preun scriptlet.
So it is enabled in %posttrans explicitly.

Closes: #610 