### PR TITLE
github: restrict execution timeout

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     name: Build
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -114,6 +115,7 @@ jobs:
     name: Test
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     name: Build
+    timeout-minutes: 30
     strategy:
       fail-fast: false
     runs-on: macos-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     name: Build
+    timeout-minutes: 90
     strategy:
       fail-fast: false
     runs-on: windows-2019

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     name: Build
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -93,6 +94,7 @@ jobs:
     name: Test (CGroup V1)
     needs: build
     runs-on: ubuntu-20.04
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -141,6 +143,7 @@ jobs:
     name: Test (CGroup V2)
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
There is no need to waste CI resources.

ref.
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes