### PR TITLE
deb rpm: add helper script to generate install script

### DIFF
--- a/fluent-package/make-install-script.erb
+++ b/fluent-package/make-install-script.erb
@@ -1,0 +1,181 @@
+<% if install_info[:distribution] == "redhat" %>
+echo "=============================="
+echo " <%= install_info[:package_name] %> Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install rpm packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+
+  # add GPG key
+  rpm --import <%= install_info[:base_url] %>/GPG-KEY-td-agent
+<% if install_info[:channel_version] >= 5 %>
+  rpm --import <%= install_info[:base_url] %>/GPG-KEY-fluent-package
+<% end %>
+
+<% if install_info[:channel_version] == 5 %>
+  # add <%= install_info[:package_name] %> repository to yum
+<% else %>
+  # add treasure data repository to yum
+<% end %>
+  cat >/etc/yum.repos.d/<%= install_info[:repo_file] %> <<'EOF';
+[<%= install_info[:repo_label] %>]
+name=<%= install_info[:repo_name] %>
+<% if install_info[:channel_version] >= 2 %>
+baseurl=<%= install_info[:base_url] %>/<% if install_info[:lts] %>lts/<% end %><%= install_info[:channel_version] %>/redhat/\$releasever/\$basearch
+<% else %>
+baseurl=<%= install_info[:base_url] %>/redhat/\$basearch
+<% end %>
+<% if install_info[:channel_version] >= 5 %>
+enabled=1
+<% end %>
+gpgcheck=1
+gpgkey=<%= install_info[:base_url] %>/GPG-KEY-td-agent<% if install_info[:old_sha1] %>-old-sha1<% end%>
+<% if install_info[:channel_version] > 4 %>
+       <%= install_info[:base_url] %>/GPG-KEY-fluent-package
+<% end %>
+EOF
+
+  # update your sources
+  yum check-update
+
+  # install the toolbelt
+  yes | yum install -y <%= install_info[:package_name] %>
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""
+<% elsif install_info[:distribution] == 'amazon' %>
+echo "=============================="
+echo " <%= install_info[:package_name] %> Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install rpm packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+
+  # add GPG key
+  rpm --import <%= install_info[:base_url] %>/GPG-KEY-td-agent
+<% if install_info[:channel_version] >= 5 %>
+  rpm --import <%= install_info[:base_url] %>/GPG-KEY-fluent-package
+<% end %>
+
+<% if install_info[:channel_version] == 5 %>
+  # add fluent package repository to yum
+<% else %>
+  # add treasure data repository to yum
+<% end %>
+  cat >/etc/yum.repos.d/<%= install_info[:repo_file] %> <<'EOF';
+[<%= install_info[:repo_label] %>]
+name=<%= install_info[:repo_name] %>
+<% if install_info[:channel_version] == 3 and install_info[:version] <= 2 %>
+baseurl=<%= install_info[:base_url] %>/<% if install_info[:lts] %>lts/<% end %><%= install_info[:channel_version] %>/<%= install_info[:distribution] %>/<%= install_info[:version] %>/\$releasever/\$basearch
+<% else %>
+baseurl=<%= install_info[:base_url] %>/<% if install_info[:lts] %>lts/<% end %><%= install_info[:channel_version] %>/<%= install_info[:distribution] %>/<%= install_info[:version] %>/\$basearch
+<% end %>
+<% if install_info[:channel_version] >= 5 %>
+enabled=1
+<% end %>
+gpgcheck=1
+gpgkey=<%= install_info[:base_url] %>/GPG-KEY-td-agent
+<% if install_info[:channel_version] >= 5 %>
+       <%= install_info[:base_url] %>/GPG-KEY-fluent-package
+<% end %>
+EOF
+
+  # update your sources
+  yum check-update
+
+  # install the toolbelt
+  yes | yum install -y <%= install_info[:package_name] %>
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""
+<% elsif ['debian', 'ubuntu'].include?(install_info[:distribution]) %>
+echo "=============================="
+echo " <%= install_info[:package_name] %> Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+<% if install_info[:channel_version] >= 5 %>
+  # use apt-source package which contains keyring
+  curl -o fluent-apt-source.deb <%= install_info[:base_url] %>/<% if install_info[:lts] %>lts/<% end %><%= install_info[:channel_version] %>/<%= install_info[:distribution] %>/<%= install_info[:version] %>/pool/contrib/f/<%= install_info[:apt_source_deb] %>
+  apt install -y ./fluent-apt-source.deb
+<% elsif install_info[:channel_version] == 4 %>
+<% if install_info[:distribution] == 'ubuntu' and install_info[:version] == 'xenial' %>
+  
+    # Deprecated
+    curl <%= install_info[:base_url] %>/GPG-KEY-td-agent | apt-key add -
+    # add treasure data repository to apt
+    echo "deb <%= install_info[:base_url] %>/4/ubuntu/xenial/ xenial contrib" > /etc/apt/sources.list.d/treasure-data.list
+  
+<% else %>
+  
+    # use apt-source package which contains keyring
+    curl -o td-agent-apt-source.deb <%= install_info[:base_url] %>/<%= install_info[:channel_version] %>/<%= install_info[:distribution] %>/<%= install_info[:version] %>/pool/contrib/f/<%= install_info[:apt_source_deb] %>
+    apt install -y ./td-agent-apt-source.deb
+  
+<% end %>
+<% elsif install_info[:channel_version] >= 2 %>
+  curl <%= install_info[:base_url] %>/GPG-KEY-td-agent | apt-key add -
+
+  # add treasure data repository to apt
+  echo "deb <%= install_info[:base_url] %>/<%= install_info[:channel_version] %>/<%= install_info[:distribution] %>/<%= install_info[:version] %>/ <%= install_info[:version] %> contrib" > /etc/apt/sources.list.d/treasure-data.list
+
+<% elsif install_info[:channel_version] == 1 %>
+  curl <%= install_info[:base_url] %>/GPG-KEY-td-agent-old-sha1 | apt-key add -
+
+  # add treasure data repository to apt
+<% if install_info[:version] == 'lucid' %>
+  echo "deb <%= install_info[:base_url] %>/<%= install_info[:distribution] %>/ <%= install_info[:version] %> contrib" > /etc/apt/sources.list.d/treasure-data.list
+<% else %>
+  echo "deb <%= install_info[:base_url] %>/<%= install_info[:version] %>/ <%= install_info[:version] %> contrib" > /etc/apt/sources.list.d/treasure-data.list
+<% end %>
+
+<% end %>
+  # update your sources
+  <%= install_info[:apt] %> update
+
+  # install the toolbelt
+  <%= install_info[:apt] %> install -y <%= install_info[:package_name] %>
+
+SCRIPT
+
+# message
+<% if install_info[:channel_version] >= 2.5 %>
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi
+<% else %>
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""
+<% end %>
+<% end %>

--- a/fluent-package/make-install-script.rb
+++ b/fluent-package/make-install-script.rb
@@ -1,0 +1,377 @@
+require 'erb'
+require 'pathname'
+require 'optparse'
+require 'open-uri'
+
+#
+# This script generate our install script and replaces the install
+# script which was hosted on https://toolbelt.treasuredata.com/ previously.
+#
+
+options = {
+  site: "https://fluentd.cdn.cncf.io",
+  channel: %w(4 5),
+  verify: false,
+  debug: false
+}
+
+opt = OptionParser.new
+opt.on("-a", "--archive", "Enable archived installed script to verify with") { |v| options[:archive] = true }
+opt.on("-b", "--backup", "Backup original install script (e.g. https://toolbelt.treasuredata.com)") { |v| options[:backup] = true }
+opt.on("-c", "--channel TARGET_CHANNEL", Array, "Specify channel with comma separated (e.g. --channel 4,5)") { |v| options[:channel] = v }
+opt.on("-d", "--debug", "Enable debug logging") { options[:debug] = true }
+opt.on("-s", "--site URL", "Specify distribution site (e.g. https://fluentd.cdn.cncf.io)") { |v| options[:site] = v }
+opt.on("-v", "--verify", "Enable verification mode") { options[:verify] = true }
+top_dir = opt.parse!(ARGV).first
+
+unless File.exist?(top_dir)
+  puts "#{top_dir} not found"
+  exit 1
+end
+
+class FluentInstallScript
+  def initialize(options={})
+    @options = options
+    @package_name = 'fluent-package'
+    @old_package_name = 'td-agent'
+    @repo_file = 'fluent-package.repo'
+    @old_repo_file = 'td.repo'
+    @lts_repo_file = 'fluent-package-lts.repo'
+    @base_url = options[:site]
+    @metadata = {}
+    @template_path = File.expand_path("#{File.basename(__FILE__, ".rb")}.erb")
+    @archive_dir = File.expand_path(File.join(File.dirname(__FILE__), "toolbelt"))
+  end
+
+  def relative_install_script(symbol)
+    script_base = symbol.to_s.gsub(/_/, '-')
+                    .sub(/agent25/, 'agent2.5')
+    "sh/#{script_base}.sh"
+  end
+
+  def setup_metadata
+    @options[:channel].each do |channel|
+      case channel
+      when "5"
+        @metadata.merge!(generate_5x_metadata)
+      when "4"
+        @metadata.merge!(generate_4x_metadata)
+      when "3"
+        @metadata.merge!(generate_3x_metadata)
+      when "2.5"
+        @metadata.merge!(generate_25x_metadata)
+      when "2"
+        @metadata.merge!(generate_2x_metadata)
+      when "1"
+        @metadata.merge!(generate_1x_metadata)
+      end
+    end
+  end
+
+  def backup_install_scripts
+    setup_metadata
+    @metadata.keys.each do |key|
+      install_script_path = relative_install_script(key)
+      previous_script_url = "https://toolbelt.treasuredata.com/#{install_script_path}"
+      puts "Fetch: #{previous_script_url}" if @options[:debug]
+      previous_content = URI.open(previous_script_url) { |f| f.read }
+      backup_script_path = File.expand_path(File.join(@archive_dir, File.basename(install_script_path)))
+      FileUtils.mkdir_p(@archive_dir)
+      File.open(backup_script_path, "w+") do |file|
+        file.puts(previous_content)
+        puts "Generated: #{backup_script_path}" if @options[:debug]
+      end
+    end
+  end
+
+  def previous_script_uri(install_script)
+    if @options[:archive]
+      File.expand_path(@archive_dir, File.basename(install_script))
+    else
+      "https://toolbelt.treasuredata.com/#{install_script}"
+    end
+  end
+
+  def fetch_previous_install_script(install_script)
+    if @options[:archive]
+      install_script_path = File.expand_path(File.join(@archive_dir, File.basename(install_script)))
+      puts "Read: #{install_script_path}" if @options[:debug]
+      content = File.open(install_script_path) { |f| f.read }
+    else
+      previous_script_url = "https://toolbelt.treasuredata.com/#{install_script}"
+      puts "Fetch: #{previous_script_url}" if @options[:debug]
+      content = URI.open(previous_script_url) { |f| f.read }
+    end
+    # reinterpret for newer hosting site
+    content.gsub(/packages.treasuredata.com/, 'fluentd.cdn.cncf.io')
+      .gsub(/http:/, 'https:')
+  end
+
+  def generate_install_scripts(top_dir)
+    setup_metadata
+    puts "Template path: #{@template_path}" if @options[:debug]
+    @metadata.keys.each do |key|
+      install_script_path = File.join(top_dir, relative_install_script(key))
+      install_info = @metadata[key]
+      content = ERB.new(File.read(@template_path), trim_mode: '<>').result(binding)
+      File.open(install_script_path, "w+") do |file|
+        file.puts(content)
+        puts "Generated: #{install_script_path}"
+      end
+      if @options[:verify]
+        previous_content = fetch_previous_install_script(relative_install_script(key))
+        previous_script_path = previous_script_uri(relative_install_script(key))
+        if previous_content != content # ignore newline
+          if @options[:debug]
+            File.open("/tmp/before.txt", "w+") { |f| f.write(previous_content) }
+            File.open("/tmp/after.txt", "w+") { |f| f.write(content) }
+            puts `diff -u /tmp/before.txt /tmp/after.txt`
+          end
+          puts "[NG] Compared with: #{previous_script_path}"
+        else
+          puts "[OK] Compared with: #{previous_script_path}"
+        end
+      end
+    end
+  end
+  
+  def generate_5x_metadata
+    metadata = {}
+    puts "Processing fluent-package 5 ..." if @options[:debug]
+    template = {
+      channel_version: 5,
+      package_name: @package_name,
+      base_url: @base_url
+    }
+    rhel_template = template.merge({
+                                     channel_version: 5,
+                                     distribution: 'redhat',
+                                     repo_label: @package_name,
+                                     repo_file: @repo_file,
+                                     repo_name: 'Fluentd Project',
+                                   })
+    rhel_lts_template = rhel_template.merge({
+                                              repo_file: @lts_repo_file,
+                                              repo_label: "#{@package_name}-lts",
+                                              lts: true
+                                            })
+    debian_template = template.merge({
+                                       distribution: 'debian',
+                                       apt_source_deb: 'fluent-apt-source/fluent-apt-source_2023.6.29-1_all.deb',
+                                       apt: 'apt'
+                                     })
+    ubuntu_template = debian_template.merge({
+                                              distribution: 'ubuntu',
+                                              apt_source_deb: 'fluent-apt-source/fluent-apt-source_2023.6.29-1_all.deb'
+                                            })
+    debian_lts_template = debian_template.merge({
+                                                  apt_source_deb: 'fluent-lts-apt-source/fluent-lts-apt-source_2023.7.29-1_all.deb',
+                                                  lts: true
+                                                })
+    ubuntu_lts_template = ubuntu_template.merge({
+                                                  apt_source_deb: 'fluent-lts-apt-source/fluent-lts-apt-source_2023.7.29-1_all.deb',
+                                                  lts: true
+                                                })
+    metadata.merge!({
+                      install_redhat_fluent_package5: rhel_template,
+                      install_amazon2_fluent_package5: rhel_template.merge({distribution: 'amazon', version: 2}),
+                      install_amazon2023_fluent_package5: rhel_template.merge({distribution: 'amazon', version: 2023}),
+                      install_ubuntu_noble_fluent_package5: ubuntu_template.merge({version: 'noble'}),
+                      install_ubuntu_jammy_fluent_package5: ubuntu_template.merge({version: 'jammy'}),
+                      install_ubuntu_focal_fluent_package5: ubuntu_template.merge({version: 'focal'}),
+                      install_debian_bullseye_fluent_package5: debian_template.merge({version: 'bullseye'}),
+                      install_debian_bookworm_fluent_package5: debian_template.merge({version: 'bookworm'}),
+                      install_redhat_fluent_package5_lts: rhel_lts_template,
+                      install_amazon2_fluent_package5_lts: rhel_lts_template.merge({distribution: 'amazon', version: 2}),
+                      install_amazon2023_fluent_package5_lts: rhel_lts_template.merge({distribution: 'amazon', version: 2023}),
+                      install_ubuntu_noble_fluent_package5_lts: ubuntu_lts_template.merge({version: 'noble'}),
+                      install_ubuntu_jammy_fluent_package5_lts: ubuntu_lts_template.merge({version: 'jammy'}),
+                      install_ubuntu_focal_fluent_package5_lts: ubuntu_lts_template.merge({version: 'focal'}),
+                      install_debian_bullseye_fluent_package5_lts: debian_lts_template.merge({version: 'bullseye'}),
+                      install_debian_bookworm_fluent_package5_lts: debian_lts_template.merge({version: 'bookworm'}),
+                    })
+  end
+
+  def generate_4x_metadata
+    metadata = {}
+    template = {
+      channel_version: 4,
+      package_name: @old_package_name,
+      base_url: @base_url
+    }
+    rhel_template = template.merge({
+                                     distribution: 'redhat',
+                                     repo_file: @old_repo_file,
+                                     repo_label: 'treasuredata',
+                                     repo_name: 'TreasureData',
+                                   })
+    debian_template = template.merge({
+                                       repo_label: 'treasuredata',
+                                       distribution: 'debian',
+                                       apt_source_deb: 'fluentd-apt-source/fluentd-apt-source_2020.8.25-1_all.deb',
+                                       apt: 'apt'
+                                     })
+    ubuntu_template = debian_template.merge({
+                                              distribution: 'ubuntu',
+                                              apt_source_deb: 'fluentd-apt-source/fluentd-apt-source_2020.8.25-1_all.deb'
+                                            })
+    metadata.merge!({
+                      install_redhat_td_agent4: rhel_template,
+                      install_amazon2_td_agent4: rhel_template.merge({distribution: 'amazon', version: 2}),
+                      install_ubuntu_jammy_td_agent4: ubuntu_template.merge({version: 'jammy'}),
+                      install_ubuntu_focal_td_agent4: ubuntu_template.merge({version: 'focal'}),
+                      install_ubuntu_bionic_td_agent4: ubuntu_template.merge({version: 'bionic'}),
+                      install_ubuntu_xenial_td_agent4: ubuntu_template.merge({version: 'xenial'}),
+                      install_debian_bullseye_td_agent4: debian_template.merge({version: 'bullseye'}),
+                      install_debian_buster_td_agent4: debian_template.merge({version: 'buster'}),
+                    })
+  end
+
+  def generate_3x_metadata
+    metadata = {}
+    template = {
+      channel_version: 3,
+      package_name: @old_package_name,
+      base_url: @base_url
+    }
+    rhel_template = template.merge({
+                                     distribution: 'redhat',
+                                     repo_file: @old_repo_file,
+                                     repo_label: 'treasuredata',
+                                     repo_name: 'TreasureData',
+                                   })
+    debian_template = template.merge({
+                                       repo_label: 'treasuredata',
+                                       distribution: 'debian',
+                                       apt_source_deb: 'fluentd-apt-source/fluentd-apt-source_2020.8.25-1_all.deb',
+                                       apt: 'apt-get'
+                                     })
+    ubuntu_template = template.merge({
+                                       distribution: 'ubuntu',
+                                       apt_source_deb: 'fluentd-apt-source/fluentd-apt-source_2020.8.25-1_all.deb',
+                                       apt: 'apt-get'
+                                     })
+    metadata.merge!({
+                      install_redhat_td_agent3: rhel_template,
+                      install_amazon1_td_agent3: rhel_template.merge({distribution: 'amazon', version: 1}),
+                      install_amazon2_td_agent3: rhel_template.merge({distribution: 'amazon', version: 2}),
+                      install_ubuntu_bionic_td_agent3: ubuntu_template.merge({version: 'bionic'}),
+                      install_ubuntu_xenial_td_agent3: ubuntu_template.merge({version: 'xenial'}),
+                      install_ubuntu_trusty_td_agent3: ubuntu_template.merge({version: 'trusty'}),
+                      install_debian_buster_td_agent3: debian_template.merge({version: 'buster'}),
+                      install_debian_stretch_td_agent3: debian_template.merge({version: 'stretch'}),
+                      install_debian_jessie_td_agent3: debian_template.merge({version: 'jessie'}),
+                    })
+  end
+
+  def generate_25x_metadata
+    metadata = {}
+    template = {
+      channel_version: 2.5,
+      package_name: @old_package_name,
+      base_url: @base_url
+    }
+    rhel_template = template.merge({
+                                     distribution: 'redhat',
+                                     repo_file: @old_repo_file,
+                                     repo_label: 'treasuredata',
+                                     repo_name: 'TreasureData',
+                                   })
+    debian_template = template.merge({
+                                       repo_label: 'treasuredata',
+                                       distribution: 'debian',
+                                       apt_source_deb: 'fluentd-apt-source/fluentd-apt-source_2020.8.25-1_all.deb',
+                                       apt: 'apt-get'
+                                     })
+    ubuntu_template = debian_template.merge({
+                                              distribution: 'ubuntu',
+                                              apt_source_deb: 'fluentd-apt-source/fluentd-apt-source_2020.8.25-1_all.deb',
+                                            })
+    metadata.merge!({
+                      install_redhat_td_agent25: rhel_template,
+                      install_ubuntu_bionic_td_agent25: ubuntu_template.merge({version: 'bionic'}),
+                      install_ubuntu_xenial_td_agent25: ubuntu_template.merge({version: 'xenial'}),
+                      install_ubuntu_trusty_td_agent25: ubuntu_template.merge({version: 'trusty'}),
+                      install_debian_stretch_td_agent25: debian_template.merge({version: 'stretch'}),
+                    })
+  end
+
+  def generate_2x_metadata
+    metadata = {}
+    template = {
+      channel_version: 2,
+      package_name: @old_package_name,
+      base_url: @base_url
+    }
+    rhel_template = template.merge({
+                                     distribution: 'redhat',
+                                     repo_file: @old_repo_file,
+                                     repo_label: 'treasuredata',
+                                     repo_name: 'TreasureData',
+                                   })
+    debian_template = template.merge({
+                                       repo_label: 'treasuredata',
+                                       distribution: 'debian',
+                                       apt_source_deb: 'fluentd-apt-source/fluentd-apt-source_2020.8.25-1_all.deb',
+                                       apt: 'apt-get'
+                                     })
+    ubuntu_template = debian_template.merge({
+                                              distribution: 'ubuntu',
+                                              apt_source_deb: 'fluentd-apt-source/fluentd-apt-source_2020.8.25-1_all.deb',
+                                            })
+    metadata.merge!({
+                      install_redhat5_td_agent2: rhel_template.merge({old_sha1: true}),
+                      install_redhat_td_agent2: rhel_template,
+                      install_ubuntu_xenial_td_agent2: ubuntu_template.merge({version: 'xenial'}),
+                      install_ubuntu_trusty_td_agent2: ubuntu_template.merge({version: 'trusty'}),
+                      install_ubuntu_precise_td_agent2: ubuntu_template.merge({version: 'precise'}),
+                      install_ubuntu_lucid_td_agent2: ubuntu_template.merge({version: 'lucid'}),
+                      install_debian_stretch_td_agent2: debian_template.merge({version: 'stretch'}),
+                      install_debian_jessie_td_agent2: debian_template.merge({version: 'jessie'}),
+                      install_debian_wheezy_td_agent2: debian_template.merge({version: 'wheezy'}),
+                      install_debian_squeeze_td_agent2: debian_template.merge({version: 'squeeze'}),
+                    })
+  end
+
+  def generate_1x_metadata
+    metadata = {}
+    template = {
+      channel_version: 1,
+      package_name: @old_package_name,
+      base_url: @base_url
+    }
+    rhel_template = template.merge({
+                                     distribution: 'redhat',
+                                     repo_file: @old_repo_file,
+                                     repo_label: 'treasuredata',
+                                     repo_name: 'TreasureData',
+                                     old_sha1: true
+                                   })
+    debian_template = template.merge({
+                                       repo_label: 'treasuredata',
+                                       distribution: 'debian',
+                                       apt: 'apt-get'
+                                     })
+    ubuntu_template = debian_template.merge({
+                                              distribution: 'ubuntu'
+                                            })
+    metadata.merge!({
+                      install_redhat: rhel_template,
+                      install_ubuntu_precise: ubuntu_template.merge({version: 'precise'}),
+                      # lucid should be /lucid, but kept under /debian
+                      install_ubuntu_lucid: debian_template.merge({version: 'lucid'}),
+                      install_debian_lenny: ubuntu_template.merge({version: 'lenny'}),
+                    })
+  end
+
+  def run(top_dir)
+    if @options[:backup]
+      backup_install_scripts
+    else
+      generate_install_scripts(top_dir)
+    end
+  end
+end
+
+runner = FluentInstallScript.new(options)
+runner.run(top_dir)

--- a/fluent-package/toolbelt/README.md
+++ b/fluent-package/toolbelt/README.md
@@ -1,0 +1,16 @@
+# toolbelt/*.sh Introduction
+
+This directory is created to archive original installation scripts
+which are hosted on toolbelt.treasuredata.com.
+
+These installation script was dynamically generated on
+https://toolbelt.treasuredata.com and source code was hosted on
+TreasureData's private repository.
+
+It rely on deploying commercial cloud service and if we lost access to
+that private repository, can't manage them anymore. As a workaround,
+support to generate similar install script and upload it as static
+file. make-install-script.rb now supports to generate static version
+of installation script, but to confirm compatibility some extent,
+original installation scripts should be archived to make it comparable
+with them.

--- a/fluent-package/toolbelt/install-amazon1-td-agent3.sh
+++ b/fluent-package/toolbelt/install-amazon1-td-agent3.sh
@@ -1,0 +1,36 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install rpm packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+
+  # add GPG key
+  rpm --import https://packages.treasuredata.com/GPG-KEY-td-agent
+
+  # add treasure data repository to yum
+  cat >/etc/yum.repos.d/td.repo <<'EOF';
+[treasuredata]
+name=TreasureData
+baseurl=http://packages.treasuredata.com/3/amazon/1/\$releasever/\$basearch
+gpgcheck=1
+gpgkey=https://packages.treasuredata.com/GPG-KEY-td-agent
+EOF
+
+  # update your sources
+  yum check-update
+
+  # install the toolbelt
+  yes | yum install -y td-agent
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-amazon2-fluent-package5-lts.sh
+++ b/fluent-package/toolbelt/install-amazon2-fluent-package5-lts.sh
@@ -1,0 +1,39 @@
+echo "=============================="
+echo " fluent-package Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install rpm packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+
+  # add GPG key
+  rpm --import https://packages.treasuredata.com/GPG-KEY-td-agent
+  rpm --import https://packages.treasuredata.com/GPG-KEY-fluent-package
+
+  # add fluent package repository to yum
+  cat >/etc/yum.repos.d/fluent-package-lts.repo <<'EOF';
+[fluent-package-lts]
+name=Fluentd Project
+baseurl=https://packages.treasuredata.com/lts/5/amazon/2/\$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.treasuredata.com/GPG-KEY-td-agent
+       https://packages.treasuredata.com/GPG-KEY-fluent-package
+EOF
+
+  # update your sources
+  yum check-update
+
+  # install the toolbelt
+  yes | yum install -y fluent-package
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-amazon2-fluent-package5.sh
+++ b/fluent-package/toolbelt/install-amazon2-fluent-package5.sh
@@ -1,0 +1,39 @@
+echo "=============================="
+echo " fluent-package Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install rpm packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+
+  # add GPG key
+  rpm --import https://packages.treasuredata.com/GPG-KEY-td-agent
+  rpm --import https://packages.treasuredata.com/GPG-KEY-fluent-package
+
+  # add fluent package repository to yum
+  cat >/etc/yum.repos.d/fluent-package.repo <<'EOF';
+[fluent-package]
+name=Fluentd Project
+baseurl=https://packages.treasuredata.com/5/amazon/2/\$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.treasuredata.com/GPG-KEY-td-agent
+       https://packages.treasuredata.com/GPG-KEY-fluent-package
+EOF
+
+  # update your sources
+  yum check-update
+
+  # install the toolbelt
+  yes | yum install -y fluent-package
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-amazon2-td-agent3.sh
+++ b/fluent-package/toolbelt/install-amazon2-td-agent3.sh
@@ -1,0 +1,36 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install rpm packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+
+  # add GPG key
+  rpm --import https://packages.treasuredata.com/GPG-KEY-td-agent
+
+  # add treasure data repository to yum
+  cat >/etc/yum.repos.d/td.repo <<'EOF';
+[treasuredata]
+name=TreasureData
+baseurl=http://packages.treasuredata.com/3/amazon/2/\$releasever/\$basearch
+gpgcheck=1
+gpgkey=https://packages.treasuredata.com/GPG-KEY-td-agent
+EOF
+
+  # update your sources
+  yum check-update
+
+  # install the toolbelt
+  yes | yum install -y td-agent
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-amazon2-td-agent4.sh
+++ b/fluent-package/toolbelt/install-amazon2-td-agent4.sh
@@ -1,0 +1,36 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install rpm packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+
+  # add GPG key
+  rpm --import https://packages.treasuredata.com/GPG-KEY-td-agent
+
+  # add treasure data repository to yum
+  cat >/etc/yum.repos.d/td.repo <<'EOF';
+[treasuredata]
+name=TreasureData
+baseurl=http://packages.treasuredata.com/4/amazon/2/\$basearch
+gpgcheck=1
+gpgkey=https://packages.treasuredata.com/GPG-KEY-td-agent
+EOF
+
+  # update your sources
+  yum check-update
+
+  # install the toolbelt
+  yes | yum install -y td-agent
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-amazon2023-fluent-package5-lts.sh
+++ b/fluent-package/toolbelt/install-amazon2023-fluent-package5-lts.sh
@@ -1,0 +1,39 @@
+echo "=============================="
+echo " fluent-package Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install rpm packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+
+  # add GPG key
+  rpm --import https://packages.treasuredata.com/GPG-KEY-td-agent
+  rpm --import https://packages.treasuredata.com/GPG-KEY-fluent-package
+
+  # add fluent package repository to yum
+  cat >/etc/yum.repos.d/fluent-package-lts.repo <<'EOF';
+[fluent-package-lts]
+name=Fluentd Project
+baseurl=https://packages.treasuredata.com/lts/5/amazon/2023/\$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.treasuredata.com/GPG-KEY-td-agent
+       https://packages.treasuredata.com/GPG-KEY-fluent-package
+EOF
+
+  # update your sources
+  yum check-update
+
+  # install the toolbelt
+  yes | yum install -y fluent-package
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-amazon2023-fluent-package5.sh
+++ b/fluent-package/toolbelt/install-amazon2023-fluent-package5.sh
@@ -1,0 +1,39 @@
+echo "=============================="
+echo " fluent-package Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install rpm packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+
+  # add GPG key
+  rpm --import https://packages.treasuredata.com/GPG-KEY-td-agent
+  rpm --import https://packages.treasuredata.com/GPG-KEY-fluent-package
+
+  # add fluent package repository to yum
+  cat >/etc/yum.repos.d/fluent-package.repo <<'EOF';
+[fluent-package]
+name=Fluentd Project
+baseurl=https://packages.treasuredata.com/5/amazon/2023/\$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.treasuredata.com/GPG-KEY-td-agent
+       https://packages.treasuredata.com/GPG-KEY-fluent-package
+EOF
+
+  # update your sources
+  yum check-update
+
+  # install the toolbelt
+  yes | yum install -y fluent-package
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-debian-bookworm-fluent-package5-lts.sh
+++ b/fluent-package/toolbelt/install-debian-bookworm-fluent-package5-lts.sh
@@ -1,0 +1,32 @@
+echo "=============================="
+echo " fluent-package Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  # use apt-source package which contains keyring
+  curl -o fluent-apt-source.deb https://packages.treasuredata.com/lts/5/debian/bookworm/pool/contrib/f/fluent-lts-apt-source/fluent-lts-apt-source_2023.7.29-1_all.deb
+  apt install -y ./fluent-apt-source.deb
+  # update your sources
+  apt update
+
+  # install the toolbelt
+  apt install -y fluent-package
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-debian-bookworm-fluent-package5.sh
+++ b/fluent-package/toolbelt/install-debian-bookworm-fluent-package5.sh
@@ -1,0 +1,32 @@
+echo "=============================="
+echo " fluent-package Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  # use apt-source package which contains keyring
+  curl -o fluent-apt-source.deb https://packages.treasuredata.com/5/debian/bookworm/pool/contrib/f/fluent-apt-source/fluent-apt-source_2023.6.29-1_all.deb
+  apt install -y ./fluent-apt-source.deb
+  # update your sources
+  apt update
+
+  # install the toolbelt
+  apt install -y fluent-package
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-debian-bullseye-fluent-package5-lts.sh
+++ b/fluent-package/toolbelt/install-debian-bullseye-fluent-package5-lts.sh
@@ -1,0 +1,32 @@
+echo "=============================="
+echo " fluent-package Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  # use apt-source package which contains keyring
+  curl -o fluent-apt-source.deb https://packages.treasuredata.com/lts/5/debian/bullseye/pool/contrib/f/fluent-lts-apt-source/fluent-lts-apt-source_2023.7.29-1_all.deb
+  apt install -y ./fluent-apt-source.deb
+  # update your sources
+  apt update
+
+  # install the toolbelt
+  apt install -y fluent-package
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-debian-bullseye-fluent-package5.sh
+++ b/fluent-package/toolbelt/install-debian-bullseye-fluent-package5.sh
@@ -1,0 +1,32 @@
+echo "=============================="
+echo " fluent-package Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  # use apt-source package which contains keyring
+  curl -o fluent-apt-source.deb https://packages.treasuredata.com/5/debian/bullseye/pool/contrib/f/fluent-apt-source/fluent-apt-source_2023.6.29-1_all.deb
+  apt install -y ./fluent-apt-source.deb
+  # update your sources
+  apt update
+
+  # install the toolbelt
+  apt install -y fluent-package
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-debian-bullseye-td-agent4.sh
+++ b/fluent-package/toolbelt/install-debian-bullseye-td-agent4.sh
@@ -1,0 +1,34 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  
+    # use apt-source package which contains keyring
+    curl -o td-agent-apt-source.deb https://packages.treasuredata.com/4/debian/bullseye/pool/contrib/f/fluentd-apt-source/fluentd-apt-source_2020.8.25-1_all.deb
+    apt install -y ./td-agent-apt-source.deb
+  
+  # update your sources
+  apt update
+
+  # install the toolbelt
+  apt install -y td-agent
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-debian-buster-td-agent3.sh
+++ b/fluent-package/toolbelt/install-debian-buster-td-agent3.sh
@@ -1,0 +1,34 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  curl https://packages.treasuredata.com/GPG-KEY-td-agent | apt-key add -
+
+  # add treasure data repository to apt
+  echo "deb http://packages.treasuredata.com/3/debian/buster/ buster contrib" > /etc/apt/sources.list.d/treasure-data.list
+
+  # update your sources
+  apt-get update
+
+  # install the toolbelt
+  apt-get install -y td-agent
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-debian-buster-td-agent4.sh
+++ b/fluent-package/toolbelt/install-debian-buster-td-agent4.sh
@@ -1,0 +1,34 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  
+    # use apt-source package which contains keyring
+    curl -o td-agent-apt-source.deb https://packages.treasuredata.com/4/debian/buster/pool/contrib/f/fluentd-apt-source/fluentd-apt-source_2020.8.25-1_all.deb
+    apt install -y ./td-agent-apt-source.deb
+  
+  # update your sources
+  apt update
+
+  # install the toolbelt
+  apt install -y td-agent
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-debian-jessie-td-agent2.sh
+++ b/fluent-package/toolbelt/install-debian-jessie-td-agent2.sh
@@ -1,0 +1,28 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  curl https://packages.treasuredata.com/GPG-KEY-td-agent | apt-key add -
+
+  # add treasure data repository to apt
+  echo "deb http://packages.treasuredata.com/2/debian/jessie/ jessie contrib" > /etc/apt/sources.list.d/treasure-data.list
+
+  # update your sources
+  apt-get update
+
+  # install the toolbelt
+  apt-get install -y td-agent
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-debian-jessie-td-agent3.sh
+++ b/fluent-package/toolbelt/install-debian-jessie-td-agent3.sh
@@ -1,0 +1,34 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  curl https://packages.treasuredata.com/GPG-KEY-td-agent | apt-key add -
+
+  # add treasure data repository to apt
+  echo "deb http://packages.treasuredata.com/3/debian/jessie/ jessie contrib" > /etc/apt/sources.list.d/treasure-data.list
+
+  # update your sources
+  apt-get update
+
+  # install the toolbelt
+  apt-get install -y td-agent
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-debian-lenny.sh
+++ b/fluent-package/toolbelt/install-debian-lenny.sh
@@ -1,0 +1,28 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  curl https://packages.treasuredata.com/GPG-KEY-td-agent-old-sha1 | apt-key add -
+
+  # add treasure data repository to apt
+  echo "deb http://packages.treasuredata.com/lenny/ lenny contrib" > /etc/apt/sources.list.d/treasure-data.list
+
+  # update your sources
+  apt-get update
+
+  # install the toolbelt
+  apt-get install -y td-agent
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-debian-squeeze-td-agent2.sh
+++ b/fluent-package/toolbelt/install-debian-squeeze-td-agent2.sh
@@ -1,0 +1,28 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  curl https://packages.treasuredata.com/GPG-KEY-td-agent | apt-key add -
+
+  # add treasure data repository to apt
+  echo "deb http://packages.treasuredata.com/2/debian/squeeze/ squeeze contrib" > /etc/apt/sources.list.d/treasure-data.list
+
+  # update your sources
+  apt-get update
+
+  # install the toolbelt
+  apt-get install -y td-agent
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-debian-stretch-td-agent2.5.sh
+++ b/fluent-package/toolbelt/install-debian-stretch-td-agent2.5.sh
@@ -1,0 +1,34 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  curl https://packages.treasuredata.com/GPG-KEY-td-agent | apt-key add -
+
+  # add treasure data repository to apt
+  echo "deb http://packages.treasuredata.com/2.5/debian/stretch/ stretch contrib" > /etc/apt/sources.list.d/treasure-data.list
+
+  # update your sources
+  apt-get update
+
+  # install the toolbelt
+  apt-get install -y td-agent
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-debian-stretch-td-agent2.sh
+++ b/fluent-package/toolbelt/install-debian-stretch-td-agent2.sh
@@ -1,0 +1,28 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  curl https://packages.treasuredata.com/GPG-KEY-td-agent | apt-key add -
+
+  # add treasure data repository to apt
+  echo "deb http://packages.treasuredata.com/2/debian/stretch/ stretch contrib" > /etc/apt/sources.list.d/treasure-data.list
+
+  # update your sources
+  apt-get update
+
+  # install the toolbelt
+  apt-get install -y td-agent
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-debian-stretch-td-agent3.sh
+++ b/fluent-package/toolbelt/install-debian-stretch-td-agent3.sh
@@ -1,0 +1,34 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  curl https://packages.treasuredata.com/GPG-KEY-td-agent | apt-key add -
+
+  # add treasure data repository to apt
+  echo "deb http://packages.treasuredata.com/3/debian/stretch/ stretch contrib" > /etc/apt/sources.list.d/treasure-data.list
+
+  # update your sources
+  apt-get update
+
+  # install the toolbelt
+  apt-get install -y td-agent
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-debian-wheezy-td-agent2.sh
+++ b/fluent-package/toolbelt/install-debian-wheezy-td-agent2.sh
@@ -1,0 +1,28 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  curl https://packages.treasuredata.com/GPG-KEY-td-agent | apt-key add -
+
+  # add treasure data repository to apt
+  echo "deb http://packages.treasuredata.com/2/debian/wheezy/ wheezy contrib" > /etc/apt/sources.list.d/treasure-data.list
+
+  # update your sources
+  apt-get update
+
+  # install the toolbelt
+  apt-get install -y td-agent
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-redhat-fluent-package5-lts.sh
+++ b/fluent-package/toolbelt/install-redhat-fluent-package5-lts.sh
@@ -1,0 +1,39 @@
+echo "=============================="
+echo " fluent-package Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install rpm packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+
+  # add GPG key
+  rpm --import https://packages.treasuredata.com/GPG-KEY-td-agent
+  rpm --import https://packages.treasuredata.com/GPG-KEY-fluent-package
+
+  # add fluent-package repository to yum
+  cat >/etc/yum.repos.d/fluent-package-lts.repo <<'EOF';
+[fluent-package-lts]
+name=Fluentd Project
+baseurl=https://packages.treasuredata.com/lts/5/redhat/\$releasever/\$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.treasuredata.com/GPG-KEY-td-agent
+       https://packages.treasuredata.com/GPG-KEY-fluent-package
+EOF
+
+  # update your sources
+  yum check-update
+
+  # install the toolbelt
+  yes | yum install -y fluent-package
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-redhat-fluent-package5.sh
+++ b/fluent-package/toolbelt/install-redhat-fluent-package5.sh
@@ -1,0 +1,39 @@
+echo "=============================="
+echo " fluent-package Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install rpm packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+
+  # add GPG key
+  rpm --import https://packages.treasuredata.com/GPG-KEY-td-agent
+  rpm --import https://packages.treasuredata.com/GPG-KEY-fluent-package
+
+  # add fluent-package repository to yum
+  cat >/etc/yum.repos.d/fluent-package.repo <<'EOF';
+[fluent-package]
+name=Fluentd Project
+baseurl=https://packages.treasuredata.com/5/redhat/\$releasever/\$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.treasuredata.com/GPG-KEY-td-agent
+       https://packages.treasuredata.com/GPG-KEY-fluent-package
+EOF
+
+  # update your sources
+  yum check-update
+
+  # install the toolbelt
+  yes | yum install -y fluent-package
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-redhat-td-agent2.5.sh
+++ b/fluent-package/toolbelt/install-redhat-td-agent2.5.sh
@@ -1,0 +1,36 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install rpm packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+
+  # add GPG key
+  rpm --import https://packages.treasuredata.com/GPG-KEY-td-agent
+
+  # add treasure data repository to yum
+  cat >/etc/yum.repos.d/td.repo <<'EOF';
+[treasuredata]
+name=TreasureData
+baseurl=http://packages.treasuredata.com/2.5/redhat/\$releasever/\$basearch
+gpgcheck=1
+gpgkey=https://packages.treasuredata.com/GPG-KEY-td-agent
+EOF
+
+  # update your sources
+  yum check-update
+
+  # install the toolbelt
+  yes | yum install -y td-agent
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-redhat-td-agent2.sh
+++ b/fluent-package/toolbelt/install-redhat-td-agent2.sh
@@ -1,0 +1,36 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install rpm packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+
+  # add GPG key
+  rpm --import https://packages.treasuredata.com/GPG-KEY-td-agent
+
+  # add treasure data repository to yum
+  cat >/etc/yum.repos.d/td.repo <<'EOF';
+[treasuredata]
+name=TreasureData
+baseurl=http://packages.treasuredata.com/2/redhat/\$releasever/\$basearch
+gpgcheck=1
+gpgkey=https://packages.treasuredata.com/GPG-KEY-td-agent
+EOF
+
+  # update your sources
+  yum check-update
+
+  # install the toolbelt
+  yes | yum install -y td-agent
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-redhat-td-agent3.sh
+++ b/fluent-package/toolbelt/install-redhat-td-agent3.sh
@@ -1,0 +1,36 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install rpm packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+
+  # add GPG key
+  rpm --import https://packages.treasuredata.com/GPG-KEY-td-agent
+
+  # add treasure data repository to yum
+  cat >/etc/yum.repos.d/td.repo <<'EOF';
+[treasuredata]
+name=TreasureData
+baseurl=http://packages.treasuredata.com/3/redhat/\$releasever/\$basearch
+gpgcheck=1
+gpgkey=https://packages.treasuredata.com/GPG-KEY-td-agent
+EOF
+
+  # update your sources
+  yum check-update
+
+  # install the toolbelt
+  yes | yum install -y td-agent
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-redhat-td-agent4.sh
+++ b/fluent-package/toolbelt/install-redhat-td-agent4.sh
@@ -1,0 +1,36 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install rpm packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+
+  # add GPG key
+  rpm --import https://packages.treasuredata.com/GPG-KEY-td-agent
+
+  # add treasure data repository to yum
+  cat >/etc/yum.repos.d/td.repo <<'EOF';
+[treasuredata]
+name=TreasureData
+baseurl=http://packages.treasuredata.com/4/redhat/\$releasever/\$basearch
+gpgcheck=1
+gpgkey=https://packages.treasuredata.com/GPG-KEY-td-agent
+EOF
+
+  # update your sources
+  yum check-update
+
+  # install the toolbelt
+  yes | yum install -y td-agent
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-redhat.sh
+++ b/fluent-package/toolbelt/install-redhat.sh
@@ -1,0 +1,36 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install rpm packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+
+  # add GPG key
+  rpm --import https://packages.treasuredata.com/GPG-KEY-td-agent
+
+  # add treasure data repository to yum
+  cat >/etc/yum.repos.d/td.repo <<'EOF';
+[treasuredata]
+name=TreasureData
+baseurl=http://packages.treasuredata.com/redhat/\$basearch
+gpgcheck=1
+gpgkey=https://packages.treasuredata.com/GPG-KEY-td-agent-old-sha1
+EOF
+
+  # update your sources
+  yum check-update
+
+  # install the toolbelt
+  yes | yum install -y td-agent
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-redhat5-td-agent2.sh
+++ b/fluent-package/toolbelt/install-redhat5-td-agent2.sh
@@ -1,0 +1,36 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install rpm packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+
+  # add GPG key
+  rpm --import https://packages.treasuredata.com/GPG-KEY-td-agent
+
+  # add treasure data repository to yum
+  cat >/etc/yum.repos.d/td.repo <<'EOF';
+[treasuredata]
+name=TreasureData
+baseurl=http://packages.treasuredata.com/2/redhat/\$releasever/\$basearch
+gpgcheck=1
+gpgkey=https://packages.treasuredata.com/GPG-KEY-td-agent-old-sha1
+EOF
+
+  # update your sources
+  yum check-update
+
+  # install the toolbelt
+  yes | yum install -y td-agent
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-ubuntu-bionic-td-agent2.5.sh
+++ b/fluent-package/toolbelt/install-ubuntu-bionic-td-agent2.5.sh
@@ -1,0 +1,34 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  curl https://packages.treasuredata.com/GPG-KEY-td-agent | apt-key add -
+
+  # add treasure data repository to apt
+  echo "deb http://packages.treasuredata.com/2.5/ubuntu/bionic/ bionic contrib" > /etc/apt/sources.list.d/treasure-data.list
+
+  # update your sources
+  apt-get update
+
+  # install the toolbelt
+  apt-get install -y td-agent
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-ubuntu-bionic-td-agent3.sh
+++ b/fluent-package/toolbelt/install-ubuntu-bionic-td-agent3.sh
@@ -1,0 +1,34 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  curl https://packages.treasuredata.com/GPG-KEY-td-agent | apt-key add -
+
+  # add treasure data repository to apt
+  echo "deb http://packages.treasuredata.com/3/ubuntu/bionic/ bionic contrib" > /etc/apt/sources.list.d/treasure-data.list
+
+  # update your sources
+  apt-get update
+
+  # install the toolbelt
+  apt-get install -y td-agent
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-ubuntu-bionic-td-agent4.sh
+++ b/fluent-package/toolbelt/install-ubuntu-bionic-td-agent4.sh
@@ -1,0 +1,34 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  
+    # use apt-source package which contains keyring
+    curl -o td-agent-apt-source.deb https://packages.treasuredata.com/4/ubuntu/bionic/pool/contrib/f/fluentd-apt-source/fluentd-apt-source_2020.8.25-1_all.deb
+    apt install -y ./td-agent-apt-source.deb
+  
+  # update your sources
+  apt update
+
+  # install the toolbelt
+  apt install -y td-agent
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-ubuntu-focal-fluent-package5-lts.sh
+++ b/fluent-package/toolbelt/install-ubuntu-focal-fluent-package5-lts.sh
@@ -1,0 +1,32 @@
+echo "=============================="
+echo " fluent-package Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  # use apt-source package which contains keyring
+  curl -o fluent-apt-source.deb https://packages.treasuredata.com/lts/5/ubuntu/focal/pool/contrib/f/fluent-lts-apt-source/fluent-lts-apt-source_2023.7.29-1_all.deb
+  apt install -y ./fluent-apt-source.deb
+  # update your sources
+  apt update
+
+  # install the toolbelt
+  apt install -y fluent-package
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-ubuntu-focal-fluent-package5.sh
+++ b/fluent-package/toolbelt/install-ubuntu-focal-fluent-package5.sh
@@ -1,0 +1,32 @@
+echo "=============================="
+echo " fluent-package Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  # use apt-source package which contains keyring
+  curl -o fluent-apt-source.deb https://packages.treasuredata.com/5/ubuntu/focal/pool/contrib/f/fluent-apt-source/fluent-apt-source_2023.6.29-1_all.deb
+  apt install -y ./fluent-apt-source.deb
+  # update your sources
+  apt update
+
+  # install the toolbelt
+  apt install -y fluent-package
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-ubuntu-focal-td-agent4.sh
+++ b/fluent-package/toolbelt/install-ubuntu-focal-td-agent4.sh
@@ -1,0 +1,34 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  
+    # use apt-source package which contains keyring
+    curl -o td-agent-apt-source.deb https://packages.treasuredata.com/4/ubuntu/focal/pool/contrib/f/fluentd-apt-source/fluentd-apt-source_2020.8.25-1_all.deb
+    apt install -y ./td-agent-apt-source.deb
+  
+  # update your sources
+  apt update
+
+  # install the toolbelt
+  apt install -y td-agent
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-ubuntu-jammy-fluent-package5-lts.sh
+++ b/fluent-package/toolbelt/install-ubuntu-jammy-fluent-package5-lts.sh
@@ -1,0 +1,32 @@
+echo "=============================="
+echo " fluent-package Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  # use apt-source package which contains keyring
+  curl -o fluent-apt-source.deb https://packages.treasuredata.com/lts/5/ubuntu/jammy/pool/contrib/f/fluent-lts-apt-source/fluent-lts-apt-source_2023.7.29-1_all.deb
+  apt install -y ./fluent-apt-source.deb
+  # update your sources
+  apt update
+
+  # install the toolbelt
+  apt install -y fluent-package
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-ubuntu-jammy-fluent-package5.sh
+++ b/fluent-package/toolbelt/install-ubuntu-jammy-fluent-package5.sh
@@ -1,0 +1,32 @@
+echo "=============================="
+echo " fluent-package Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  # use apt-source package which contains keyring
+  curl -o fluent-apt-source.deb https://packages.treasuredata.com/5/ubuntu/jammy/pool/contrib/f/fluent-apt-source/fluent-apt-source_2023.6.29-1_all.deb
+  apt install -y ./fluent-apt-source.deb
+  # update your sources
+  apt update
+
+  # install the toolbelt
+  apt install -y fluent-package
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-ubuntu-jammy-td-agent4.sh
+++ b/fluent-package/toolbelt/install-ubuntu-jammy-td-agent4.sh
@@ -1,0 +1,34 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  
+    # use apt-source package which contains keyring
+    curl -o td-agent-apt-source.deb https://packages.treasuredata.com/4/ubuntu/jammy/pool/contrib/f/fluentd-apt-source/fluentd-apt-source_2020.8.25-1_all.deb
+    apt install -y ./td-agent-apt-source.deb
+  
+  # update your sources
+  apt update
+
+  # install the toolbelt
+  apt install -y td-agent
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-ubuntu-lucid-td-agent2.sh
+++ b/fluent-package/toolbelt/install-ubuntu-lucid-td-agent2.sh
@@ -1,0 +1,28 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  curl https://packages.treasuredata.com/GPG-KEY-td-agent | apt-key add -
+
+  # add treasure data repository to apt
+  echo "deb http://packages.treasuredata.com/2/ubuntu/lucid/ lucid contrib" > /etc/apt/sources.list.d/treasure-data.list
+
+  # update your sources
+  apt-get update
+
+  # install the toolbelt
+  apt-get install -y td-agent
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-ubuntu-lucid.sh
+++ b/fluent-package/toolbelt/install-ubuntu-lucid.sh
@@ -1,0 +1,28 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  curl https://packages.treasuredata.com/GPG-KEY-td-agent-old-sha1 | apt-key add -
+
+  # add treasure data repository to apt
+  echo "deb http://packages.treasuredata.com/debian/ lucid contrib" > /etc/apt/sources.list.d/treasure-data.list
+
+  # update your sources
+  apt-get update
+
+  # install the toolbelt
+  apt-get install -y td-agent
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-ubuntu-noble-fluent-package5-lts.sh
+++ b/fluent-package/toolbelt/install-ubuntu-noble-fluent-package5-lts.sh
@@ -1,0 +1,32 @@
+echo "=============================="
+echo " fluent-package Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  # use apt-source package which contains keyring
+  curl -o fluent-apt-source.deb https://packages.treasuredata.com/lts/5/ubuntu/noble/pool/contrib/f/fluent-lts-apt-source/fluent-lts-apt-source_2023.7.29-1_all.deb
+  apt install -y ./fluent-apt-source.deb
+  # update your sources
+  apt update
+
+  # install the toolbelt
+  apt install -y fluent-package
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-ubuntu-noble-fluent-package5.sh
+++ b/fluent-package/toolbelt/install-ubuntu-noble-fluent-package5.sh
@@ -1,0 +1,32 @@
+echo "=============================="
+echo " fluent-package Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  # use apt-source package which contains keyring
+  curl -o fluent-apt-source.deb https://packages.treasuredata.com/5/ubuntu/noble/pool/contrib/f/fluent-apt-source/fluent-apt-source_2023.6.29-1_all.deb
+  apt install -y ./fluent-apt-source.deb
+  # update your sources
+  apt update
+
+  # install the toolbelt
+  apt install -y fluent-package
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-ubuntu-precise-td-agent2.sh
+++ b/fluent-package/toolbelt/install-ubuntu-precise-td-agent2.sh
@@ -1,0 +1,28 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  curl https://packages.treasuredata.com/GPG-KEY-td-agent | apt-key add -
+
+  # add treasure data repository to apt
+  echo "deb http://packages.treasuredata.com/2/ubuntu/precise/ precise contrib" > /etc/apt/sources.list.d/treasure-data.list
+
+  # update your sources
+  apt-get update
+
+  # install the toolbelt
+  apt-get install -y td-agent
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-ubuntu-precise.sh
+++ b/fluent-package/toolbelt/install-ubuntu-precise.sh
@@ -1,0 +1,28 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  curl https://packages.treasuredata.com/GPG-KEY-td-agent-old-sha1 | apt-key add -
+
+  # add treasure data repository to apt
+  echo "deb http://packages.treasuredata.com/precise/ precise contrib" > /etc/apt/sources.list.d/treasure-data.list
+
+  # update your sources
+  apt-get update
+
+  # install the toolbelt
+  apt-get install -y td-agent
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-ubuntu-trusty-td-agent2.5.sh
+++ b/fluent-package/toolbelt/install-ubuntu-trusty-td-agent2.5.sh
@@ -1,0 +1,34 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  curl https://packages.treasuredata.com/GPG-KEY-td-agent | apt-key add -
+
+  # add treasure data repository to apt
+  echo "deb http://packages.treasuredata.com/2.5/ubuntu/trusty/ trusty contrib" > /etc/apt/sources.list.d/treasure-data.list
+
+  # update your sources
+  apt-get update
+
+  # install the toolbelt
+  apt-get install -y td-agent
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-ubuntu-trusty-td-agent2.sh
+++ b/fluent-package/toolbelt/install-ubuntu-trusty-td-agent2.sh
@@ -1,0 +1,28 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  curl https://packages.treasuredata.com/GPG-KEY-td-agent | apt-key add -
+
+  # add treasure data repository to apt
+  echo "deb http://packages.treasuredata.com/2/ubuntu/trusty/ trusty contrib" > /etc/apt/sources.list.d/treasure-data.list
+
+  # update your sources
+  apt-get update
+
+  # install the toolbelt
+  apt-get install -y td-agent
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-ubuntu-trusty-td-agent3.sh
+++ b/fluent-package/toolbelt/install-ubuntu-trusty-td-agent3.sh
@@ -1,0 +1,34 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  curl https://packages.treasuredata.com/GPG-KEY-td-agent | apt-key add -
+
+  # add treasure data repository to apt
+  echo "deb http://packages.treasuredata.com/3/ubuntu/trusty/ trusty contrib" > /etc/apt/sources.list.d/treasure-data.list
+
+  # update your sources
+  apt-get update
+
+  # install the toolbelt
+  apt-get install -y td-agent
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-ubuntu-xenial-td-agent2.5.sh
+++ b/fluent-package/toolbelt/install-ubuntu-xenial-td-agent2.5.sh
@@ -1,0 +1,34 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  curl https://packages.treasuredata.com/GPG-KEY-td-agent | apt-key add -
+
+  # add treasure data repository to apt
+  echo "deb http://packages.treasuredata.com/2.5/ubuntu/xenial/ xenial contrib" > /etc/apt/sources.list.d/treasure-data.list
+
+  # update your sources
+  apt-get update
+
+  # install the toolbelt
+  apt-get install -y td-agent
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-ubuntu-xenial-td-agent2.sh
+++ b/fluent-package/toolbelt/install-ubuntu-xenial-td-agent2.sh
@@ -1,0 +1,28 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  curl https://packages.treasuredata.com/GPG-KEY-td-agent | apt-key add -
+
+  # add treasure data repository to apt
+  echo "deb http://packages.treasuredata.com/2/ubuntu/xenial/ xenial contrib" > /etc/apt/sources.list.d/treasure-data.list
+
+  # update your sources
+  apt-get update
+
+  # install the toolbelt
+  apt-get install -y td-agent
+
+SCRIPT
+
+# message
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/fluent-package/toolbelt/install-ubuntu-xenial-td-agent3.sh
+++ b/fluent-package/toolbelt/install-ubuntu-xenial-td-agent3.sh
@@ -1,0 +1,34 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  curl https://packages.treasuredata.com/GPG-KEY-td-agent | apt-key add -
+
+  # add treasure data repository to apt
+  echo "deb http://packages.treasuredata.com/3/ubuntu/xenial/ xenial contrib" > /etc/apt/sources.list.d/treasure-data.list
+
+  # update your sources
+  apt-get update
+
+  # install the toolbelt
+  apt-get install -y td-agent
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi

--- a/fluent-package/toolbelt/install-ubuntu-xenial-td-agent4.sh
+++ b/fluent-package/toolbelt/install-ubuntu-xenial-td-agent4.sh
@@ -1,0 +1,35 @@
+echo "=============================="
+echo " td-agent Installation Script "
+echo "=============================="
+echo "This script requires superuser access to install apt packages."
+echo "You will be prompted for your password by sudo."
+
+# clear any previous sudo permission
+sudo -k
+
+# run inside sudo
+sudo sh <<SCRIPT
+  
+    # Deprecated
+    curl https://packages.treasuredata.com/GPG-KEY-td-agent | apt-key add -
+    # add treasure data repository to apt
+    echo "deb http://packages.treasuredata.com/4/ubuntu/xenial/ xenial contrib" > /etc/apt/sources.list.d/treasure-data.list
+  
+  # update your sources
+  apt update
+
+  # install the toolbelt
+  apt install -y td-agent
+
+SCRIPT
+
+# message
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "Installation completed. Happy Logging!"
+  echo ""
+else
+  echo ""
+  echo "Installation incompleted. Check above messages."
+  echo ""
+fi


### PR DESCRIPTION
Currently, fluent-package install script is hosted on
https://toolbelt.treasuredata.com and maintained under private
repository.

It rely on deploying commercial cloud service and if we lost access to
that private repository, can't manage them anymore. As a workaround,
support to generate similar install script and upload it as static
file.
