### PR TITLE
ci: add update tests about service status

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -117,7 +117,7 @@ jobs:
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/binstubs-test.sh
   test:
-    name: Test ${{ matrix.label }} ${{ matrix.test-file }}
+    name: Test ${{ matrix.label }} ${{ matrix.test }}
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -130,47 +130,51 @@ jobs:
           - Ubuntu Focal amd64
           - Ubuntu Jammy amd64
           - Ubuntu Noble amd64
-        test-file:
+        test:
           - "update-from-v4.sh"
-          - "update-to-next-version-with-backward-compat-for-v4.sh"
-          - "update-to-next-version.sh"
           - "downgrade-to-v4.sh"
           - "install-newly.sh local"
           - "install-newly.sh v5"
           - "install-newly.sh lts"
+          - "update-to-next-version.sh"
+          - "update-to-next-version-with-backward-compat-for-v4.sh"
+          - "update-to-next-version-service-status.sh enabled active"
+          - "update-to-next-version-service-status.sh enabled inactive"
+          - "update-to-next-version-service-status.sh disabled active"
+          - "update-to-next-version-service-status.sh disabled inactive"
         include:
           - label: Debian bullseye amd64
             rake-job: debian-bullseye
-            test-lxc-image: images:debian/11
+            lxc-image: images:debian/11
           - label: Debian bookworm amd64
             rake-job: debian-bookworm
-            test-lxc-image: images:debian/12
+            lxc-image: images:debian/12
           - label: Ubuntu Focal amd64
             rake-job: ubuntu-focal
-            test-lxc-image: ubuntu:20.04
+            lxc-image: ubuntu:20.04
           - label: Ubuntu Jammy amd64
             rake-job: ubuntu-jammy
-            test-lxc-image: ubuntu:22.04
+            lxc-image: ubuntu:22.04
           - label: Ubuntu Noble amd64
             rake-job: ubuntu-noble
-            test-lxc-image: ubuntu:24.04
+            lxc-image: ubuntu:24.04
         exclude:
           - label: Debian bookworm amd64
-            test-file: update-from-v4.sh
+            test: update-from-v4.sh
           - label: Debian bookworm amd64
-            test-file: update-to-next-version-with-backward-compat-for-v4.sh
+            test: update-to-next-version-with-backward-compat-for-v4.sh
           - label: Debian bookworm amd64
-            test-file: downgrade-to-v4.sh
+            test: downgrade-to-v4.sh
           - label: Ubuntu Noble amd64
-            test-file: update-from-v4.sh
+            test: update-from-v4.sh
           - label: Ubuntu Noble amd64
-            test-file: update-to-next-version-with-backward-compat-for-v4.sh
+            test: update-to-next-version-with-backward-compat-for-v4.sh
           - label: Ubuntu Noble amd64
-            test-file: downgrade-to-v4.sh
+            test: downgrade-to-v4.sh
           - label: Ubuntu Noble amd64
-            test-file: install-newly.sh v5
+            test: install-newly.sh v5
           - label: Ubuntu Noble amd64
-            test-file: install-newly.sh lts
+            test: install-newly.sh lts
     steps:
       - uses: actions/checkout@master
       - uses: actions/download-artifact@v4
@@ -180,5 +184,5 @@ jobs:
         with:
           name: packages-apt-source-${{ matrix.rake-job }}
       - uses: canonical/setup-lxd@v0.1.1
-      - name: Run Test  ${{ matrix.test-file }} on ${{ matrix.test-lxc-image }}
-        run: fluent-package/apt/systemd-test/test.sh ${{ matrix.test-lxc-image }} ${{ matrix.test-file }}
+      - name: Run Test  ${{ matrix.test }} on ${{ matrix.lxc-image }}
+        run: fluent-package/apt/systemd-test/test.sh ${{ matrix.lxc-image }} ${{ matrix.test }}

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -99,7 +99,7 @@ jobs:
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/yum/binstubs-test.sh
   v1test:
-    name: Test ${{ matrix.label }} ${{ matrix.test-file }} (CGroup V1)
+    name: Test ${{ matrix.label }} ${{ matrix.test }} (CGroup V1)
     needs: build
     runs-on: ubuntu-20.04
     timeout-minutes: 15
@@ -109,39 +109,43 @@ jobs:
         label:
           - AmazonLinux 2 x86_64
           - AmazonLinux 2023 x86_64
-        test-file:
+        test:
           - "update-from-v4.sh"
-          - "update-to-next-version-with-backward-compat-for-v4.sh"
-          - "update-to-next-version.sh"
           - "downgrade-to-v4.sh"
           - "install-newly.sh local"
           - "install-newly.sh v5"
           - "install-newly.sh lts"
+          - "update-to-next-version.sh"
+          - "update-to-next-version-with-backward-compat-for-v4.sh"
+          - "update-to-next-version-service-status.sh enabled active"
+          - "update-to-next-version-service-status.sh enabled inactive"
+          - "update-to-next-version-service-status.sh disabled active"
+          - "update-to-next-version-service-status.sh disabled inactive"
         include:
           - label: AmazonLinux 2 x86_64
             rake-job: amazonlinux-2
-            test-lxc-image: images:amazonlinux/2
+            lxc-image: images:amazonlinux/2
           - label: AmazonLinux 2023 x86_64
             rake-job: amazonlinux-2023
-            test-lxc-image: images:amazonlinux/2023
+            lxc-image: images:amazonlinux/2023
         exclude:
           - label: AmazonLinux 2023 x86_64
-            test-file: update-from-v4.sh
+            test: update-from-v4.sh
           - label: AmazonLinux 2023 x86_64
-            test-file: update-to-next-version-with-backward-compat-for-v4.sh
+            test: update-to-next-version-with-backward-compat-for-v4.sh
           - label: AmazonLinux 2023 x86_64
-            test-file: downgrade-to-v4.sh
+            test: downgrade-to-v4.sh
     steps:
       - uses: actions/checkout@master
       - uses: actions/download-artifact@v4
         with:
           name: packages-${{ matrix.rake-job }}
       - uses: canonical/setup-lxd@v0.1.1
-      - name: Run Test ${{ matrix.test-file }} on ${{ matrix.test-lxc-image }}
-        run: fluent-package/yum/systemd-test/test.sh ${{ matrix.test-lxc-image }} ${{ matrix.test-file }}
+      - name: Run Test ${{ matrix.test }} on ${{ matrix.lxc-image }}
+        run: fluent-package/yum/systemd-test/test.sh ${{ matrix.lxc-image }} ${{ matrix.test }}
 
   v2test:
-    name: Test ${{ matrix.label }} ${{ matrix.test-file }} (CGroup V2)
+    name: Test ${{ matrix.label }} ${{ matrix.test }} (CGroup V2)
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -151,26 +155,30 @@ jobs:
         label:
           - RockyLinux 8 x86_64
           - AlmaLinux 9 x86_64
-        test-file:
+        test:
           - "update-from-v4.sh"
-          - "update-to-next-version-with-backward-compat-for-v4.sh"
-          - "update-to-next-version.sh"
           - "downgrade-to-v4.sh"
           - "install-newly.sh local"
           - "install-newly.sh v5"
           - "install-newly.sh lts"
+          - "update-to-next-version.sh"
+          - "update-to-next-version-with-backward-compat-for-v4.sh"
+          - "update-to-next-version-service-status.sh enabled active"
+          - "update-to-next-version-service-status.sh enabled inactive"
+          - "update-to-next-version-service-status.sh disabled active"
+          - "update-to-next-version-service-status.sh disabled inactive"
         include:
           - label: RockyLinux 8 x86_64
             rake-job: rockylinux-8
-            test-lxc-image: images:rockylinux/8
+            lxc-image: images:rockylinux/8
           - label: AlmaLinux 9 x86_64
             rake-job: almalinux-9
-            test-lxc-image: images:almalinux/9
+            lxc-image: images:almalinux/9
     steps:
       - uses: actions/checkout@master
       - uses: actions/download-artifact@v4
         with:
           name: packages-${{ matrix.rake-job }}
       - uses: canonical/setup-lxd@v0.1.1
-      - name: Run Test ${{ matrix.test-file }} on ${{ matrix.test-lxc-image }}
-        run: fluent-package/yum/systemd-test/test.sh ${{ matrix.test-lxc-image }} ${{ matrix.test-file }}
+      - name: Run Test ${{ matrix.test }} on ${{ matrix.lxc-image }}
+        run: fluent-package/yum/systemd-test/test.sh ${{ matrix.lxc-image }} ${{ matrix.test }}

--- a/fluent-package/apt/systemd-test/test.sh
+++ b/fluent-package/apt/systemd-test/test.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-if [ -z $1 ]; then
-    echo "Error: Need to specify lxc image name."
-    echo "Ex.) $ ./test.sh ubuntu:20.04 "
+if [ $# -lt 2 ]; then
+    echo "Error: Need to specify lxc image name and filename."
     echo "Ex. CI) $ ./test.sh ubuntu:20.04 install-newly.sh local"
     exit 1
 fi
 
 image=$1
 test_file=$2
-apt_repo_type=$3
+shift 2
+other_args="$@"
 dir="/host/fluent-package/apt/systemd-test"
 
 set -eux
@@ -25,8 +25,8 @@ echo "::endgroup::"
 echo "::group::Run test: setup $image"
 lxc exec target -- $dir/setup.sh
 echo "::endgroup::"
-echo "::group::Run test: $test_file $apt_repo_type on $image"
-lxc exec target -- $dir/$test_file $apt_repo_type
+echo "::group::Run test: $test_file $other_args on $image"
+lxc exec target -- $dir/$test_file $other_args
 echo "::endgroup::"
 echo "::group::Run test: cleanup $image"
 lxc stop target

--- a/fluent-package/apt/systemd-test/update-to-next-version-service-status.sh
+++ b/fluent-package/apt/systemd-test/update-to-next-version-service-status.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -exu
+
+. $(dirname $0)/../commonvar.sh
+
+enabled_before_update=$1 # enabled / disabled
+status_before_update=$2 # active / inactive
+
+# Install the current
+sudo apt install -V -y \
+    /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb
+
+# Make a dummy pacakge for the next version
+dpkg-deb -R /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb tmp
+last_ver=$(cat tmp/DEBIAN/control | grep "Version: " | sed -E "s/Version: ([0-9.]+)-([0-9]+)/\2/g")
+sed -i -E "s/Version: ([0-9.]+)-([0-9]+)/Version: \1-$(($last_ver+1))/g" tmp/DEBIAN/control
+dpkg-deb --build tmp next_version.deb
+
+# The service should start automatically
+systemctl is-active fluentd
+# The service should be enabled by default
+systemctl is-enabled fluentd
+
+# Start the service
+if [ "$enabled_before_update" = disabled ]; then
+    sudo systemctl disable fluentd
+fi
+if [ "$status_before_update" = inactive ]; then
+    sudo systemctl stop fluentd
+fi
+
+main_pid=$(systemctl show --value --property=MainPID fluentd)
+
+# Install the dummy package
+sudo apt install -V -y ./next_version.deb
+
+# The service should take over the state
+if [ "$enabled_before_update" = enabled ]; then
+    systemctl is-enabled fluentd
+else
+    (! systemctl is-enabled fluentd)
+fi
+
+if [ "$status_before_update" = active ] || [ "$enabled_before_update" = enabled ] ; then
+    # The service should restart automatically after update
+    systemctl is-active fluentd
+    test $main_pid -ne $(systemctl show --value --property=MainPID fluentd)
+else
+    # The service should NOT start automatically
+    (! systemctl is-active fluentd)
+fi

--- a/fluent-package/yum/systemd-test/test.sh
+++ b/fluent-package/yum/systemd-test/test.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 
-if [ -z $1 ]; then
-    echo "Error: Need to specify distribution name."
-    echo "Ex.) $ ./test.sh centos-7"
-    echo "Ex.CI) $ ./test.sh centos-7 install-newly.sh local"
+if [ $# -lt 2 ]; then
+    echo "Error: Need to specify lxc image name and filename."
+    echo "Ex. CI) $ ./test.sh images:rockylinux/8 install-newly.sh local"
     exit 1
 fi
 
 image=$1
 test_file=$2
-yum_repo_type=$3
+shift 2
+other_args="$@"
 dir="/host/fluent-package/yum/systemd-test"
+
 set -eux
 
 echo "::group::Run test: launch $image"
@@ -21,8 +22,8 @@ echo "::group::Run test: configure $image"
 lxc config device add target host disk source=$PWD path=/host
 lxc list
 echo "::endgroup::"
-echo "::group::Run test: $test_file $yum_repo_type on $image"
-lxc exec target -- $dir/$test_file $yum_repo_type
+echo "::group::Run test: $test_file $other_args on $image"
+lxc exec target -- $dir/$test_file $other_args
 echo "::endgroup::"
 echo "::group::Run test: cleanup $image"
 lxc stop target

--- a/fluent-package/yum/systemd-test/update-to-next-version-service-status.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version-service-status.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -exu
+
+. $(dirname $0)/commonvar.sh
+
+enabled_before_update=$1 # enabled / disabled
+status_before_update=$2 # active / inactive
+
+# Install the current
+package="/host/${distribution}/${DISTRIBUTION_VERSION}/x86_64/Packages/fluent-package-[0-9]*.rpm"
+sudo $DNF install -y $package
+
+# The service should NOT start automatically
+(! systemctl is-active fluentd)
+# The service should be DISabled by default
+(! systemctl is-enabled fluentd)
+
+# Start the service
+if [ "$enabled_before_update" = enabled ]; then
+    sudo systemctl enable fluentd
+fi
+if [ "$status_before_update" = active ]; then
+    sudo systemctl start fluentd
+fi
+
+main_pid=$(eval $(systemctl show fluentd --property=MainPID) && echo $MainPID)
+
+# Make a dummy pacakge for the next version
+case $distribution in
+    amazon)
+        case $version in
+            2023)
+                curl -L -o rpmrebuild.noarch.rpm https://sourceforge.net/projects/rpmrebuild/files/latest/download
+                sudo $DNF install -y ./rpmrebuild.noarch.rpm
+                ;;
+            2)
+                sudo amazon-linux-extras install -y epel
+                sudo $DNF install -y rpmrebuild
+                ;;
+        esac
+        ;;
+    *)
+        sudo $DNF install -y epel-release
+        sudo $DNF install -y rpmrebuild
+        ;;
+esac
+# Example: "1.el9"
+release=$(rpmquery --queryformat="%{Release}" -p $package)
+# Example: "1"
+release_ver=$(echo $release | cut -d . -f1)
+# Example: "2.el9"
+next_release=$(($release_ver+1)).$(echo $release | cut -d. -f2)
+rpmrebuild --release=$next_release --package $package
+next_package=$(find rpmbuild -name "*.rpm")
+
+# Install the dummy package of the next version
+sudo $DNF install -y ./$next_package
+
+# The service should take over the state
+if [ "$enabled_before_update" = enabled ]; then
+    systemctl is-enabled fluentd
+else
+    (! systemctl is-enabled fluentd)
+fi
+
+if [ "$status_before_update" = active ]; then
+    # The service should restart automatically after update
+    systemctl is-active fluentd
+    test $main_pid -ne $(eval $(systemctl show fluentd --property=MainPID) && echo $MainPID)
+else
+    # The service should NOT start automatically
+    (! systemctl is-active fluentd)
+fi


### PR DESCRIPTION
There is specification difference between DEB and RPM.

At least, there should be tests to clarify the current specification.

The current specification:

* DEB
  * The service is **enabled** by default.
  * The service **starts automatically after new install**.
  * The service starts automatically **when it was active OR enabled before update**.
* RPM
  * The service is **disabled** by default.
  * The service **does not start automatically after new install**.
  * The service starts automatically **only when it was active before update**.
