### PR TITLE
td-agent-v4: Backport #620

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Treasure Agent 4 changelog
 
+## Release v4.5.3 for Windows - 2024/02/29
+
+### News
+
+* This release is only for Windows, to fix failure launching worker process when
+  non-ASCII registry key exists (#616).
+
 ## Release v4.5.2 - 2023/11/29
 
 ### News

--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -841,8 +841,17 @@ class BuildTask
       dependency = Gem::Dependency.new('', version_condition)
       if dependency.match?('', ruby_version)
         patch_path = File.join(__dir__, "patches", patch_name)
-        cd(ruby_lib_dir) do
-          sh("ridk", "exec", "patch", "-p2", "--input=#{patch_path}")
+        if patch_name.start_with?("rubyinstaller/")
+          # Patches for RubyInstaller's binary package
+          base_dir = td_agent_staging_dir
+          strip_level = 1
+        else
+          # patches for Ruby source tree
+          base_dir = ruby_lib_dir
+          strip_level = 2
+        end
+        cd(base_dir) do
+          sh("ridk", "exec", "patch", "-p#{strip_level}", "--input=#{patch_path}")
         end
       end
     end

--- a/td-agent/config.rb
+++ b/td-agent/config.rb
@@ -41,10 +41,10 @@ BUNDLED_RUBY_INSTALLER_X64_SHA256SUM = "6958f62524da23d5956851a4e4488a5184c605e9
 #BUNDLED_RUBY_INSTALLER_X64_VERSION = "3.1.4-1"
 #BUNDLED_RUBY_INSTALLER_X64_SHA256SUM = "6701088607ea4b587a31af76d75cb3fe9f7bcd75fc175cffcca22369ebb6331d"
 
-# Patch files are assumed to be for Ruby's source tree, then applied to
-# lib/ruby/x.y.0 in RubyInstaller. So that "-p2" options will be passed
-# to patch command.
+# Files under rubyinstaller/ are patches for RubyInstaller's binary package.
+# Other patches are for Ruby's source tree which can be shared with BUNDLED_RUBY_PATCHES.
 BUNDLED_RUBY_INSTALLER_PATCHES = [
   ["ruby-3.0/0001-ruby-resolv-Fix-confusion-of-received-response-messa.patch", ["= 2.7.3"]],
   ["ruby-3.0/0001-ruby-resolv-Fix-confusion-of-received-response-messa.patch", ["= 3.0.1"]],
+  ["rubyinstaller/0001-Avoid-crash-on-invalid-registry-key-while-detecting-.patch", [">= 2.7.8"]],
 ]

--- a/td-agent/config.rb
+++ b/td-agent/config.rb
@@ -1,5 +1,5 @@
 PACKAGE_NAME = "td-agent"
-PACKAGE_VERSION = "4.5.2"
+PACKAGE_VERSION = "4.5.3"
 
 FLUENTD_REVISION = 'd3cf2e0f95a0ad88b9897197db6c5152310f114f' # v1.16.3
 FLUENTD_LOCAL_GEM_REPO = "file://" + File.expand_path(File.join(__dir__, "local_gem_repo"))

--- a/td-agent/debian/changelog
+++ b/td-agent/debian/changelog
@@ -1,3 +1,9 @@
+td-agent (4.5.3-1) unstable; urgency=low
+
+  * New upstream release.
+
+ -- Takuro Ashie <ashie@clear-code.com>  Thu, 29 Feb 2024 01:56:09 -0000
+
 td-agent (4.5.2-1) unstable; urgency=low
 
   * New upstream release.

--- a/td-agent/patches/rubyinstaller/0001-Avoid-crash-on-invalid-registry-key-while-detecting-.patch
+++ b/td-agent/patches/rubyinstaller/0001-Avoid-crash-on-invalid-registry-key-while-detecting-.patch
@@ -1,0 +1,29 @@
+From dce1859255d8f0710e38282ba3a54a1d46e910e0 Mon Sep 17 00:00:00 2001
+From: Takuro Ashie <ashie@clear-code.com>
+Date: Thu, 29 Feb 2024 09:31:22 +0900
+Subject: [PATCH] Avoid crash on invalid registry key while detecting MSYS2
+ installation
+
+https://github.com/oneclick/rubyinstaller2/issues/372
+
+Signed-off-by: Takuro Ashie <ashie@clear-code.com>
+---
+ .../2.7.0/ruby_installer/runtime/msys2_installation.rb          | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/lib/ruby/site_ruby/2.7.0/ruby_installer/runtime/msys2_installation.rb b/lib/ruby/site_ruby/2.7.0/ruby_installer/runtime/msys2_installation.rb
+index e9ce60d5..d5f78eac 100644
+--- a/lib/ruby/site_ruby/2.7.0/ruby_installer/runtime/msys2_installation.rb
++++ b/lib/ruby/site_ruby/2.7.0/ruby_installer/runtime/msys2_installation.rb
+@@ -78,6 +78,8 @@ module Runtime # Rewrite from D:/a/rubyinstaller2/rubyinstaller2/lib/ruby_instal
+                 # Ignore entries without valid installer data or broken character encoding
+               end
+             end
++          rescue Encoding::InvalidByteSequenceError, Encoding::UndefinedConversionError
++            # Avoid crash even if subkey includes inconvertible characters to internal encoding
+           end
+         rescue Win32::Registry::Error
+         end
+-- 
+2.34.1
+

--- a/td-agent/yum/td-agent.spec.in
+++ b/td-agent/yum/td-agent.spec.in
@@ -261,6 +261,9 @@ fi
 # NOTE: %{_tmpfilesdir} is available since CentOS 7
 %attr(0755,td-agent,td-agent) %dir /tmp/@PACKAGE@
 %changelog
+* Thu Feb 29 2024 Takuro Ashie <ashie@clear-code.com> - 4.5.3-1
+- New upstream release.
+
 * Wed Nov 22 2023 Takuro Ashie <ashie@clear-code.com> - 4.5.2-1
 - New upstream release.
 


### PR DESCRIPTION
When a non-ASCII key exists under the registry key `SOFTWARE/Microsoft/Windows/CurrentVersion/Uninstall/`, Fluentd fails to start workers due to `Encoding::UndefinedConversionError`. This patch avoid this issue.

Backported from v5.0.3: #620