### PR TITLE
ci: use last end of version for CI

### DIFF
--- a/fluent-package/apt/commonvar.sh
+++ b/fluent-package/apt/commonvar.sh
@@ -2,7 +2,7 @@ code_name=$(lsb_release --codename --short)
 architecture=$(dpkg --print-architecture)
 repositories_dir=/fluentd/fluent-package/apt/repositories
 java_jdk=openjdk-11-jre
-td_agent_version=4.5.1
+td_agent_version=4.5.2
 case ${code_name} in
   xenial)
     distribution=ubuntu

--- a/fluent-package/msi/update-from-v4-test.ps1
+++ b/fluent-package/msi/update-from-v4-test.ps1
@@ -3,8 +3,8 @@ $ProgressPreference = 'SilentlyContinue'
 Set-PSDebug -Trace 1
 
 # Install v4
-Invoke-WebRequest "https://s3.amazonaws.com/packages.treasuredata.com/4/windows/td-agent-4.5.1-x64.msi" -OutFile "td-agent-4.5.1-x64.msi"
-Start-Process msiexec -ArgumentList "/i", "td-agent-4.5.1-x64.msi", "/quiet" -Wait -NoNewWindow
+Invoke-WebRequest "https://s3.amazonaws.com/packages.treasuredata.com/4/windows/td-agent-4.5.2-x64.msi" -OutFile "td-agent-4.5.2-x64.msi"
+Start-Process msiexec -ArgumentList "/i", "td-agent-4.5.2-x64.msi", "/quiet" -Wait -NoNewWindow
 Start-Sleep 30 # Must wait until all processes are surely started.
 $test_setting = @'
 <source>


### PR DESCRIPTION
The last version of td-agent v4 is 4.5.2.