### PR TITLE
github: drop CentOS 7 from GitHub workflow

### DIFF
--- a/.github/workflows/yum-arm.yml
+++ b/.github/workflows/yum-arm.yml
@@ -8,16 +8,12 @@ jobs:
       fail-fast: false
       matrix:
         label:
-          - CentOS 7 aarch64
           - RockyLinux 8 aarch64
           - AlmaLinux 9 aarch64
           - Amazon Linux 2 aarch64
           # It takes too long time on GitHub Actions.
           #- Amazon Linux 2023 aarch64
         include:
-          - label: CentOS 7 aarch64
-            rake-job: centos-7
-            test-docker-image: centos:7
           - label: RockyLinux 8 aarch64
             rake-job: rockylinux-8
             test-docker-image: rockylinux:8

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -13,16 +13,11 @@ jobs:
       fail-fast: false
       matrix:
         label:
-          - CentOS 7 x86_64
           - RockyLinux 8 x86_64
           - AlmaLinux 9 x86_64
           - Amazon Linux 2 x86_64
           - Amazon Linux 2023 x86_64
         include:
-          - label: CentOS 7 x86_64
-            rake-job: centos-7
-            test-docker-image: centos:7
-            centos-stream: false
           - label: RockyLinux 8 x86_64
             rake-job: rockylinux-8
             test-docker-image: rockylinux/rockylinux:8
@@ -99,7 +94,6 @@ jobs:
       fail-fast: false
       matrix:
         label:
-          - CentOS 7 x86_64
           - AmazonLinux 2 x86_64
           - AmazonLinux 2023 x86_64
         test-file:
@@ -110,9 +104,6 @@ jobs:
           - "install-newly.sh v5"
           - "install-newly.sh lts"
         include:
-          - label: CentOS 7 x86_64
-            rake-job: centos-7
-            test-lxc-image: images:centos/7
           - label: AmazonLinux 2 x86_64
             rake-job: amazonlinux-2
             test-lxc-image: images:amazonlinux/2


### PR DESCRIPTION
CentOS 7 has reached EOL, so drop support for building it.

NOTE: keep build recipe for a while