### PR TITLE
msi: fix slow start issue on Windows

### DIFF
--- a/fluent-package/Gemfile
+++ b/fluent-package/Gemfile
@@ -31,11 +31,19 @@ if ENV["INSTALL_GEM_FROM_LOCAL_REPO"]
   # into managed Gemfile.lock
   source FLUENTD_LOCAL_GEM_REPO do
     gem "fluentd"
+    # Bundle forked version of win32-service until
+    # https://github.com/chef/win32-service/pull/85 is merged.
+    # This workaround should be applied to fluent-package not to block starting
+    # fluentdwinsvc service on Windows. See
+    # https://github.com/fluent/fluent-package-builder/issues/618
+    # NOTE: platforms: does not work in source ... do block
+    gem "win32-service" if RUBY_PLATFORM =~ /mswin|mingw/
   end
 else
   # Lock to specific revision
   git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
   gem "fluentd", github: "fluent/fluentd", ref: FLUENTD_REVISION
+  gem "win32-service", github: "fluent-plugins-nursery/win32-service", branch: "fluent-package", platforms: [:mingw, :x64_mingw]
 end
 
 # plugin gems
@@ -81,7 +89,8 @@ gem "ffi-win32-extensions", "1.0.4", platforms: windows_platforms
 gem "nokogiri", "1.15.5", platforms: windows_platforms
 gem "win32-event", "0.6.3", platforms: windows_platforms
 gem "win32-ipc", "0.7.0", platforms: windows_platforms
-gem "win32-service", "2.3.2", platforms: windows_platforms
+# Use officially released version when PR was merged and released.
+#gem "win32-service", "2.3.2", platforms: windows_platforms
 gem "winevt_c", "0.10.1", platforms: windows_platforms
 gem "win32-eventlog", "0.6.7", platforms: windows_platforms
 gem "fluent-plugin-parser-winevt_xml", "0.2.6", platforms: windows_platforms

--- a/fluent-package/Gemfile.lock
+++ b/fluent-package/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/fluent-plugins-nursery/win32-service
+  revision: cfcc2007b3843127329d6a7307a62a927a714327
+  branch: fluent-package
+  specs:
+    win32-service (2.3.2)
+      ffi
+      ffi-win32-extensions
+
+GIT
   remote: https://github.com/fluent/fluentd
   revision: d3cf2e0f95a0ad88b9897197db6c5152310f114f
   ref: d3cf2e0f95a0ad88b9897197db6c5152310f114f
@@ -257,9 +266,6 @@ GEM
       ffi
     win32-ipc (0.7.0)
       ffi
-    win32-service (2.3.2)
-      ffi
-      ffi-win32-extensions
     winevt_c (0.10.1)
     yajl-ruby (1.4.3)
     zip-zip (0.3)
@@ -333,7 +339,7 @@ DEPENDENCIES
   win32-event (= 0.6.3)
   win32-eventlog (= 0.6.7)
   win32-ipc (= 0.7.0)
-  win32-service (= 2.3.2)
+  win32-service!
   winevt_c (= 0.10.1)
   yajl-ruby (= 1.4.3)
 

--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -177,6 +177,7 @@ class DownloadTask
   attr_reader :file_jemalloc_source
   attr_reader :file_ruby_source, :file_ruby_installer_x64
   attr_reader :file_fluentd_archive
+  attr_reader :file_win32_service_archive
   attr_reader :files_ruby_gems
   attr_reader :file_openssl_source
 
@@ -199,6 +200,7 @@ class DownloadTask
     define_jemalloc_file
     define_ruby_files
     define_fluentd_archive
+    define_win32_service_archive if windows?
     define_gem_files
     define_openssl_file
 
@@ -210,7 +212,10 @@ class DownloadTask
       task :ruby => [@file_ruby_source, @file_ruby_installer_x64]
 
       desc "Clone fluentd repository and create a tarball"
-      task :fluentd => @file_fluentd_archive
+      task :fluentd => [@file_fluentd_archive]
+
+      desc "Clone win32-service repository and create a tarball"
+      task :win32_service => [@file_win32_service_archive]
 
       desc "Download ruby gems"
       task :ruby_gems => @files_ruby_gems
@@ -318,6 +323,21 @@ class DownloadTask
     end
   end
 
+  def define_win32_service_archive
+    @file_win32_service_archive = File.join(DOWNLOADS_DIR, "win32-service.tar.gz")
+    file @file_win32_service_archive do
+      ensure_directory(DOWNLOADS_DIR) do
+        dirname = "win32-service"
+        rm_rf(dirname) if File.exist?(dirname)
+        sh("git", "clone", "https://github.com/fluent-plugins-nursery/win32-service.git")
+        cd("win32-service") do
+          sh("git", "checkout", "fluent-package")
+        end
+        sh(*tar_command, "cvfz", "#{dirname}.tar.gz", dirname)
+      end
+    end
+  end
+
   def define_gem_files
     paths = []
     Dir.glob("#{DOWNLOADS_DIR}/*.gem") do |path|
@@ -407,7 +427,7 @@ class BuildTask
       end
 
       desc "Install ruby gems"
-      task :ruby_gems => [:"download:ruby_gems", :fluentd] do
+      task :ruby_gems => windows? ? [:"download:ruby_gems", :fluentd, :win32_service] : [:"download:ruby_gems", :fluentd] do
         gem_install("bundler", BUNDLER_VERSION)
 
         gem_home = ENV["GEM_HOME"]
@@ -435,6 +455,19 @@ class BuildTask
             sh("rake", "build")
             setup_local_gem_repo
             install_gemfiles
+          end
+        end
+      end
+
+      desc "Install win32-service"
+      task :win32_service => [:"download:win32_service"] do
+        cd(DOWNLOADS_DIR) do
+          tar_options = ["--no-same-owner", "--force-local"]
+          archive_path = @download_task.file_win32_service_archive
+          sh(*tar_command, "xvf", archive_path, *tar_options) unless File.exist?("win32-service")
+          cd("win32-service") do
+            sh("rake", "build")
+            setup_local_gem_repo
           end
         end
       end

--- a/serverspec/windows/td-agent.rb
+++ b/serverspec/windows/td-agent.rb
@@ -3,6 +3,8 @@ set :backend, :cmd
 set :os, :family => 'windows'
 require "bundler"
 require "win32/service"
+require "find"
+require "digest/md5"
 
 config_path = File.join(File.dirname(File.dirname(File.dirname(__FILE__))),
                         "fluent-package/config.rb")
@@ -32,5 +34,15 @@ end
 describe "win32-service" do
   it "fluentdwinsvc" do
     expect(Win32::Service.services.collect(&:service_name).include?('fluentdwinsvc')).to eq true
+  end
+
+  it "forked version" do
+    Find.find("c:/opt/fluent/lib/ruby/gems") do |f|
+      if f.end_with?("win32-service-2.3.2/lib/win32/daemon.rb")
+        expect(Digest::MD5.file(f).to_s).to eq "3cb1461c18ab2fd1e39d61c3169ac671".force_encoding("US-ASCII")
+      elsif f.end_with?("win32-service-2.3.2/lib/win32/windows/functions.rb")
+        expect(Digest::MD5.file(f).to_s).to eq "c40427a92dc1a7b6ba7808410535dd00".force_encoding("US-ASCII")
+      end
+    end
   end
 end


### PR DESCRIPTION
Until https://github.com/chef/win32-service/pull/85 is merged,
use forked version of win32-service.

This fix should be applied to fluent-package not to block starting
fluentdwinsvc service on Windows.

See https://github.com/fluent/fluent-package-builder/issues/618

Closes: #630

NOTE: even though just putting the following line
does not install forked version of win32-service, so
install it explicitly as same as fluentd gem.

```
  gem "win32-service", github: "fluent-plugins-nursery/win32-service",
  branch: "fluent-package", platforms: [:mingw, :x64_mingw]
```
