### PR TITLE
github: update remote image server

### DIFF
--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -130,6 +130,10 @@ jobs:
         with:
           name: packages-${{ matrix.rake-job }}
       - uses: canonical/setup-lxd@v0.1.1
+      - name: Update image server
+        run: |
+          lxc remote remove images
+          lxc remote add images https://images.lxd.canonical.com --protocol=simplestreams
       - name: Run Test ${{ matrix.test-file }} on ${{ matrix.test-lxc-image }}
         run: fluent-package/yum/systemd-test/test.sh ${{ matrix.test-lxc-image }} ${{ matrix.test-file }}
 


### PR DESCRIPTION
Since the Linux Containers project has made the decision to phase out access to linuxcontainers.org image server for LXD users, so we need to switch to new image server to use cgroup v1 images.

See
* https://discuss.linuxcontainers.org/t/important-notice-for-lxd-users-image-server/18479
* https://discourse.ubuntu.com/t/new-lxd-image-server-available-images-lxd-canonical-com/43824