### PR TITLE
CI: Check time to start service on Windows

### DIFF
--- a/fluent-package/msi/install-test.ps1
+++ b/fluent-package/msi/install-test.ps1
@@ -4,14 +4,35 @@ $msi = ((Get-Item "C:\\fluentd\\fluent-package\\msi\\repositories\\fluent-packag
 Write-Host "Installing ${msi} ..."
 
 Start-Process msiexec -ArgumentList "/i", $msi, "/quiet" -Wait -NoNewWindow
-Start-Service fluentdwinsvc
+$initialStatus = (Get-Service fluentdwinsvc).Status
+if ($initialStatus -ne "Stopped") {
+    Write-Host "The initial status must be 'Stopped', but it was '${initialStatus}'."
+    [Environment]::Exit(1)
+}
 
 $ENV:PATH="C:\\opt\\fluent\\bin;" + $ENV:PATH
 $ENV:PATH="C:\\opt\\fluent;" + $ENV:PATH
 
 td-agent --version
 
-Start-Sleep 3
+# https://github.com/fluent/fluent-package-builder/issues/618
+$thresholdSeconds = 6
+Write-Host "Measuring times to start the service..."
+$timeSpans = 0..2 | % {
+    Measure-Command { Start-Service fluentdwinsvc }
+    Start-Sleep 15
+    Stop-Service fluentdwinsvc
+    Start-Sleep 15
+}
+Write-Host "Measured seconds to start the service:"
+$timeSpans | %{ Write-Host $_.TotalSeconds }
+if (($timeSpans | Measure-Object -Property TotalSeconds -Maximum).Maximum -gt $thresholdSeconds) {
+    # It should be 0.5s ~ 3s because starting service should be done immediately.
+    # (The only things that take time are starting Ruby and loading the libraries.)
+    Write-Host "Launching is abnormally slow. (The max value is greater than ${thresholdSeconds}s)"
+    [Environment]::Exit(1)
+}
+
 Get-ChildItem "C:\\opt\\fluent\\*.log" | %{
     if (Select-String -Path $_ -Pattern "[warn]", "[error]", "[fatal]" -SimpleMatch -Quiet) {
         Write-Host "There are abnormal level logs in ${_}:"


### PR DESCRIPTION
Add a test for

* #618

On v5.0.2, I have confirmed it takes 4.6s ~ 6.7s.

https://github.com/daipom/fluent-package-builder/actions/runs/8417853364/job/23047108305#step:7:168

On the master, it takes less than 1s.

https://github.com/daipom/fluent-package-builder/actions/runs/8417835331/job/23047050065#step:7:167