### PR TITLE
deb rpm: group logging

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -71,6 +71,7 @@ jobs:
           docker run \
           --rm \
           --tty \
+          --env CI=true \
           --volume ${PWD}:/fluentd:ro \
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/install-test.sh
@@ -81,6 +82,7 @@ jobs:
           --privileged \
           --rm \
           --tty \
+          --env CI=true \
           --volume ${PWD}:/fluentd:ro \
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/piuparts-test.sh
@@ -90,6 +92,7 @@ jobs:
           docker run \
           --rm \
           --tty \
+          --env CI=true \
           --volume ${PWD}:/fluentd:ro \
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/serverspec-test.sh
@@ -99,6 +102,7 @@ jobs:
           docker run \
           --rm \
           --tty \
+          --env CI=true \
           --volume ${PWD}:/fluentd:ro \
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/confluent-test.sh
@@ -108,6 +112,7 @@ jobs:
           docker run \
           --rm \
           --tty \
+          --env CI=true \
           --volume ${PWD}:/fluentd:ro \
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/binstubs-test.sh

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -61,6 +61,7 @@ jobs:
           docker run \
           --rm \
           --tty \
+          --env CI=true \
           --volume ${PWD}:/fluentd:ro \
           --env CENTOS_STREAM=${{ matrix.centos-stream }} \
           ${{ matrix.test-docker-image }} \
@@ -71,6 +72,7 @@ jobs:
           docker run \
           --rm \
           --tty \
+          --env CI=true \
           --volume ${PWD}:/fluentd:ro \
           --env CENTOS_STREAM=${{ matrix.centos-stream }} \
           ${{ matrix.test-docker-image }} \
@@ -81,6 +83,7 @@ jobs:
           docker run \
           --rm \
           --tty \
+          --env CI=true \
           --volume ${PWD}:/fluentd:ro \
           --env CENTOS_STREAM=${{ matrix.centos-stream }} \
           ${{ matrix.test-docker-image }} \

--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -309,6 +309,7 @@ class DownloadTask
   def define_fluentd_archive
     @file_fluentd_archive = File.join(DOWNLOADS_DIR, "fluentd-#{FLUENTD_REVISION}.tar.gz")
     file @file_fluentd_archive do
+      puts "::group::Create #{@file_fluentd_archive}" if ENV["CI"]
       ensure_directory(DOWNLOADS_DIR) do
         dirname = "fluentd-#{FLUENTD_REVISION}"
         rm_rf("fluentd") if File.exist?("fluentd")
@@ -320,6 +321,7 @@ class DownloadTask
         mv("fluentd", dirname)
         sh(*tar_command, "cvfz", "#{dirname}.tar.gz", dirname)
       end
+      puts "::endgroup::" if ENV["CI"]
     end
   end
 
@@ -428,6 +430,7 @@ class BuildTask
 
       desc "Install ruby gems"
       task :ruby_gems => windows? ? [:"download:ruby_gems", :fluentd, :win32_service] : [:"download:ruby_gems", :fluentd] do
+        puts "::group::Install ruby gems" if ENV["CI"]
         gem_install("bundler", BUNDLER_VERSION)
 
         gem_home = ENV["GEM_HOME"]
@@ -441,10 +444,12 @@ class BuildTask
         # for fat gems which depend on nonexistent libraries
         # mainly for nokogiri 1.11 or later on CentOS 6
         rebuild_gems
+        puts "::endgroup::" if ENV["CI"]
       end
 
       desc "Install fluentd"
       task :fluentd => [:"download:fluentd", windows? ? :rubyinstaller : :ruby] do
+        puts "::group::Install fluentd" if ENV["CI"]
         cd(DOWNLOADS_DIR) do
           archive_path = @download_task.file_fluentd_archive
           fluentd_dir = archive_path.sub(/\.tar\.gz$/, '')
@@ -457,6 +462,7 @@ class BuildTask
             install_gemfiles
           end
         end
+        puts "::endgroup::" if ENV["CI"]
       end
 
       desc "Install win32-service"
@@ -662,6 +668,7 @@ class BuildTask
   end
 
   def build_jemalloc
+    puts "::group::Build jemalloc from source" if ENV["CI"]
     tarball = @download_task.file_jemalloc_source
     source_dir = tarball.sub(/\.tar\.bz2$/, '')
 
@@ -693,6 +700,7 @@ class BuildTask
       sh("./configure", *configure_opts)
       sh("make", "install", "-j#{Etc.nprocessors}", "DESTDIR=#{STAGING_DIR}")
     end
+    puts "::endgroup::" if ENV["CI"]
   end
 
   def openssldir
@@ -731,6 +739,7 @@ class BuildTask
   end
 
   def build_openssl
+    puts "::group::Build openssl from source" if ENV["CI"]
     tarball = @download_task.file_openssl_source
     source_dir = tarball.sub(/\.tar\.gz$/, '')
 
@@ -768,9 +777,11 @@ class BuildTask
       sh("make", "install")
       sh("make", "install", "DESTDIR=#{STAGING_DIR}")
     end
+    puts "::endgroup::" if ENV["CI"]
   end
 
   def build_ruby_from_source
+    puts "::group::Build ruby from source" if ENV["CI"]
     tarball = @download_task.file_ruby_source
     ruby_source_dir = tarball.sub(/\.tar\.gz$/, '')
 
@@ -797,6 +808,7 @@ class BuildTask
       # For building gems. The built ruby & gem command cannot use without install.
       sh("make", "install")
     end
+    puts "::endgroup::" if ENV["CI"]
   end
 
   def extract_ruby_installer
@@ -1104,6 +1116,7 @@ class BuildTask
   end
 
   def remove_needless_files
+    puts "::group::Remove needless files" if ENV["CI"]
     remove_files("#{fluent_package_staging_dir}/bin/jeprof", true) # jemalloc 4 or later
     remove_files("#{fluent_package_staging_dir}/bin/pprof", true) # jemalloc 3
     remove_files("#{fluent_package_staging_dir}/share/doc", true) # Contains only jemalloc.html
@@ -1131,6 +1144,7 @@ class BuildTask
     Dir.glob("#{fluent_package_staging_dir}/**/.git").each do |git_dir|
       remove_files(git_dir, true)
     end
+    puts "::endgroup::" if ENV["CI"]
   end
 
   def render_fluent_package_config(package_type)
@@ -1292,6 +1306,7 @@ EOS
 
   def build_archive
     cd("..") do
+      puts "::group::Create #{@full_archive_name}" if ENV["CI"]
       sh("git", "archive", "HEAD",
          "--prefix", "#{@archive_base_name}/",
          "--output", @full_archive_name)
@@ -1317,6 +1332,7 @@ EOS
       tar_options << "--force-local" if windows?
       sh(*tar_command, "cvfz", @full_archive_name, @archive_base_name, *tar_options)
       rm_rf(@archive_base_name)
+      puts "::endgroup::" if ENV["CI"]
     end
   end
 

--- a/fluent-package/apt/binstubs-test.sh
+++ b/fluent-package/apt/binstubs-test.sh
@@ -2,6 +2,11 @@
 
 set -exu
 
+echo "BINSTUBS TEST"
+if [ "$CI" = "true" ]; then
+   echo "::group::Setup binstubs test"
+fi
+
 apt update
 apt install -V -y lsb-release
 
@@ -10,7 +15,9 @@ apt install -V -y lsb-release
 apt install -V -y \
   ${repositories_dir}/${distribution}/pool/${code_name}/${channel}/*/*/*_${architecture}.deb
 
-echo "BINSTUBS TEST"
+if [ "$CI" = "true" ]; then
+   echo "::endgroup::"
+fi
 /opt/fluent/bin/ruby /fluentd/fluent-package/binstubs-test.rb
 if [ $? -eq 0 ]; then
     echo "Checking existence of binstubs: OK"

--- a/fluent-package/apt/confluent-test.sh
+++ b/fluent-package/apt/confluent-test.sh
@@ -2,6 +2,10 @@
 
 set -exu
 
+if [ "$CI" = "true" ]; then
+   echo "::group::Setup confluent test"
+fi
+
 export DEBIAN_FRONTEND=noninteractive
 
 apt update
@@ -60,6 +64,9 @@ while true ; do
 	exit 1
     fi
 done
+if [ "$CI" = "true" ]; then
+   echo "::endgroup::"
+fi
 /usr/bin/kafka-topics --create --bootstrap-server localhost:9092 --replication-factor 1 --partitions 1 --topic test
 export PATH=/opt/fluent/bin:$PATH
 export INSTALLATION_TEST=true

--- a/fluent-package/apt/install-test.sh
+++ b/fluent-package/apt/install-test.sh
@@ -2,12 +2,12 @@
 
 set -exu
 
-apt update
-apt install -V -y lsb-release
+apt update --quiet
+apt install -V -y --quiet lsb-release
 
 . $(dirname $0)/commonvar.sh
 
-apt install -V -y \
+apt install -V -y --quiet \
   ${repositories_dir}/${distribution}/pool/${code_name}/${channel}/*/*/*_${architecture}.deb
 
 fluentd --version
@@ -44,18 +44,18 @@ case $code_name in
 	;;
 esac
 # TODO: Remove it when v5 repository was deployed
-apt install -y curl
+apt install -y --quiet curl
 curl -O https://packages.treasuredata.com/4/${distribution}/${code_name}/pool/contrib/f/fluentd-apt-source/fluentd-apt-source_2020.8.25-1_all.deb
-apt install -y ./fluentd-apt-source_2020.8.25-1_all.deb
+apt install -y --quiet ./fluentd-apt-source_2020.8.25-1_all.deb
 
 apt clean all
 # Uncomment when v5 repository was deployed
 #apt_source_package=${apt_source_repositories_dir}/${distribution}/pool/${code_name}/${channel}/*/*/fluent-apt-source*_all.deb
 #apt install -V -y ${apt_source_package} ca-certificates
-apt update
-apt install -V -y td-agent
+apt update --quiet
+apt install -V -y --quiet td-agent
 
-apt install -V -y \
+apt install -V -y --quiet \
   ${repositories_dir}/${distribution}/pool/${code_name}/${channel}/*/*/*_${architecture}.deb
 
 getent passwd td-agent >/dev/null

--- a/fluent-package/apt/piuparts-test.sh
+++ b/fluent-package/apt/piuparts-test.sh
@@ -2,6 +2,10 @@
 
 set -exu
 
+if [ "$CI" = "true" ]; then
+   echo "::group::Setup piuparts test"
+fi
+
 apt update
 apt install -V -y lsb-release
 
@@ -29,6 +33,9 @@ package=${repositories_dir}/${distribution}/pool/${code_name}/${channel}/*/*/*_$
 cp ${package} /tmp
 echo "deb [signed-by=/usr/share/keyrings/td-agent-archive-keyring.gpg] https://packages.treasuredata.com/5/${distribution}/${code_name}/ ${code_name} contrib" | tee $CHROOT/etc/apt/sources.list.d/td.list
 rm -rf $CHROOT/opt
+if [ "$CI" = "true" ]; then
+   echo "::endgroup::"
+fi
 piuparts --distribution=${code_name} \
 	 --existing-chroot=${CHROOT} \
 	 --skip-logrotatefiles-test \

--- a/fluent-package/apt/piuparts-test.sh
+++ b/fluent-package/apt/piuparts-test.sh
@@ -6,8 +6,8 @@ if [ "$CI" = "true" ]; then
    echo "::group::Setup piuparts test"
 fi
 
-apt update
-apt install -V -y lsb-release
+apt update --quiet
+apt install -V -y --quiet lsb-release
 
 . $(dirname $0)/commonvar.sh
 
@@ -28,7 +28,7 @@ mkdir -p $CHROOT
 debootstrap --include=ca-certificates ${code_name} $CHROOT ${mirror}
 cp $TD_AGENT_KEYRING $CHROOT/usr/share/keyrings/
 chmod 644 $CHROOT/usr/share/keyrings/td-agent-archive-keyring.gpg
-chroot $CHROOT apt install -V -y libyaml-0-2
+chroot $CHROOT apt install -V -y --quiet libyaml-0-2
 package=${repositories_dir}/${distribution}/pool/${code_name}/${channel}/*/*/*_${architecture}.deb
 cp ${package} /tmp
 echo "deb [signed-by=/usr/share/keyrings/td-agent-archive-keyring.gpg] https://packages.treasuredata.com/5/${distribution}/${code_name}/ ${code_name} contrib" | tee $CHROOT/etc/apt/sources.list.d/td.list

--- a/fluent-package/apt/pkgsize-test.sh
+++ b/fluent-package/apt/pkgsize-test.sh
@@ -4,6 +4,10 @@ set -exu
 
 echo "CHECK PACKAGE SIZE"
 
+if [ "$CI" = "true" ]; then
+   echo "::group::Setup package size check"
+fi
+
 #
 # Usage: $0 ubuntu:focal aarch64
 #
@@ -57,6 +61,10 @@ case ${DISTRIBUTION} in
 	exit 1
 	;;
 esac
+
+if [ "$CI" = "true" ]; then
+   echo "::endgroup::"
+fi
 
 set -e
 

--- a/fluent-package/apt/serverspec-test.sh
+++ b/fluent-package/apt/serverspec-test.sh
@@ -4,6 +4,10 @@ set -exu
 
 export DEBIAN_FRONTEND=noninteractive
 
+if [ "$CI" = "true" ]; then
+   echo "::group::Setup serverspec test"
+fi
+
 apt update
 apt install -V -y lsb-release
 
@@ -13,6 +17,10 @@ apt install -V -y \
   ${repositories_dir}/${distribution}/pool/${code_name}/${channel}/*/*/*_${architecture}.deb
 
 fluentd --version
+
+if [ "$CI" = "true" ]; then
+   echo "::endgroup::"
+fi
 
 export PATH=/opt/fluent/bin:$PATH
 export INSTALLATION_TEST=true

--- a/fluent-package/apt/serverspec-test.sh
+++ b/fluent-package/apt/serverspec-test.sh
@@ -8,12 +8,12 @@ if [ "$CI" = "true" ]; then
    echo "::group::Setup serverspec test"
 fi
 
-apt update
-apt install -V -y lsb-release
+apt update --quiet
+apt install -V -y --quiet lsb-release
 
 . $(dirname $0)/commonvar.sh
 
-apt install -V -y \
+apt install -V -y --quiet \
   ${repositories_dir}/${distribution}/pool/${code_name}/${channel}/*/*/*_${architecture}.deb
 
 fluentd --version

--- a/fluent-package/binstubs-test.rb
+++ b/fluent-package/binstubs-test.rb
@@ -17,7 +17,9 @@ end
 Dir.chdir(STUB_DIR) do
   # Install all stub files which is described in Gemfile
   gem_command = File.join(FLUENT_PACKAGE_DIR, "bin/gem")
+  puts "::group::Create stub files" if ENV["CI"]
   system(gem_command, "pristine", "--all", "--only-executables", "--bindir", "#{STUB_DIR}/bin")
+  puts "::endgroup::" if ENV["CI"]
 
   required_stub_paths = Dir.glob("#{STUB_DIR}/bin/*").each do |stub|
     basename = File.basename(stub)

--- a/fluent-package/debian/rules
+++ b/fluent-package/debian/rules
@@ -13,7 +13,7 @@ override_dh_builddeb:
 
 override_dh_auto_install:
 	rake build:deb_config FLUENT_PACKAGE_STAGING_PATH="$(CURDIR)/debian/tmp" NO_VAR_RUN=1
-	rake build:all        FLUENT_PACKAGE_STAGING_PATH="$(CURDIR)/debian/tmp" PATH="$(HOME)/.cargo/bin:$(PATH)"
+	CI=$CI rake build:all        FLUENT_PACKAGE_STAGING_PATH="$(CURDIR)/debian/tmp" PATH="$(HOME)/.cargo/bin:$(PATH)"
 	dh_installman
 
 override_dh_auto_clean:

--- a/fluent-package/yum/binstubs-test.sh
+++ b/fluent-package/yum/binstubs-test.sh
@@ -9,6 +9,11 @@ set -exu
 # This means that column glitch exists.
 # So, we should remove before "o" character.
 
+echo "BINSTUBS TEST"
+if [ "$CI" = "true" ]; then
+   echo "::group::Setup binstubs test"
+fi
+
 distribution=$(cat /etc/system-release-cpe | awk '{print substr($0, index($1, "o"))}' | cut -d: -f2)
 version=$(cat /etc/system-release-cpe | awk '{print substr($0, index($1, "o"))}' | cut -d: -f4)
 
@@ -58,7 +63,10 @@ ARCH=$(rpm --eval "%{_arch}")
 ${DNF} install -y \
   ${repositories_dir}/${distribution}/${DISTRIBUTION_VERSION}/${ARCH}/Packages/*.rpm
 
-echo "BINSTUBS TEST"
+if [ "$CI" = "true" ]; then
+   echo "::endgroup::"
+fi
+
 /opt/fluent/bin/ruby /fluentd/fluent-package/binstubs-test.rb
 if [ $? -eq 0 ]; then
     echo "Checking existence of binstubs: OK"

--- a/fluent-package/yum/pkgsize-test.sh
+++ b/fluent-package/yum/pkgsize-test.sh
@@ -4,6 +4,10 @@ set -exu
 
 echo "CHECK PACKAGE SIZE"
 
+if [ "$CI" = "true" ]; then
+   echo "::group::Setup package size check"
+fi
+
 #
 # Usage: $0 centos:8 aarch64
 #
@@ -67,6 +71,10 @@ for v in "${PREVIOUS_VERSIONS[@]}"; do
 	break
     fi
 done
+
+if [ "$CI" = "true" ]; then
+   echo "::endgroup::"
+fi
 
 PREVIOUS_SIZE=$(stat -c %s $BASE_NAME)
 THRESHOLD_SIZE=`echo "$PREVIOUS_SIZE * 1.3" | bc -l | cut -d. -f1`

--- a/fluent-package/yum/serverspec-test.sh
+++ b/fluent-package/yum/serverspec-test.sh
@@ -11,6 +11,10 @@ set -exu
 # This means that column glitch exists.
 # So, we should remove before "o" character.
 
+if [ "$CI" = "true" ]; then
+   echo "::group::Setup serverspec test"
+fi
+
 distribution=$(cat /etc/system-release-cpe | awk '{print substr($0, index($1, "o"))}' | cut -d: -f2)
 version=$(cat /etc/system-release-cpe | awk '{print substr($0, index($1, "o"))}' | cut -d: -f4)
 
@@ -131,6 +135,9 @@ EOF
 	done
 	/usr/bin/kafka-topics --bootstrap-server localhost:9092 --topic test --create --replication-factor 1 --partitions 1
 	/usr/sbin/fluentd -c /fluentd/serverspec/test.conf &
+    fi
+    if [ "$CI" = "true" ]; then
+	echo "::endgroup::"
     fi
     export PATH=/opt/fluent/bin:$PATH
     export INSTALLATION_TEST=true

--- a/lib/package-task.rb
+++ b/lib/package-task.rb
@@ -133,6 +133,10 @@ class PackageTask
     if skip_lintian?
       run_command_line.concat(["--env", "LINTIAN=no"])
     end
+    if ENV["CI"]
+      build_command_line.concat(["--build-arg", "CI=yes"])
+      run_command_line.concat(["--env", "CI=true"])
+    end
     if File.exist?(File.join(id, "Dockerfile"))
       docker_context = id
     else


### PR DESCRIPTION
To investigate build log effectively, grouping log is better to do.
