### PR TITLE
github: try to use more customized test labels

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -13,16 +13,16 @@ jobs:
       fail-fast: false
       matrix:
         label:
-          - Debian GNU/Linux bullseye amd64
-          - Debian GNU/Linux bookworm amd64
+          - Debian bullseye amd64
+          - Debian bookworm amd64
           - Ubuntu Focal amd64
           - Ubuntu Jammy amd64
           - Ubuntu Noble amd64
         include:
-          - label: Debian GNU/Linux bullseye amd64
+          - label: Debian bullseye amd64
             rake-job: debian-bullseye
             test-docker-image: debian:bullseye
-          - label: Debian GNU/Linux bookworm amd64
+          - label: Debian bookworm amd64
             rake-job: debian-bookworm
             test-docker-image: debian:bookworm
           - label: Ubuntu Focal amd64
@@ -117,7 +117,7 @@ jobs:
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/binstubs-test.sh
   test:
-    name: Test
+    name: Test ${{ matrix.label }} ${{ matrix.test-file }}
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -125,8 +125,8 @@ jobs:
       fail-fast: false
       matrix:
         label:
-          - Debian GNU/Linux bullseye amd64
-          - Debian GNU/Linux bookworm amd64
+          - Debian bullseye amd64
+          - Debian bookworm amd64
           - Ubuntu Focal amd64
           - Ubuntu Jammy amd64
           - Ubuntu Noble amd64
@@ -138,10 +138,10 @@ jobs:
           - "install-newly.sh v5"
           - "install-newly.sh lts"
         include:
-          - label: Debian GNU/Linux bullseye amd64
+          - label: Debian bullseye amd64
             rake-job: debian-bullseye
             test-lxc-image: images:debian/11
-          - label: Debian GNU/Linux bookworm amd64
+          - label: Debian bookworm amd64
             rake-job: debian-bookworm
             test-lxc-image: images:debian/12
           - label: Ubuntu Focal amd64
@@ -154,11 +154,11 @@ jobs:
             rake-job: ubuntu-noble
             test-lxc-image: ubuntu:24.04
         exclude:
-          - label: Debian GNU/Linux bookworm amd64
+          - label: Debian bookworm amd64
             test-file: update-from-v4.sh
-          - label: Debian GNU/Linux bookworm amd64
+          - label: Debian bookworm amd64
             test-file: update-to-next-version-with-backward-compat-for-v4.sh
-          - label: Debian GNU/Linux bookworm amd64
+          - label: Debian bookworm amd64
             test-file: downgrade-to-v4.sh
           - label: Ubuntu Noble amd64
             test-file: update-from-v4.sh

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -99,7 +99,7 @@ jobs:
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/yum/binstubs-test.sh
   v1test:
-    name: Test (CGroup V1)
+    name: Test ${{ matrix.label }} ${{ matrix.test-file }} (CGroup V1)
     needs: build
     runs-on: ubuntu-20.04
     timeout-minutes: 15
@@ -140,7 +140,7 @@ jobs:
         run: fluent-package/yum/systemd-test/test.sh ${{ matrix.test-lxc-image }} ${{ matrix.test-file }}
 
   v2test:
-    name: Test (CGroup V2)
+    name: Test ${{ matrix.label }} ${{ matrix.test-file }} (CGroup V2)
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
Currently, it is bit hard to distinct each Test jobs
on fluent-package-builder/actions/runs page.

This is because Test (CGroup V1) matrix.label matrix.test-file
is shown by default.

This commit try to make it more visibility on that page.

