### PR TITLE
Add tests and fixes to no-downtime feature branch

### DIFF
--- a/fluent-package/apt/systemd-test/update-to-next-version-service-status.sh
+++ b/fluent-package/apt/systemd-test/update-to-next-version-service-status.sh
@@ -42,10 +42,13 @@ else
     (! systemctl is-enabled fluentd)
 fi
 
-if [ "$status_before_update" = active ] || [ "$enabled_before_update" = enabled ] ; then
-    # The service should restart automatically after update
+if [ "$status_before_update" = active ]; then
+    # The service should NOT restart automatically after update
     systemctl is-active fluentd
-    test $main_pid -ne $(systemctl show --value --property=MainPID fluentd)
+    test $main_pid -eq $(systemctl show --value --property=MainPID fluentd)
+elif [ "$enabled_before_update" = enabled ] && [ "$status_before_update" = inactive ]; then
+    # The service should start automatically
+    systemctl is-active fluentd
 else
     # The service should NOT start automatically
     (! systemctl is-active fluentd)

--- a/fluent-package/apt/systemd-test/update-to-next-version-service-status.sh
+++ b/fluent-package/apt/systemd-test/update-to-next-version-service-status.sh
@@ -46,7 +46,7 @@ if [ "$status_before_update" = active ]; then
     # The service should NOT restart automatically after update
     systemctl is-active fluentd
     test $main_pid -eq $(systemctl show --value --property=MainPID fluentd)
-elif [ "$enabled_before_update" = enabled ] && [ "$status_before_update" = inactive ]; then
+elif [ "$enabled_before_update" = enabled ]; then
     # The service should start automatically
     systemctl is-active fluentd
 else

--- a/fluent-package/apt/systemd-test/update-to-next-version-service-status.sh
+++ b/fluent-package/apt/systemd-test/update-to-next-version-service-status.sh
@@ -44,6 +44,7 @@ fi
 
 if [ "$status_before_update" = active ]; then
     # The service should NOT restart automatically after update
+    # (The process before update should continue to run)
     systemctl is-active fluentd
     test $main_pid -eq $(systemctl show --value --property=MainPID fluentd)
 elif [ "$enabled_before_update" = enabled ]; then

--- a/fluent-package/apt/systemd-test/update-to-next-version.sh
+++ b/fluent-package/apt/systemd-test/update-to-next-version.sh
@@ -42,7 +42,8 @@ test $(eval $env_vars && echo $FLUENT_CONF) = "/etc/fluent/fluentd.conf"
 test $(eval $env_vars && echo $FLUENT_PACKAGE_LOG_FILE) = "/var/log/fluent/fluentd.log"
 test $(eval $env_vars && echo $FLUENT_PLUGIN) = "/etc/fluent/plugin"
 test $(eval $env_vars && echo $FLUENT_SOCKET) = "/var/run/fluent/fluentd.sock"
-test $(eval $env_vars && echo $FLUENT_PACKAGE_VERSION) = "$next_package_ver"
+# FLUENT_PACKAGE_VERSION will be updated after the next restart
+(! test $(eval $env_vars && echo $FLUENT_PACKAGE_VERSION) = "$next_package_ver")
 
 # Test: fluent-diagtool
 sudo fluent-gem install fluent-plugin-concat

--- a/fluent-package/apt/systemd-test/update-to-next-version.sh
+++ b/fluent-package/apt/systemd-test/update-to-next-version.sh
@@ -43,6 +43,7 @@ test $(eval $env_vars && echo $FLUENT_PACKAGE_LOG_FILE) = "/var/log/fluent/fluen
 test $(eval $env_vars && echo $FLUENT_PLUGIN) = "/etc/fluent/plugin"
 test $(eval $env_vars && echo $FLUENT_SOCKET) = "/var/run/fluent/fluentd.sock"
 # FLUENT_PACKAGE_VERSION will be updated after the next restart
+# TODO: consider how to test the update of version info
 (! test $(eval $env_vars && echo $FLUENT_PACKAGE_VERSION) = "$next_package_ver")
 
 # Test: fluent-diagtool

--- a/fluent-package/debian/rules
+++ b/fluent-package/debian/rules
@@ -20,7 +20,7 @@ override_dh_auto_install:
 # related start/restart hook script embedding. It does not omit
 # deb-systemd-helper enable/update-state fluentd.service
 override_dh_installsystemd:
-	dh_installsystemd --no-stop-on-upgrade
+	dh_installsystemd --no-restart-after-upgrade --no-stop-on-upgrade
 
 override_dh_auto_clean:
 	rake clean

--- a/fluent-package/yum/systemd-test/update-to-next-version-service-status.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version-service-status.sh
@@ -65,9 +65,9 @@ else
 fi
 
 if [ "$status_before_update" = active ]; then
-    # The service should restart automatically after update
+    # The service should NOT restart automatically after update
     systemctl is-active fluentd
-    test $main_pid -ne $(eval $(systemctl show fluentd --property=MainPID) && echo $MainPID)
+    test $main_pid -eq $(eval $(systemctl show fluentd --property=MainPID) && echo $MainPID)
 else
     # The service should NOT start automatically
     (! systemctl is-active fluentd)

--- a/fluent-package/yum/systemd-test/update-to-next-version-service-status.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version-service-status.sh
@@ -66,6 +66,7 @@ fi
 
 if [ "$status_before_update" = active ]; then
     # The service should NOT restart automatically after update
+    # (The process before update should continue to run)
     systemctl is-active fluentd
     test $main_pid -eq $(eval $(systemctl show fluentd --property=MainPID) && echo $MainPID)
 else

--- a/fluent-package/yum/systemd-test/update-to-next-version.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version.sh
@@ -65,18 +65,8 @@ test $(eval $env_vars && echo $FLUENT_CONF) = "/etc/fluent/fluentd.conf"
 test $(eval $env_vars && echo $FLUENT_PACKAGE_LOG_FILE) = "/var/log/fluent/fluentd.log"
 test $(eval $env_vars && echo $FLUENT_PLUGIN) = "/etc/fluent/plugin"
 test $(eval $env_vars && echo $FLUENT_SOCKET) = "/var/run/fluent/fluentd.sock"
-cpe_name=$(grep CPE_NAME /etc/os-release | cut -d'=' -f2)
-case $cpe_name in
-    *rocky:8*)
-	# RHEL8 %systemd_postun_with_restart doesn't restart when already service is running
-	# thus, FLUENT_PACKAGE_VERSION will be kept.
-	release=$(rpmquery --queryformat="%{Version}" -p $package)
-	test $(eval $env_vars && echo $FLUENT_PACKAGE_VERSION) = "$release"
-    ;;
-    *)
-	test $(eval $env_vars && echo $FLUENT_PACKAGE_VERSION) = "$next_package_ver"
-	;;
-esac
+# FLUENT_PACKAGE_VERSION will be updated after the next restart
+(! test $(eval $env_vars && echo $FLUENT_PACKAGE_VERSION) = "$next_package_ver")
 
 # Test: logs
 sleep 3

--- a/fluent-package/yum/systemd-test/update-to-next-version.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version.sh
@@ -66,6 +66,7 @@ test $(eval $env_vars && echo $FLUENT_PACKAGE_LOG_FILE) = "/var/log/fluent/fluen
 test $(eval $env_vars && echo $FLUENT_PLUGIN) = "/etc/fluent/plugin"
 test $(eval $env_vars && echo $FLUENT_SOCKET) = "/var/run/fluent/fluentd.sock"
 # FLUENT_PACKAGE_VERSION will be updated after the next restart
+# TODO: consider how to test the update of version info
 (! test $(eval $env_vars && echo $FLUENT_PACKAGE_VERSION) = "$next_package_ver")
 
 # Test: logs


### PR DESCRIPTION
This PR integrates tests into into feature branches.
The changes are prepared at https://github.com/fluent/fluent-package-builder/pull/683

* Add --no-restart-after-upgrade option for dh_installsystemd in order to suppress restarting on ubuntu focal
* Fix tests for no-downtime feature to confirm no-restart at upgrading package
  * Note: Debian/Ubuntu packages need to fix migration_from_v4_main_process and restart at upgrade time. This causes some tests to fail on Debian/Ubuntu.