### PR TITLE
deb: enable building fluent-lts-apt-source package

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -51,6 +51,11 @@ jobs:
         with:
           name: packages-apt-source-${{ matrix.rake-job }}
           path: fluent-apt-source/apt/repositories
+      - name: Upload fluent-lts-apt-source deb
+        uses: actions/upload-artifact@master
+        with:
+          name: packages-lts-apt-source-${{ matrix.rake-job }}
+          path: fluent-lts-apt-source/apt/repositories
       # TODO move the following steps to "Test" job
       - name: Check Package Size
         run: |

--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,8 @@ PACKAGES = [
 ]
 
 APT_SOURCE_PACKAGES = [
-  "fluent-apt-source"
+  "fluent-apt-source",
+  "fluent-lts-apt-source",
 ]
 
 ALL_PACKAGE = [


### PR DESCRIPTION
In the previous versions, fluent-lts-apt-source package was built manually and integrated into repository.

Now it will be built with apt:build rake task.