### PR TITLE
msi: guard duplicated instance (not adding a new option)

### DIFF
--- a/fluent-package/msi/assets/fluentd.bat
+++ b/fluent-package/msi/assets/fluentd.bat
@@ -15,12 +15,39 @@ set PATH=%FLUENT_PACKAGE_TOPDIR%;%PATH%
 set "FLUENT_CONF=%FLUENT_PACKAGE_TOPDIR%etc/fluent/fluentd.conf"
 set "FLUENT_PLUGIN=%FLUENT_PACKAGE_TOPDIR%etc/fluent/plugin"
 
-setlocal
+setlocal enabledelayedexpansion
 set "FLUENT_PACKAGE_VERSION=%FLUENT_PACKAGE_TOPDIR%bin/fluent-package-version.rb"
+set PREVENT_DUPLICATE_LAUNCH=1
+set HAS_SHORT_VERBOSE_OPTION=0
+
 for %%p in (%*) do (
     if "%%p"=="--version" (
         ruby "%FLUENT_PACKAGE_VERSION%"
         goto last
+    )
+    if "%%p"=="-c" set PREVENT_DUPLICATE_LAUNCH=0
+    if "%%p"=="--config" set PREVENT_DUPLICATE_LAUNCH=0
+    if "%%p"=="--dry-run" set PREVENT_DUPLICATE_LAUNCH=0
+    if "%%p"=="--reg-winsvc" set PREVENT_DUPLICATE_LAUNCH=0
+    if "%%p"=="--reg-winsvc-fluentdopt" set PREVENT_DUPLICATE_LAUNCH=0
+    if "%%p"=="-v" set HAS_SHORT_VERBOSE_OPTION=1
+)
+
+@rem Abort if the fluentdwinsvc service is running and the config path is not specified.
+if %PREVENT_DUPLICATE_LAUNCH% equ 1 (
+    sc query fluentdwinsvc | findstr RUNNING > nul 2>&1
+    if !ERRORLEVEL! equ 0 (
+        echo Error: Can't start duplicate Fluentd instance with the default config.
+        if %HAS_SHORT_VERBOSE_OPTION% equ 1 (
+            echo.
+            echo To take the version, please use '--version', not '-v' ^('--verbose'^).
+        )
+        echo.
+        echo To start Fluentd, please do one of the following:
+        echo   ^(Caution: Please be careful not to start multiple instances with the same config.^)
+        echo   - Stop the Fluentd Windows service 'fluentdwinsvc'.
+        echo   - Specify the config path explicitly by '-c' ^('--config'^).
+        exit /b 2
     )
 )
 endlocal


### PR DESCRIPTION
# Abstraction

* Partially (msi) solves #611
* Inspired by #622
  * This is another version that does not add a new option and considers some options to skip checking duplicate launches.
* Both #622 and this can be a solution to #611
  * Let's consider how to solve it based on the information so far.

# Spec change

Before:

We can launch Fluentd by fluentd.bat even though fluentdwinsvc is running.
Launching multiple Fluentd with the same config may cause inconsistency of the buffers or the pos files.

After:

We can't launch Fluentd by fluent.bat with the default config path if fluentdwinsvc is running.
If one of the following options is specified, we can execute fluentd.bat as before.

* `--config` (`-c`)
* `--dry-run`
* `--reg-winsvc`
* `--reg-winsvc-fluentdopt`

# Output

When the `fluentdwinsvc` is running, the behavior of `fluentd.bat` is as follows:

```console
> fluentd
Error: Can't start duplicate Fluentd instance with the default config.

To start Fluentd, please do one of the following:
  (Caution: Please be careful not to start multiple instances with the same config.)
  - Stop the Fluentd Windows service 'fluentdwinsvc'.
  - Specify the config path explicitly by '-c' ('--config').

> fluentd -v
Error: Can't start duplicate Fluentd instance with the default config.

To take the version, please use '--version', not '-v' ('--verbose').

To start Fluentd, please do one of the following:
  (Caution: Please be careful not to start multiple instances with the same config.)
  - Stop the Fluentd Windows service 'fluentdwinsvc'.
  - Specify the config path explicitly by '-c' ('--config')
```
