### PR TITLE
ci: use the last supported version on each distribution to fix failure

### DIFF
--- a/fluent-package/apt/ubuntu-focal/Dockerfile
+++ b/fluent-package/apt/ubuntu-focal/Dockerfile
@@ -54,7 +54,7 @@ RUN \
   apt clean && \
   # raise IPv4 priority
   sed -i'' -e 's,#precedence ::ffff:0:0/96  100,precedence ::ffff:0:0/96  100,' /etc/gai.conf && \
-  # enable multiplatform feature
-  gem install --no-document --install-dir /usr/share/rubygems-integration/all bundler builder && \
+  # enable multiplatform feature (bundler 2.4.22 is the latest version which supports ruby 2.6)
+  gem install --no-document --install-dir /usr/share/rubygems-integration/all bundler:2.4.22 builder && \
   rm -rf /var/lib/apt/lists/* && \
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/fluent-package/yum/amazonlinux-2/Dockerfile
+++ b/fluent-package/yum/amazonlinux-2/Dockerfile
@@ -50,7 +50,7 @@ RUN \
   amazon-linux-extras install ruby2.6 && \
   # raise IPv4 priority
   echo "precedence ::ffff:0:0/96 100" > /etc/gai.conf && \
-  # enable multiplatform feature
-  gem install --no-document bundler builder && \
+  # enable multiplatform feature (bundler 2.4.22 is the latest version which supports ruby 2.6)
+  gem install --no-document bundler:2.4.22 builder && \
   yum clean ${quiet} all && \
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/fluent-package/yum/centos-7/Dockerfile
+++ b/fluent-package/yum/centos-7/Dockerfile
@@ -52,8 +52,8 @@ RUN \
     cmake3 && \
   # raise IPv4 priority
   echo "precedence ::ffff:0:0/96 100" > /etc/gai.conf && \
-  # enable multiplatform feature
-  source /opt/rh/rh-ruby26/enable && gem install --no-document --install-dir /opt/rh/rh-ruby26/root/usr/share/gems bundler builder && \
+  # enable multiplatform feature (bundler 2.4.22 is the latest version which supports ruby 2.6)
+  source /opt/rh/rh-ruby26/enable && gem install --no-document --install-dir /opt/rh/rh-ruby26/root/usr/share/gems bundler:2.4.22 builder && \
   scl enable devtoolset-11 bash && \
   yum clean ${quiet} all && \
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION
There are some distribution which can't support the latest version of bundler because the version of ruby is 2.6.