### PR TITLE
msi: guard duplicated instance

### DIFF
--- a/fluent-package/msi/assets/fluentd.bat
+++ b/fluent-package/msi/assets/fluentd.bat
@@ -14,13 +14,33 @@ set PATH=%FLUENT_PACKAGE_TOPDIR%;%PATH%
 set "FLUENT_CONF=%FLUENT_PACKAGE_TOPDIR%/etc/fluent/fluentd.conf"
 set "FLUENT_PLUGIN=%FLUENT_PACKAGE_TOPDIR%/etc/fluent/plugin"
 set "FLUENT_PACKAGE_VERSION=%FLUENT_PACKAGE_TOPDIR%/bin/fluent-package-version.rb"
+set FLUENT_FORCE_RUN=0
+set FLUENT_ARGS=
 for %%p in (%*) do (
     if "%%p"=="--version" (
         ruby "%FLUENT_PACKAGE_VERSION%"
         goto last
     )
+    if "%%p"=="--force-running-multiple-instance" (
+        set /a FLUENT_FORCE_RUN=1
+    ) else (
+        set "FLUENT_ARGS=!FLUENT_ARGS! %%p"
+    )
 )
-"%FLUENT_PACKAGE_TOPDIR%/bin/fluentd" %*
+
+@rem Abort if the fluentdwinsvc service is running without --force option.
+sc query fluentdwinsvc | findstr RUNNING > nul
+if !ERRORLEVEL! equ 0 (
+    if %FLUENT_FORCE_RUN% equ 1 (
+        goto noguard
+    ) else (
+        echo Error: can't start duplicate Fluentd instance. Use --force-running-multiple-instance option explicitly.
+        exit /b 2
+    )
+)
+
+:noguard
+"%FLUENT_PACKAGE_TOPDIR%/bin/fluentd" %FLUENT_ARGS%
 endlocal
 
 :last

--- a/fluent-package/msi/assets/fluentd.bat
+++ b/fluent-package/msi/assets/fluentd.bat
@@ -11,9 +11,9 @@ set FLUENT_PACKAGE_TOPDIR=!FLUENT_PACKAGE_TOPDIR:\=/!
 
 set PATH=%FLUENT_PACKAGE_TOPDIR%bin;%PATH%
 set PATH=%FLUENT_PACKAGE_TOPDIR%;%PATH%
-set "FLUENT_CONF=%FLUENT_PACKAGE_TOPDIR%/etc/fluent/fluentd.conf"
-set "FLUENT_PLUGIN=%FLUENT_PACKAGE_TOPDIR%/etc/fluent/plugin"
-set "FLUENT_PACKAGE_VERSION=%FLUENT_PACKAGE_TOPDIR%/bin/fluent-package-version.rb"
+set "FLUENT_CONF=%FLUENT_PACKAGE_TOPDIR%etc/fluent/fluentd.conf"
+set "FLUENT_PLUGIN=%FLUENT_PACKAGE_TOPDIR%etc/fluent/plugin"
+set "FLUENT_PACKAGE_VERSION=%FLUENT_PACKAGE_TOPDIR%bin/fluent-package-version.rb"
 set FLUENT_FORCE_RUN=0
 set FLUENT_ARGS=
 for %%p in (%*) do (

--- a/fluent-package/msi/update-from-v4-test.ps1
+++ b/fluent-package/msi/update-from-v4-test.ps1
@@ -50,3 +50,11 @@ $output_files_after_sleep = Get-ChildItem "C:\\opt\\td-agent\\output"
 If ($output_files_after_sleep.Count -le $output_files.Count) {
     [Environment]::Exit(1)
 }
+
+# Test: Abort if FLUENT_CONF is conflict with fluentdopt
+$proc = Start-Process "C:\\opt\\fluent\\fluentd.bat" -Wait -NoNewWindow -PassThru
+if ($proc.ExitCode -ne 2) {
+    Write-Host "Failed to abort when already fluentdwinsvc service is running"
+    [Environment]::Exit(1)
+}
+Write-Host "Succeeded to abort if trying to launch multiple Fluentd instance"


### PR DESCRIPTION
msi: guard multiple Fluentd instance

Before:

      Even though fluentdwinsvc is running, you can execute duplicated
      Fluentd instance.
      It may cause inconsistency of buffer or pos file.

After:

      Guard multiple Fluentd instance when fluendwinsvc service is
      running by default.

      Note that --force option is specified, you can run additional
      Fluentd instance explicitly. (it is same as previous behavior)
