### PR TITLE
msi: refactor exectuion bat files

### DIFF
--- a/fluent-package/msi/assets/fluent-gem.bat
+++ b/fluent-package/msi/assets/fluent-gem.bat
@@ -1,4 +1,6 @@
 @echo off
+setlocal
+
 if "%~nx0" == "td-agent-gem.bat" (
   set "FLUENT_PACKAGE_TOPDIR=%~dp0..\"
 ) else (
@@ -10,3 +12,5 @@ for /f "usebackq" %%i in (`^""%FLUENT_PACKAGE_BINDIR%\ruby.exe" -rrbconfig -e "p
 set "GEM_HOME=%FLUENT_PACKAGE_TOPDIR%lib\ruby\gems\%RUBY_VERSION%"
 set "GEM_PATH=%FLUENT_PACKAGE_TOPDIR%lib\ruby\gems\%RUBY_VERSION%"
 "%FLUENT_PACKAGE_BINDIR%\fluent-gem" %*
+
+endlocal

--- a/fluent-package/msi/assets/fluentd.bat
+++ b/fluent-package/msi/assets/fluentd.bat
@@ -1,4 +1,6 @@
 @echo off
+setlocal
+
 if "%~nx0" == "td-agent.bat" (
   set "FLUENT_PACKAGE_TOPDIR=%~dp0..\"
 ) else (
@@ -6,21 +8,25 @@ if "%~nx0" == "td-agent.bat" (
 )
 
 @rem Convert path separator from backslash to forwardslash
-setlocal enabledelayedexpansion
-set FLUENT_PACKAGE_TOPDIR=!FLUENT_PACKAGE_TOPDIR:\=/!
+set FLUENT_PACKAGE_TOPDIR=%FLUENT_PACKAGE_TOPDIR:\=/%
 
 set PATH=%FLUENT_PACKAGE_TOPDIR%bin;%PATH%
 set PATH=%FLUENT_PACKAGE_TOPDIR%;%PATH%
-set "FLUENT_CONF=%FLUENT_PACKAGE_TOPDIR%/etc/fluent/fluentd.conf"
-set "FLUENT_PLUGIN=%FLUENT_PACKAGE_TOPDIR%/etc/fluent/plugin"
-set "FLUENT_PACKAGE_VERSION=%FLUENT_PACKAGE_TOPDIR%/bin/fluent-package-version.rb"
+set "FLUENT_CONF=%FLUENT_PACKAGE_TOPDIR%etc/fluent/fluentd.conf"
+set "FLUENT_PLUGIN=%FLUENT_PACKAGE_TOPDIR%etc/fluent/plugin"
+
+setlocal
+set "FLUENT_PACKAGE_VERSION=%FLUENT_PACKAGE_TOPDIR%bin/fluent-package-version.rb"
 for %%p in (%*) do (
     if "%%p"=="--version" (
         ruby "%FLUENT_PACKAGE_VERSION%"
         goto last
     )
 )
-"%FLUENT_PACKAGE_TOPDIR%/bin/fluentd" %*
+endlocal
+
+"%FLUENT_PACKAGE_TOPDIR%bin/fluentd" %*
+
 endlocal
 
 :last


### PR DESCRIPTION
* Add entire local scope to prevent changing global env vars
* Remove unnecessary enabledelayedexpansion
* Remove unnecessary `/`

# fluentd.bat

Before: `FLUENT_PACKAGE_VERSION`  was passed to Fluentd process.
After: `FLUENT_PACKAGE_VERSION` is not passed to Fluentd process.

# fluent-gem.bat

Previously, it changed the environment variables unintentionally.

Before

```console
> ruby -e "ENV['PATH'].split(';').select{|v| v.include?('fluent')}.map{|v| p v}"
"C:\\opt\\fluent\\"
"C:\\opt\\fluent\\bin"

> fluent-gem --version
3.4.19

> ruby -e "ENV['PATH'].split(';').select{|v| v.include?('fluent')}.map{|v| p v}"
"C:\\opt\\fluent\\bin"
"C:\\opt\\fluent\\"
"C:\\opt\\fluent\\bin"
```

After


```console
> ruby -e "ENV['PATH'].split(';').select{|v| v.include?('fluent')}.map{|v| p v}"
"C:\\opt\\fluent\\"
"C:\\opt\\fluent\\bin"

> fluent-gem --version
3.4.19

> ruby -e "ENV['PATH'].split(';').select{|v| v.include?('fluent')}.map{|v| p v}"
"C:\\opt\\fluent\\"
"C:\\opt\\fluent\\bin"
```