### PR TITLE
deb rpm: quote target files

### DIFF
--- a/fluent-package/apt/systemd-test/update-from-v4.sh
+++ b/fluent-package/apt/systemd-test/update-from-v4.sh
@@ -19,6 +19,14 @@ sudo apt install -V -y td-agent=${td_agent_version}-1
 
 systemctl status --no-pager td-agent
 
+# Generate garbage files
+touch /etc/td-agent/a\ b\ c
+touch /var/log/td-agent/a\ b\ c.log
+touch /etc/td-agent/plugin/in_fake.rb
+for d in $(seq 1 10); do
+    touch /var/log/td-agent/$d.log
+done
+
 # Install the current
 sudo apt install -V -y \
     /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb
@@ -40,10 +48,15 @@ test -h /etc/td-agent
 test -h /etc/fluent/fluentd.conf
 test $(readlink "/etc/fluent/fluentd.conf") = "/etc/fluent/td-agent.conf"
 test -e /etc/td-agent/td-agent.conf
+test -e /etc/fluent/a\ b\ c
+test -e /etc/fluent/plugin/in_fake.rb
 
 # Test: log file migration
 test -h /var/log/td-agent
 test -e /var/log/td-agent/td-agent.log
+for d in $(seq 1 10); do
+    test -e /var/log/fluent/$d.log
+done
 
 # Test: bin file migration
 test -h /usr/sbin/td-agent

--- a/fluent-package/apt/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
+++ b/fluent-package/apt/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
@@ -19,6 +19,14 @@ sudo apt install -V -y td-agent=${td_agent_version}-1
 
 systemctl status --no-pager td-agent
 
+# Generate garbage files
+touch /etc/td-agent/a\ b\ c
+touch /var/log/td-agent/a\ b\ c.log
+touch /etc/td-agent/plugin/in_fake.rb
+for d in $(seq 1 10); do
+    touch /var/log/td-agent/$d.log
+done
+
 # Install the current
 sudo apt install -V -y \
     /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb
@@ -49,9 +57,13 @@ test -h /etc/td-agent
 test -h /etc/fluent/fluentd.conf
 test $(readlink "/etc/fluent/fluentd.conf") = "/etc/fluent/td-agent.conf"
 test -e /etc/td-agent/td-agent.conf
+test -e /etc/fluent/plugin/in_fake.rb
 
 # Test: keep compatibility with v4: symlinks for log files
 test -h /var/log/td-agent
+for d in $(seq 1 10); do
+    test -e /var/log/fluent/$d.log
+done
 
 # Test: keep compatibility with v4: symlinks for bin files
 test -h /usr/sbin/td-agent

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postinst
@@ -74,13 +74,16 @@ migration_from_v4_main_process() {
             echo "Migrating from /etc/<%= compat_package_dir %>/<%= compat_service_name %>.conf to /etc/<%= package_dir %>/<%= compat_service_name %>.conf"
             cp -f /etc/<%= compat_package_dir %>/<%= compat_service_name %>.conf /etc/<%= package_dir %>/<%= compat_service_name %>.conf
         fi
-        for d in $(ls /etc/<%= compat_package_dir %>); do
-            if [ ! "$d" = "plugin" -a ! "$d" = "<%= compat_service_name %>.conf" ]; then
-                # except managed under deb files must be migrated
-                mv -f /etc/<%= compat_package_dir %>/$d /etc/<%= package_dir %>/
-            fi
-        done
-        if [ $create_link_for_config = "y" ]; then
+	if [ -n "$(ls /etc/<%= compat_package_dir %>/)" ]; then
+	    for d in /etc/<%= compat_package_dir %>/*; do
+		if [ ! "$d" = "/etc/<%= compat_package_dir %>/plugin" -a ! "$d" = "/etc/<%= compat_package_dir %>/<%= compat_service_name %>.conf" ]; then
+                    # except managed under deb files must be migrated
+		    echo "Migrating from /etc/<%= compat_package_dir %>/$d to /etc/<%= package_dir %>/..."
+                    mv -f "$d" /etc/<%= package_dir %>/
+		fi
+	    done
+        fi
+	if [ $create_link_for_config = "y" ]; then
             rm -f /etc/<%= package_dir %>/<%= service_name %>.conf
             ln -sf /etc/<%= package_dir %>/<%= compat_service_name %>.conf /etc/<%= package_dir %>/<%= service_name %>.conf
         fi
@@ -103,12 +106,16 @@ migration_from_v4_main_process() {
                 mv -f /var/log/<%= compat_package_dir %>/buffer/* /var/log/<%= package_dir %>/buffer/
             fi
         fi
-        for d in $(ls /var/log/<%= compat_package_dir %>); do
-            if [ ! "$d" = "buffer" ]; then
-                # except /var/log/<%= compat_package_dir %>/buffer must be migrated
-                mv -f /var/log/<%= compat_package_dir %>/$d /var/log/<%= package_dir %>/
-            fi
-        done
+        # except /var/log/<%= compat_package_dir %>/buffer must be migrated
+	if [ -n "$(ls /var/log/<%= compat_package_dir %>/)" ]; then
+	    for d in /var/log/<%= compat_package_dir %>/*; do
+		if [ ! "$d" = "/var/log/<%= compat_package_dir %>/buffer" ]; then
+                    # except /var/log/<%= compat_package_dir %>/buffer must be migrated
+		    echo "Migrating from /var/log/<%= compat_package_dir %>/$d to /var/log/<%= package_dir %>/..."
+                    mv -f "$d" /var/log/<%= package_dir %>/
+		fi
+            done
+	fi
     fi
 }
 

--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -197,12 +197,15 @@ if [ $1 -eq 1 ]; then
     if [ -f /etc/@COMPAT_PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.conf -a ! -e /etc/@COMPAT_PACKAGE_DIR@/@SERVICE_NAME@.conf ]; then
       create_link_for_config=y
     fi
-    for d in /etc/@COMPAT_PACKAGE_DIR@/*; do
-      if [ ! "$d" == "/etc/@COMPAT_PACKAGE_DIR@/plugin" ]; then
-        echo "Migrating from $d to /etc/@PACKAGE_DIR@/..."
-        mv -f $d /etc/@PACKAGE_DIR@/
-      fi
-    done
+    if [ -n "$(ls /etc/@COMPAT_PACKAGE_DIR@/)" ]; then
+	for d in /etc/@COMPAT_PACKAGE_DIR@/*; do
+            if [ ! "$d" = "/etc/@COMPAT_PACKAGE_DIR@/plugin" ]; then
+		# except managed under deb files must be migrated
+		echo "Migrating from /etc/@COMPAT_PACKAGE_DIR@/$d to /etc/<%= package_dir %>/..."
+		mv -f "$d" /etc/@PACKAGE_DIR@/
+            fi
+	done
+    fi
     if [ $create_link_for_config = "y" ]; then
       rm -f /etc/@PACKAGE_DIR@/@SERVICE_NAME@.conf
       ln -sf /etc/@PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.conf /etc/@PACKAGE_DIR@/@SERVICE_NAME@.conf
@@ -236,12 +239,15 @@ if [ $1 -eq 1 ]; then
     if [ -d /var/log/@COMPAT_PACKAGE_DIR@/buffer -a -n "$(ls /var/log/@COMPAT_PACKAGE_DIR@/buffer)" ]; then
       mv -f /var/log/@COMPAT_PACKAGE_DIR@/buffer/* /var/log/@PACKAGE_DIR@/buffer/
     fi
-    for d in /var/log/@COMPAT_PACKAGE_DIR@/*; do
-      if [ ! "$d" == "/var/log/@COMPAT_PACKAGE_DIR@/buffer" ]; then
-        # /var/log/@COMPAT_PACKAGE_DIR@/buffer will be removed from td-agent
-        mv -f $d /var/log/@PACKAGE_DIR@/
-      fi
-    done
+    # migrate log files except owned buffer
+    if [ -n "$(ls /var/log/@COMPAT_PACKAGE_DIR@/)" ]; then
+	for d in /var/log/@COMPAT_PACKAGE_DIR@/*; do
+	    if [ ! "$d" == "/var/log/@COMPAT_PACKAGE_DIR@/buffer" ]; then
+		# /var/log/@COMPAT_PACKAGE_DIR@/buffer will be removed from td-agent
+		mv -f "$d" /var/log/@PACKAGE_DIR@/
+	    fi
+	done
+    fi
     if [ -f /var/log/@PACKAGE_DIR@/@COMPAT_SERVICE_NAME@.log ]; then
       # Backup the config since RPM removes the file if it is not edited.
       if [ -f /etc/logrotate.d/@COMPAT_SERVICE_NAME@ ]; then

--- a/fluent-package/yum/systemd-test/update-from-v4.sh
+++ b/fluent-package/yum/systemd-test/update-from-v4.sh
@@ -34,6 +34,14 @@ sudo $DNF install -y td-agent-${td_agent_version}-1.*.x86_64
 sudo systemctl enable --now td-agent
 systemctl status --no-pager td-agent
 
+# Generate garbage files
+touch /etc/td-agent/a\ b\ c
+touch /var/log/td-agent/a\ b\ c.log
+touch /etc/td-agent/plugin/in_fake.rb
+for d in $(seq 1 10); do
+    touch /var/log/td-agent/$d.log
+done
+
 # Install the current
 sudo $DNF install -y \
     /host/${distribution}/${DISTRIBUTION_VERSION}/x86_64/Packages/fluent-package-[0-9]*.rpm
@@ -51,10 +59,16 @@ test -h /etc/td-agent
 test -h /etc/fluent/fluentd.conf
 test $(readlink "/etc/fluent/fluentd.conf") = "/etc/fluent/td-agent.conf"
 test -e /etc/td-agent/td-agent.conf
+test -e /etc/fluent/a\ b\ c
+test -e /etc/fluent/plugin/in_fake.rb
 
 # Test: log file migration
 test -h /var/log/td-agent
 test -e /var/log/td-agent/td-agent.log
+test -e /var/log/fluent/a\ b\ c.log
+for d in $(seq 1 10); do
+    test -e /var/log/fluent/$d.log
+done
 
 # Test: bin file migration
 test -h /usr/sbin/td-agent

--- a/fluent-package/yum/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
@@ -34,6 +34,14 @@ sudo $DNF install -y td-agent-${td_agent_version}-1.*.x86_64
 sudo systemctl enable --now td-agent
 systemctl status --no-pager td-agent
 
+# Generate garbage files
+touch /etc/td-agent/a\ b\ c
+touch /var/log/td-agent/a\ b\ c.log
+touch /etc/td-agent/plugin/in_fake.rb
+for d in $(seq 1 10); do
+    touch /var/log/td-agent/$d.log
+done
+
 # Install the current
 package="/host/${distribution}/${DISTRIBUTION_VERSION}/x86_64/Packages/fluent-package-[0-9]*.rpm"
 sudo $DNF install -y $package
@@ -83,9 +91,14 @@ test -h /etc/td-agent
 test -h /etc/fluent/fluentd.conf
 test $(readlink "/etc/fluent/fluentd.conf") = "/etc/fluent/td-agent.conf"
 test -e /etc/td-agent/td-agent.conf
+test -e /etc/fluent/a\ b\ c
+test -e /etc/fluent/plugin/in_fake.rb
 
 # Test: keep compatibility with v4: symlinks for log files
 test -h /var/log/td-agent
+for d in $(seq 1 10); do
+    test -e /var/log/fluent/$d.log
+done
 
 # Test: keep compatibility with v4: symlinks for bin files
 test -h /usr/sbin/td-agent


### PR DESCRIPTION
There was a case that missing quote about file name causes migration failures.

* No quote under /etc/td-agent/'PATH_WITH_SPACE'
* No quote under /var/log/td-agent/'PATH_WITH_SPACE'

Usually such files should not be generated, but need to care it in practical use case.