### PR TITLE
deb rpm: add helper script to generate index.html for hosting site

### DIFF
--- a/fluent-package/make-index-html.erb
+++ b/fluent-package/make-index-html.erb
@@ -1,0 +1,50 @@
+<html data-theme="light">
+ <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="light dark">
+    <!-- https://github.com/franciscop/picnic MIT license -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/picnic">
+    <!-- https://github.com/Remix-Design/RemixIcon - Apache 2.0 license -->
+    <link href="https://cdn.jsdelivr.net/npm/remixicon@4.3.0/fonts/remixicon.css" rel="stylesheet"/>
+    <title>Fluent Package - formerly known as Treasure Agent (td-agent)</title>
+ </head>
+ <body>
+   <header>
+     <nav>
+       <a href="#" class="brand">Fluent Package - formerly known as Treasure Agent (td-agent)</a>
+       <div class="menu">
+         <a href="https://www.fluentd.org" class="button icon-puzzle">Fluentd</a>
+       </div>
+     </nav>
+   </header>
+
+   <main class="flex one">
+     <div>
+       <a href="https://www.fluentd.org">
+         <img style="margin: 4em auto 0em 4em" src="https://www.fluentd.org/images/miscellany/fluentd-logo.png">
+       </a>
+     </div>
+     <div style="margin: 0em auto 0em 2em">
+       Index of <a href="index.html"><%= options[:site] %><%= relative_path %></a>
+     </div>
+     <div>
+       <div>
+         <ul style="list-style: none">
+           <% files.each do |file| %>
+             <li><a href="<%= options[:site] %><%= relative_path %>/<%= file %>"><i class="ri-file-download-line"></i> <%= file %></span></a>
+             <%= sprintf("%.2f", File.stat(file).size / 1024 / 1024.0) %> MiB
+             (<%= File.stat(file).mtime.getutc %>)
+           <% end %>
+         </ul>
+       </div>
+     </div>
+   </main>
+   <footer>
+     <div class="flex two">
+       <div></div>
+       <div>Powered by <a href="https://www.cncf.io/">Cloud Native Computing Foundation (CNCF)</div>
+     </div>
+    </footer>
+  </body>
+</html>

--- a/fluent-package/make-index-html.rb
+++ b/fluent-package/make-index-html.rb
@@ -5,12 +5,14 @@ require 'optparse'
 
 options = {
   site: "https://fluentd.cdn.cncf.io",
-  verbose: false
+  verbose: false,
+  channel: %w(5 lts test)
 }
 
 opt = OptionParser.new
 opt.on("-s", "--site URL") { |v| options[:site] = v }
 opt.on("-v", "--verbose") { options[:verbose] = true }
+opt.on("-c", "--channel TARGET_CHANNEL") { |v| options[:channel] = v.split(',') }
 top_dir = opt.parse!(ARGV).first
 
 unless File.exist?(top_dir)
@@ -20,7 +22,7 @@ end
 
 template_path = File.expand_path("#{File.basename(__FILE__, ".rb")}.erb")
 puts "Template path: #{template_path}"
-%w(5 lts test).each do |channel|
+options[:channel].each do |channel|
   search_path = Pathname.new("#{top_dir}/#{channel}")
   Find.find(search_path).each do |path|
     Find.prune unless FileTest.directory?(path)

--- a/fluent-package/make-index-html.rb
+++ b/fluent-package/make-index-html.rb
@@ -6,7 +6,7 @@ require 'optparse'
 options = {
   site: "https://fluentd.cdn.cncf.io",
   verbose: false,
-  channel: %w(5 lts test)
+  channel: "5,lts,test"
 }
 
 opt = OptionParser.new
@@ -22,24 +22,16 @@ end
 
 template_path = File.expand_path("#{File.basename(__FILE__, ".rb")}.erb")
 puts "Template path: #{template_path}"
-options[:channel].each do |channel|
-  search_path = Pathname.new("#{top_dir}/#{channel}")
-  Find.find(search_path).each do |path|
-    Find.prune unless FileTest.directory?(path)
-    Find.prune if path.end_with?("repodata")
-    Find.prune if path.end_with?("dists")
-    if %w(windows x86_64 aarch64 fluent-package).any? { |dir| path.end_with?(dir) }
-      puts "Updating: #{path} ..." if options[:verbose]
-      index_path = File.expand_path(File.join(path, "index.html"))
-      Dir.chdir(path) do
-        files = Dir.glob(["*.deb", "*.msi", "*.rpm"])
-        relative_path = Pathname.new(path).relative_path_from(top_dir).to_s
-        erb = ERB.new(File.read(template_path)).result(binding)
-        File.open(index_path, "w+") do |file|
-          file.puts(erb)
-          puts "Generated: #{index_path}" if options[:verbose]
-        end
-      end
+Dir.glob("#{top_dir}/{#{options[:channel]}}/**/{windows,x86_64,aarch64,fluent-package}/") do |path|
+  puts "Updating: #{path} ..." if options[:verbose]
+  index_path = File.expand_path(File.join(path, "index.html"))
+  Dir.chdir(path) do
+    files = Dir.glob(["*.deb", "*.msi", "*.rpm"])
+    relative_path = Pathname.new(path).relative_path_from(top_dir).to_s
+    erb = ERB.new(File.read(template_path)).result(binding)
+    File.open(index_path, "w+") do |file|
+      file.puts(erb)
+      puts "Generated: #{index_path}" if options[:verbose]
     end
   end
 end

--- a/fluent-package/make-index-html.rb
+++ b/fluent-package/make-index-html.rb
@@ -1,0 +1,49 @@
+require 'erb'
+require 'find'
+require 'pathname'
+require 'optparse'
+
+options = {
+  :site => "https://fluentd.cdn.cncf.io",
+  :verbose => false
+}
+
+opt = OptionParser.new
+opt.on("-s", "--site [URL]") { |v| options[:site] = v }
+opt.on("-v", "--verbose") { |v|
+  options[:verbose] = v
+}
+top_dir = opt.parse!(ARGV).first
+
+unless File.exist?(top_dir)
+  puts "#{top_dir} not found"
+  exit 1
+end
+
+template_path = File.expand_path("#{File.basename(__FILE__, ".rb")}.erb")
+puts "Template path: #{template_path}"
+%w(5 lts test).each do |channel|
+  search_path = Pathname.new("#{top_dir}/#{channel}")
+  Find.find(search_path).each do |path|
+    Find.prune if path.end_with?(".deb")
+    Find.prune if path.end_with?(".msi")
+    Find.prune if path.end_with?(".gz")
+    Find.prune if path.end_with?(".bz2")
+    Find.prune if path.end_with?(".rpm")
+    Find.prune if path.end_with?("repodata")
+    Find.prune if path.end_with?("dists")
+    if %w(windows x86_64 aarch64 fluent-package).any? { |dir| path.end_with?(dir) }
+      puts "Updating: #{path} ..." if options[:verbose]
+      index_path = File.expand_path(File.join(path, "index.html"))
+      Dir.chdir(path) do
+        files = Dir.glob(["*.deb", "*.msi", "*.rpm"])
+        relative_path = path.sub(top_dir, "")
+        erb = ERB.new(File.read(template_path)).result(binding)
+        File.open(index_path, "w+") do |file|
+          file.puts(erb)
+          puts "Generated: #{index_path}" if options[:verbose]
+        end
+      end
+    end
+  end
+end

--- a/fluent-package/make-index-html.rb
+++ b/fluent-package/make-index-html.rb
@@ -10,9 +10,9 @@ options = {
 }
 
 opt = OptionParser.new
-opt.on("-s", "--site URL") { |v| options[:site] = v }
-opt.on("-v", "--verbose") { options[:verbose] = true }
-opt.on("-c", "--channel TARGET_CHANNEL") { |v| options[:channel] = v.split(',') }
+opt.on("-s", "--site URL", "Specify distribution site (e.g. https://fluentd.cdn.cncf.io)") { |v| options[:site] = v }
+opt.on("-v", "--verbose", "Enable verbose logging") { options[:verbose] = true }
+opt.on("-c", "--channel TARGET_CHANNEL", "Specify channel with comma separated (e.g. --channel 5,lts)") { |v| options[:channel] = v }
 top_dir = opt.parse!(ARGV).first
 
 unless File.exist?(top_dir)


### PR DESCRIPTION
Currently, we use https://packages.treasuredata.com hosted on AWS
which is powered by Treasure Data Inc.

Recently, we coordinated with CNCF which provides access to Cloudflare
R2 resource. As no S3Browser functionality, so need to replace it with
alternative index.html.