### PR TITLE
Embed fluent package info into environment variable

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -133,6 +133,7 @@ jobs:
         test-file:
           - "update-from-v4.sh"
           - "update-to-next-version-with-backward-compat-for-v4.sh"
+          - "update-to-next-version.sh"
           - "downgrade-to-v4.sh"
           - "install-newly.sh local"
           - "install-newly.sh v5"

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -112,6 +112,7 @@ jobs:
         test-file:
           - "update-from-v4.sh"
           - "update-to-next-version-with-backward-compat-for-v4.sh"
+          - "update-to-next-version.sh"
           - "downgrade-to-v4.sh"
           - "install-newly.sh local"
           - "install-newly.sh v5"
@@ -153,6 +154,7 @@ jobs:
         test-file:
           - "update-from-v4.sh"
           - "update-to-next-version-with-backward-compat-for-v4.sh"
+          - "update-to-next-version.sh"
           - "downgrade-to-v4.sh"
           - "install-newly.sh local"
           - "install-newly.sh v5"

--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -135,10 +135,33 @@ def template_params(params = nil)
   end
 
   if params
+    if params[:fluentd_version]
+      config.merge!({fluentd_version: params[:fluentd_version],
+                     fluentd_revision: FLUENTD_REVISION})
+    end
     config.merge(params)
   else
     config
   end
+end
+
+def fluent_package_info(version)
+  "#{PACKAGE_NAME} #{PACKAGE_VERSION} fluentd #{version} (#{FLUENTD_REVISION})"
+end
+
+def extract_fluentd_version(archive_path)
+  puts "::group::Extract fluentd version from: #{archive_path}" if ENV["CI"]
+  fluentd_version = ""
+  sh("tar", "xvf", archive_path, "-C", File.dirname(archive_path), "--no-same-owner")
+  archive_dir = File.join(File.dirname(archive_path),
+                          File.basename(archive_path, ".tar.gz"))
+  Dir.chdir(archive_dir) do
+    IO.popen("git tag --contains #{FLUENTD_REVISION}") do |tags|
+      fluentd_version = tags.readlines.last.chomp.delete_prefix("v")
+    end
+  end
+  puts "::endgroup::" if ENV["CI"]
+  fluentd_version
 end
 
 def template_path(*path_parts)
@@ -586,7 +609,8 @@ class BuildTask
       desc "Create systemd unit file for Red Hat like systems"
       task :rpm_systemd do
         dest =  File.join(STAGING_DIR, 'usr', 'lib', 'systemd', 'system', SERVICE_NAME + ".service")
-        params = {pkg_type: "rpm"}
+        version = extract_fluentd_version(@download_task.file_fluentd_archive)
+        params = {pkg_type: "rpm", fluentd_version: version}
         render_systemd_unit_file(dest, template_params(params))
         render_systemd_environment_file(template_params(params))
       end
@@ -594,7 +618,8 @@ class BuildTask
       desc "Create systemd unit file for Debian like systems"
       task :deb_systemd do
         dest = File.join(STAGING_DIR, 'lib', 'systemd', 'system', SERVICE_NAME + ".service")
-        params = {pkg_type: "deb"}
+        version = extract_fluentd_version(@download_task.file_fluentd_archive)
+        params = {pkg_type: "deb", fluentd_version: version}
         render_systemd_unit_file(dest, template_params(params))
         render_systemd_environment_file(template_params(params))
       end

--- a/fluent-package/apt/systemd-test/update-to-next-version.sh
+++ b/fluent-package/apt/systemd-test/update-to-next-version.sh
@@ -12,6 +12,10 @@ sudo apt install -V -y \
 dpkg-deb -R /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb tmp
 last_ver=$(cat tmp/DEBIAN/control | grep "Version: " | sed -E "s/Version: ([0-9.]+)-([0-9]+)/\2/g")
 sed -i -E "s/Version: ([0-9.]+)-([0-9]+)/Version: \1-$(($last_ver+1))/g" tmp/DEBIAN/control
+# Bump up x.y.w.z to check whether FLUENT_PACKAGE_VERSION was updated correctly later
+sed -i -E "s/FLUENT_PACKAGE_VERSION=([0-9.]+)/FLUENT_PACKAGE_VERSION=\1.1/g" tmp/lib/systemd/system/fluentd.service
+next_package_ver=$(cat tmp/lib/systemd/system/fluentd.service | grep "FLUENT_PACKAGE_VERSION" | sed -E "s/Environment=FLUENT_PACKAGE_VERSION=(.+)/\1/")
+echo "repacked next fluent-package version: $next_package_ver"
 dpkg-deb --build tmp next_version.deb
 
 # Install the dummy package
@@ -38,6 +42,7 @@ test $(eval $env_vars && echo $FLUENT_CONF) = "/etc/fluent/fluentd.conf"
 test $(eval $env_vars && echo $FLUENT_PACKAGE_LOG_FILE) = "/var/log/fluent/fluentd.log"
 test $(eval $env_vars && echo $FLUENT_PLUGIN) = "/etc/fluent/plugin"
 test $(eval $env_vars && echo $FLUENT_SOCKET) = "/var/run/fluent/fluentd.sock"
+test $(eval $env_vars && echo $FLUENT_PACKAGE_VERSION) = "$next_package_ver"
 
 # Test: fluent-diagtool
 sudo fluent-gem install fluent-plugin-concat

--- a/fluent-package/templates/etc/systemd/fluentd.service.erb
+++ b/fluent-package/templates/etc/systemd/fluentd.service.erb
@@ -20,6 +20,9 @@ Environment=FLUENT_CONF=/etc/<%= package_dir %>/<%= service_name %>.conf
 Environment=FLUENT_PLUGIN=/etc/<%= package_dir %>/plugin
 Environment=FLUENT_SOCKET=/var/run/<%= package_dir %>/<%= service_name %>.sock
 Environment=FLUENT_PACKAGE_LOG_FILE=/var/log/<%= package_dir %>/<%= service_name %>.log
+Environment=FLUENT_PACKAGE_VERSION=<%= version %>
+Environment=FLUENT_PACKAGE_FLUENTD_VERSION=<%= fluentd_version %>
+Environment=FLUENT_PACKAGE_FLUENTD_REVISION=<%= fluentd_revision %>
 <% if pkg_type == 'deb' %>
 EnvironmentFile=-/etc/default/<%= service_name %>
 <% else %>


### PR DESCRIPTION
Embed fluent package info into environment variable

It is aimed to detect current running process's fluentd version and
so on from /proc/id/environ.

This fix introduce the following environment variables which contains
similar information as same as /usr/sbin/fluentd -v

* FLUENT_PACKAGE_VERSION
* FLUENT_PACKAGE_FLUENTD_VERSION
* FLUENT_PACKAGE_FLUENTD_REVISION
