### PR TITLE
apt: do not copy fluent-lts-apt-source under fluent-apt-source/

### DIFF
--- a/fluent-package/convert-artifacts-layout.sh
+++ b/fluent-package/convert-artifacts-layout.sh
@@ -43,7 +43,9 @@ case $1 in
 			     -exec cp {} $ARTIFACTS_DIR/5/debian/$d/pool/contrib/f/fluent-lts-apt-source \;
 		    else
 			mkdir -p $ARTIFACTS_DIR/5/debian/$d/pool/contrib/f/fluent-apt-source
-			find $REPOSITORY_PATH/debian/pool/$d -name 'fluent*-apt-source*.deb' -not -name '*dbgsym*' \
+			find $REPOSITORY_PATH/debian/pool/$d -name 'fluent*-apt-source*.deb' \
+			     -not -name '*dbgsym*' \
+			     -not -name 'fluent-lts*' \
 			     -exec cp {} $ARTIFACTS_DIR/5/debian/$d/pool/contrib/f/fluent-apt-source \;
 		    fi
 		    ;;
@@ -62,6 +64,7 @@ case $1 in
 		    else
 			mkdir -p $ARTIFACTS_DIR/5/ubuntu/$d/pool/contrib/f/fluent-apt-source
 			find $REPOSITORY_PATH/ubuntu/pool/$d -name 'fluent*-apt-source*.deb' \
+			     -not -name 'fluent-lts*' \
 			     -exec cp {} $ARTIFACTS_DIR/5/ubuntu/$d/pool/contrib/f/fluent-apt-source \;
 		    fi
 		    ;;


### PR DESCRIPTION
In the previous versions, 'fluent*-apt-source*.deb' matches not only fluent-apt-source and fluentd-apt-source, but also matches fluent-lts-apt-source.

fluent-lts-apt-source should not put under contrib/f/fluent-apt-source because aptly raises exception when fluent-lts-apt-source is placed under contrib/f/fluent-apt-source/.