### PR TITLE
Add a patch for RubyInstaller to avoid crash on start up

### DIFF
--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -791,8 +791,17 @@ class BuildTask
       dependency = Gem::Dependency.new('', version_condition)
       if dependency.match?('', ruby_version)
         patch_path = File.join(__dir__, "patches", patch_name)
-        cd(ruby_lib_dir) do
-          sh("ridk", "exec", "patch", "-p2", "--input=#{patch_path}")
+        if patch_name.start_with?("rubyinstaller/")
+          # Patches for RubyInstaller's binary package
+          base_dir = fluent_package_staging_dir
+          strip_level = 1
+        else
+          # patches for Ruby source tree
+          base_dir = ruby_lib_dir
+          strip_level = 2
+        end
+        cd(base_dir) do
+          sh("ridk", "exec", "patch", "-p#{strip_level}", "--input=#{patch_path}")
         end
       end
     end

--- a/fluent-package/config.rb
+++ b/fluent-package/config.rb
@@ -35,10 +35,8 @@ BUNDLED_RUBY_PATCHES = [
 BUNDLED_RUBY_INSTALLER_X64_VERSION = "3.2.2-1"
 BUNDLED_RUBY_INSTALLER_X64_SHA256SUM = "1f0f55ba0790676be6d701515a244159e9ca2d6314f1101560e3e8a277a2661e"
 
-# Patch files are assumed to be for Ruby's source tree, then applied to
-# lib/ruby/x.y.0 in RubyInstaller. So that "-p2" options will be passed
-# to patch command.
+# Files under rubyinstaller/ are patches for RubyInstaller's binary package.
+# Other patches for Ruby's source tree which can be shared with BUNDLED_RUBY_PATCHES.
 BUNDLED_RUBY_INSTALLER_PATCHES = [
-  # An example entry:
-  # ["ruby-3.0/0001-ruby-resolv-Fix-confusion-of-received-response-messa.patch", ["= 3.0.1"]],
+  ["rubyinstaller/0001-Avoid-crash-on-invalid-registry-key-while-detecting-.patch", [">= 0"]],
 ]

--- a/fluent-package/patches/rubyinstaller/0001-Avoid-crash-on-invalid-registry-key-while-detecting-.patch
+++ b/fluent-package/patches/rubyinstaller/0001-Avoid-crash-on-invalid-registry-key-while-detecting-.patch
@@ -1,0 +1,29 @@
+From c034595bc14c6862e2b83a0be48a3751cf1e350b Mon Sep 17 00:00:00 2001
+From: Takuro Ashie <ashie@clear-code.com>
+Date: Tue, 20 Feb 2024 12:03:20 +0900
+Subject: [PATCH] Avoid crash on invalid registry key while detecting MSYS2
+ installation
+
+https://github.com/oneclick/rubyinstaller2/issues/372
+
+Signed-off-by: Takuro Ashie <ashie@clear-code.com>
+---
+ .../3.2.0/ruby_installer/runtime/msys2_installation.rb          | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/lib/ruby/site_ruby/3.2.0/ruby_installer/runtime/msys2_installation.rb b/lib/ruby/site_ruby/3.2.0/ruby_installer/runtime/msys2_installation.rb
+index cbd48981..83ab7ce0 100644
+--- a/lib/ruby/site_ruby/3.2.0/ruby_installer/runtime/msys2_installation.rb
++++ b/lib/ruby/site_ruby/3.2.0/ruby_installer/runtime/msys2_installation.rb
+@@ -86,6 +86,8 @@ module Runtime # Rewrite from D:/a/rubyinstaller2/rubyinstaller2/lib/ruby_instal
+                 # Ignore entries without valid installer data or broken character encoding
+               end
+             end
++          rescue Encoding::InvalidByteSequenceError, Encoding::UndefinedConversionError
++            # Avoid crash even if subkey includes inconvertible characters to internal encoding
+           end
+         rescue Win32::Registry::Error
+         end
+-- 
+2.34.1
+


### PR DESCRIPTION
When a non-ASCII key exists under the registry key `SOFTWARE/Microsoft/Windows/CurrentVersion/Uninstall/`, Fluentd fails to start workers due to `Encoding::UndefinedConversionError`. This patch avoid this issue.

Fix #616