### PR TITLE
github: use stable actions/download-artifact@v4

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -119,10 +119,10 @@ jobs:
             test-lxc-image: ubuntu:22.04
     steps:
       - uses: actions/checkout@master
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v4
         with:
           name: packages-${{ matrix.rake-job }}
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v4
         with:
           name: packages-apt-source-${{ matrix.rake-job }}
       - uses: canonical/setup-lxd@v0.1.1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@master
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v4
         with:
           name: packages-macos
       - name: Run test

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           rake yum:build YUM_TARGETS=${{ matrix.rake-job }}
       - name: Upload fluent-package rpm
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
           name: packages-${{ matrix.rake-job }}
           path: fluent-package/yum/repositories
@@ -112,7 +112,7 @@ jobs:
             test-lxc-image: images:amazonlinux/2023
     steps:
       - uses: actions/checkout@master
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v4
         with:
           name: packages-${{ matrix.rake-job }}
       - uses: canonical/setup-lxd@v0.1.1
@@ -138,7 +138,7 @@ jobs:
             test-lxc-image: images:almalinux/9
     steps:
       - uses: actions/checkout@master
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v4
         with:
           name: packages-${{ matrix.rake-job }}
       - uses: canonical/setup-lxd@v0.1.1


### PR DESCRIPTION
actions/download-artifact@master branch is already deprecated and switched to main branch. 
(master branch is 121 commits behind main)

There is no need to always dare to follow main branch, so use stable v4 release.