### PR TITLE
test: fix experimental install test

### DIFF
--- a/fluent-package/test-install-in-docker.sh
+++ b/fluent-package/test-install-in-docker.sh
@@ -59,23 +59,8 @@ exit 0
     su - $USER
 }
 
-function check_installed_version()
-{
-    VERSION=$1
-    case $VERSION in
-	*$TARGET*)
-	    echo "Succeeded to install $TARGET on $ID from $REPO"
-	    ;;
-	*)
-	    echo "Failed to install $TARGET from $REPO"
-	    exit 1
-	    ;;
-    esac
-}
-
 USER=$1
 REPO=$2
-TARGET=$3
 
 DNF=dnf
 
@@ -98,8 +83,6 @@ case $ID in
 		esac
 		sudo apt update
 		sudo apt upgrade -y
-		v=$(apt-cache show fluent-package | grep "^Version" | head -n 1 | cut -d':' -f 2)
-		check_installed_version $v
 		;;
 	esac
 	;;
@@ -118,8 +101,6 @@ case $ID in
  		;;
 	esac
 	$DNF update -y
-	v=$($DNF info fluent-package | grep "^Version" | head -n 1 | cut -d':' -f 2)
-	check_installed_version $v
 	;;
     *amzn*)
 	VERSION_ID=$(cat /etc/os-release | grep VERSION_ID | cut -d'=' -f2)
@@ -153,7 +134,5 @@ case $ID in
 		;;
 	esac
 	$DNF update -y
-	v=$($DNF info fluent-package | grep "^Version" | head -n 1 | cut -d':' -f 2)
-	check_installed_version $v
 	;;
 esac

--- a/fluent-package/test-verify-repo.sh
+++ b/fluent-package/test-verify-repo.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Usage: test-verify-repo.sh 5.0.3
+# Usage: test-verify-repo.sh
 #
 # It try to verify whether fluent-package is installable or not
 # from test/experimental/5, test/experimental/lts/5
@@ -11,7 +11,7 @@ function test_deb() {
     for d in $DEB_TARGETS; do
 	for r in $REPO_TARGETS; do
 	    echo "TEST: on $d $r"
-	    docker run --rm -v $(pwd):/work $d /work/test-install-in-docker.sh $USER $r $VERSION
+	    docker run --rm -v $(pwd):/work $d /work/test-install-in-docker.sh $USER $r
 	    if [ $? -eq 0 ]; then
 		RESULTS="$RESULTS\nOK: $d $r"
 	    else
@@ -25,7 +25,7 @@ function test_rpm() {
     for d in $RPM_TARGETS; do
 	for r in $REPO_TARGETS; do
 	    echo "TEST: on $d $r"
-	    docker run --rm -v $(pwd):/work $d /work/test-install-in-docker.sh $USER $r $VERSION
+	    docker run --rm -v $(pwd):/work $d /work/test-install-in-docker.sh $USER $r
 	    if [ $? -eq 0 ]; then
 		RESULTS="$RESULTS\nOK: $d $r"
 	    else
@@ -34,13 +34,6 @@ function test_rpm() {
 	done
     done
 }
-
-if [ $# -ne 1 ]; then
-    echo "Usage: test-verify-repo 5.0.3"
-    exit 1
-fi
-
-VERSION=$1
 
 if [ -z "$DEB_TARGETS" ]; then
     DEB_TARGETS="debian:bullseye debian:bookworm ubuntu:focal ubuntu:jammy ubuntu:noble"


### PR DESCRIPTION
`TARGET` should not be used anymore.

The current test always installs the current latest version.
After that, the test updates it to the experimental.
So, the `TARGET` is meaningless, and the check always fails.