### PR TITLE
Fix deprecated usage of ERB.new

### DIFF
--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -158,7 +158,7 @@ def render_template(dest, src, config, opts={})
   logger.info("Generate #{dest}")
   ensure_directory(directory)
   File.open(dest, 'w', mode) do |f|
-    template = ERB.new(File.read(src), nil, '<>')
+    template = ERB.new(File.read(src), trim_mode: '<>')
     f.write(template.result(erb_binding))
   end
 end


### PR DESCRIPTION
It fixes the following warning (Since Ruby 3.1):

  Rakefile:168: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
  Rakefile:168: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.

This does not change the content of fluent-package.