### PR TITLE
Fix a bug that excessively block to launch

### DIFF
--- a/fluent-package/msi/assets/fluentd.bat
+++ b/fluent-package/msi/assets/fluentd.bat
@@ -30,6 +30,9 @@ for %%p in (%*) do (
     if "%%p"=="--dry-run" set PREVENT_DUPLICATE_LAUNCH=0
     if "%%p"=="--reg-winsvc" set PREVENT_DUPLICATE_LAUNCH=0
     if "%%p"=="--reg-winsvc-fluentdopt" set PREVENT_DUPLICATE_LAUNCH=0
+    if "%%p"=="-h" set PREVENT_DUPLICATE_LAUNCH=0
+    if "%%p"=="--help" set PREVENT_DUPLICATE_LAUNCH=0
+    if "%%p"=="--show-plugin-config" set PREVENT_DUPLICATE_LAUNCH=0
     if "%%p"=="-v" set HAS_SHORT_VERBOSE_OPTION=1
 )
 

--- a/fluent-package/templates/usr/sbin/fluentd.erb
+++ b/fluent-package/templates/usr/sbin/fluentd.erb
@@ -16,7 +16,7 @@ end
 if RUBY_PLATFORM =~ /linux/
   prevent_duplicate_launch = system("systemctl", "is-active", "fluentd", out: IO::NULL)
   if prevent_duplicate_launch
-    if ["-c", "--config", "--dry-run"].none? {|allowing_opt| ARGV.include? allowing_opt}
+    if ["-c", "--config", "--dry-run", "-h", "--help", "--show-plugin-config"].none? {|allowing_opt| ARGV.include? allowing_opt}
       puts("Error: Can't start duplicate Fluentd instance with the default config.")
       if ARGV.include?("-v")
         puts("To take the version, please use '--version', not '-v' ('--verbose').")


### PR DESCRIPTION
In the previous versions, guard duplicated instance mechanism was introduced.

But it should not block -h/--help and so on because user may refer command line option in such a case.