### PR TITLE
linux: guard launching duplicated fluentd instance with same configuration

### DIFF
--- a/fluent-package/apt/systemd-test/install-newly.sh
+++ b/fluent-package/apt/systemd-test/install-newly.sh
@@ -28,6 +28,14 @@ sudo fluent-gem install fluent-plugin-concat
 /opt/fluent/bin/fluent-diagtool -t fluentd -o /tmp
 test $(find /tmp/ -name gem_local_list.output | xargs cat) = "fluent-plugin-concat"
 
+# Test: Guard duplicated instance
+if [ "$1" = "local" ]; then
+    # FIXME: until guard feature was released, skip v5 and lts.
+    (! sudo /usr/sbin/fluentd)
+    (! sudo /usr/sbin/fluentd -v)
+    sudo /usr/sbin/fluentd --dry-run
+fi
+
 sudo apt remove -y fluent-package
 
 case ${code_name} in

--- a/fluent-package/apt/systemd-test/update-from-v4.sh
+++ b/fluent-package/apt/systemd-test/update-from-v4.sh
@@ -84,6 +84,12 @@ sudo fluent-gem install fluent-plugin-concat
 /opt/fluent/bin/fluent-diagtool -t fluentd -o /tmp
 test $(find /tmp/ -name gem_local_list.output | xargs cat) = "fluent-plugin-concat"
 
+# Test: Guard duplicated instance
+(! sudo /usr/sbin/fluentd)
+(! sudo /usr/sbin/td-agent)
+(! sudo /usr/sbin/fluentd -v)
+sudo /usr/sbin/fluentd --dry-run
+
 # Uninstall
 sudo apt remove -y fluent-package
 (! systemctl status --no-pager td-agent)

--- a/fluent-package/apt/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
+++ b/fluent-package/apt/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
@@ -80,6 +80,12 @@ sleep 3
 test -e /var/log/fluent/fluentd.log
 (! grep -e '\[error\]' -e '\[fatal\]' /var/log/fluent/fluentd.log)
 
+# Test: Guard duplicated instance
+(! sudo /usr/sbin/fluentd)
+(! sudo /usr/sbin/td-agent)
+(! sudo /usr/sbin/fluentd -v)
+sudo /usr/sbin/fluentd --dry-run
+
 # Uninstall
 sudo apt remove -y fluent-package
 (! systemctl status --no-pager td-agent)

--- a/fluent-package/apt/systemd-test/update-to-next-version.sh
+++ b/fluent-package/apt/systemd-test/update-to-next-version.sh
@@ -49,6 +49,12 @@ sleep 3
 test -e /var/log/fluent/fluentd.log
 (! grep -q -e '\[warn\]' -e '\[error\]' -e '\[fatal\]' /var/log/fluent/fluentd.log)
 
+# Test: Guard duplicated instance
+(! sudo /usr/sbin/fluentd)
+(! sudo /usr/sbin/td-agent)
+(! sudo /usr/sbin/fluentd -v)
+sudo /usr/sbin/fluentd --dry-run
+
 # Uninstall
 sudo apt remove -y fluent-package
 (! systemctl status --no-pager td-agent)

--- a/fluent-package/templates/usr/sbin/fluentd.erb
+++ b/fluent-package/templates/usr/sbin/fluentd.erb
@@ -16,7 +16,7 @@ end
 if RUBY_PLATFORM =~ /linux/
   prevent_duplicate_launch = system("systemctl", "is-active", "fluentd", out: IO::NULL)
   if prevent_duplicate_launch
-    unless ARGV.include?("-c") or ARGV.include?("--config") or ARGV.include?("--dry-run")
+    if ["-c", "--config", "--dry-run"].none? {|allowing_opt| ARGV.include? allowing_opt}
       puts("Error: Can't start duplicate Fluentd instance with the default config.")
       if ARGV.include?("-v")
         puts("To take the version, please use '--version', not '-v' ('--verbose').")

--- a/fluent-package/templates/usr/sbin/fluentd.erb
+++ b/fluent-package/templates/usr/sbin/fluentd.erb
@@ -19,7 +19,7 @@ if RUBY_PLATFORM =~ /linux/
     unless ARGV.include?("-c") or ARGV.include?("--config") or ARGV.include?("--dry-run")
       puts("Error: Can't start duplicate Fluentd instance with the default config.")
       if ARGV.include?("-v")
-	puts("To take the version, please use '--version', not '-v' ('--verbose').")
+        puts("To take the version, please use '--version', not '-v' ('--verbose').")
       end
       puts <<EOS
 To start Fluentd, please do one of the following:

--- a/fluent-package/templates/usr/sbin/fluentd.erb
+++ b/fluent-package/templates/usr/sbin/fluentd.erb
@@ -12,4 +12,38 @@ if ARGV.include?("--version")
   puts "fluent-package #{PACKAGE_VERSION} fluentd #{Fluent::VERSION} (#{FLUENTD_REVISION})"
   exit 0
 end
+
+class DuplicateInstanceChecker
+  def running_fluentd?
+    `systemctl is-active fluentd`
+    return true if $?.exitstatus == 0
+    false
+  end
+
+  def prevent_duplicate_launch?
+    unless running_fluentd?
+      return false
+    end
+    true
+  end
+end
+
+if RUBY_PLATFORM =~ /linux/
+  checker = DuplicateInstanceChecker.new
+  if checker.prevent_duplicate_launch?
+    unless ARGV.include?("-c") or ARGV.include?("--config") or ARGV.include?("--dry-run")
+      puts("Error: Can't start duplicate Fluentd instance with the default config.")
+      if ARGV.include?("-v")
+	puts("To take the version, please use '--version', not '-v' ('--verbose').")
+      end
+      puts <<EOS
+To start Fluentd, please do one of the following:
+(Caution: Please be careful not to start multiple instances with the same config.)
+- Stop the Fluentd service 'fluentd'.
+- Specify the config path explicitly by '-c' ('--config').
+EOS
+      exit 2
+    end
+  end
+end
 load "<%= install_path %>/bin/fluentd"

--- a/fluent-package/templates/usr/sbin/fluentd.erb
+++ b/fluent-package/templates/usr/sbin/fluentd.erb
@@ -13,24 +13,9 @@ if ARGV.include?("--version")
   exit 0
 end
 
-class DuplicateInstanceChecker
-  def running_fluentd?
-    `systemctl is-active fluentd`
-    return true if $?.exitstatus == 0
-    false
-  end
-
-  def prevent_duplicate_launch?
-    unless running_fluentd?
-      return false
-    end
-    true
-  end
-end
-
 if RUBY_PLATFORM =~ /linux/
-  checker = DuplicateInstanceChecker.new
-  if checker.prevent_duplicate_launch?
+  prevent_duplicate_launch = system("systemctl", "is-active", "fluentd", out: IO::NULL)
+  if prevent_duplicate_launch
     unless ARGV.include?("-c") or ARGV.include?("--config") or ARGV.include?("--dry-run")
       puts("Error: Can't start duplicate Fluentd instance with the default config.")
       if ARGV.include?("-v")

--- a/fluent-package/yum/systemd-test/install-newly.sh
+++ b/fluent-package/yum/systemd-test/install-newly.sh
@@ -51,6 +51,10 @@ if [ $1 = "local" ]; then
     sudo $DNF install -y tar findutils
     sudo /opt/fluent/bin/fluent-diagtool -t fluentd -o /tmp
     test $(find /tmp/ -name gem_local_list.output | xargs cat) = "fluent-plugin-concat"
+    # FIXME: until guard feature was released, skip v5 and lts.
+    (! sudo /usr/sbin/fluentd)
+    (! sudo /usr/sbin/fluentd -v)
+    sudo /usr/sbin/fluentd --dry-run
 fi
 
 sudo $DNF remove -y fluent-package

--- a/fluent-package/yum/systemd-test/update-from-v4.sh
+++ b/fluent-package/yum/systemd-test/update-from-v4.sh
@@ -96,6 +96,12 @@ sudo fluent-gem install fluent-plugin-concat
 sudo /opt/fluent/bin/fluent-diagtool -t fluentd -o /tmp
 test $(find /tmp/ -name gem_local_list.output | xargs cat) = "fluent-plugin-concat"
 
+# Test: Guard duplicated instance
+(! sudo /usr/sbin/fluentd)
+(! sudo /usr/sbin/td-agent)
+(! sudo /usr/sbin/fluentd -v)
+sudo /usr/sbin/fluentd --dry-run
+
 # Uninstall
 sudo $DNF remove -y fluent-package
 sudo systemctl daemon-reload

--- a/fluent-package/yum/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
@@ -115,6 +115,12 @@ sudo fluent-gem install fluent-plugin-concat
 sudo /opt/fluent/bin/fluent-diagtool -t fluentd -o /tmp
 test $(find /tmp/ -name gem_local_list.output | xargs cat) = "fluent-plugin-concat"
 
+# Test: Guard duplicated instance
+(! sudo /usr/sbin/fluentd)
+(! sudo /usr/sbin/td-agent)
+(! sudo /usr/sbin/fluentd -v)
+sudo /usr/sbin/fluentd --dry-run
+
 # Uninstall
 sudo $DNF remove -y fluent-package
 (! systemctl status --no-pager td-agent)

--- a/fluent-package/yum/systemd-test/update-to-next-version.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version.sh
@@ -73,6 +73,12 @@ sudo fluent-gem install fluent-plugin-concat
 sudo /opt/fluent/bin/fluent-diagtool -t fluentd -o /tmp
 test $(find /tmp/ -name gem_local_list.output | xargs cat) = "fluent-plugin-concat"
 
+# Test: Guard duplicated instance
+(! sudo /usr/sbin/fluentd)
+(! sudo /usr/sbin/td-agent)
+(! sudo /usr/sbin/fluentd -v)
+sudo /usr/sbin/fluentd --dry-run
+
 # Uninstall
 sudo $DNF remove -y fluent-package
 sudo systemctl daemon-reload


### PR DESCRIPTION
linux: guard duplicated instance (not adding a new option)

Closes: #611 

Before:

We can launch Fluentd by /usr/sbin/fluentd even though fluentd service
is running.

Launching multiple Fluentd with the same config may cause
inconsistency of the buffers or the pos files.

After:

We can't launch Fluentd by /usr/sbin/fluentd with the default config
path if fluentd service is running.  If one of the following options is
specified, we can execute fluentd as before.

* --config (-c)
* --dry-run

```
$ sudo /usr/sbin/fluentd 
Error: Can't start duplicate Fluentd instance with the default config.
To start Fluentd, please do one of the following:
(Caution: Please be careful not to start multiple instances with the same config.)
- Stop the Fluentd service 'fluentd'.
- Specify the config path explicitly by '-c' ('--config').
```

