### PR TITLE
deb rpm: fix local dependency gem

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -54,16 +54,34 @@ jobs:
             fluent-package/apt/repositories
             fluent-apt-source/apt/repositories
             fluent-lts-apt-source/apt/repositories
+            v6-test/fluent-package/apt/repositories
           key: ${{ runner.os }}-cache-${{ matrix.rake-job }}-${{ hashFiles('**/config.rb', '**/Rakefile', '**/Gemfile*', 'fluent-package/templates/**', 'fluent-package/debian/**', 'fluent-package/apt/**/Dockerfile') }}
       - name: Build deb with Docker
         if: ${{ ! steps.cache-deb.outputs.cache-hit }}
         run: |
+          rake apt:build APT_TARGETS=${{ matrix.rake-job }}
+      - uses: actions/checkout@master
+        if: ${{ ! steps.cache-deb.outputs.cache-hit }}
+        with:
+          path: v6-test
+      - name: Build v6 deb with Docker
+        if: ${{ ! steps.cache-deb.outputs.cache-hit }}
+        run: |
+          cd v6-test
+          git config user.email "fluentd@googlegroups.com"
+          git config user.name "Fluentd developers"
+          git am fluent-package/bump-version-v6.patch
           rake apt:build APT_TARGETS=${{ matrix.rake-job }}
       - name: Upload fluent-package deb
         uses: actions/upload-artifact@master
         with:
           name: packages-${{ matrix.rake-job }}
           path: fluent-package/apt/repositories
+      - name: Upload v6 fluent-package deb
+        uses: actions/upload-artifact@master
+        with:
+          name: v6-packages-${{ matrix.rake-job }}
+          path: v6-test/fluent-package/apt/repositories
       - name: Upload fluent-apt-source deb
         uses: actions/upload-artifact@master
         with:
@@ -158,6 +176,7 @@ jobs:
           - "update-to-next-version-service-status.sh disabled active"
           - "update-to-next-version-service-status.sh disabled inactive"
           - "update-to-next-version-without-data-lost.sh"
+          - "update-to-next-major-version.sh"
         include:
           - label: Debian bullseye amd64
             rake-job: debian-bullseye
@@ -204,6 +223,10 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: packages-${{ matrix.rake-job }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: v6-packages-${{ matrix.rake-job }}
+          path: v6-test
       - uses: actions/download-artifact@v4
         with:
           name: packages-apt-source-${{ matrix.rake-job }}

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -50,17 +50,36 @@ jobs:
         uses: actions/cache@v4
         id: cache-rpm
         with:
-          path: fluent-package/yum/repositories
+          path: |
+            fluent-package/yum/repositories
+            v6-test/fluent-package/yum/repositories
           key: ${{ runner.os }}-cache-${{ matrix.rake-job }}-${{ hashFiles('**/config.rb', '**/Rakefile', '**/Gemfile*', '**/*.spec.in', 'fluent-package/templates/**', 'fluent-package/yum/**/Dockerfile') }}
       - name: Build rpm with Docker
         if: ${{ ! steps.cache-rpm.outputs.cache-hit }}
         run: |
+          rake yum:build YUM_TARGETS=${{ matrix.rake-job }}
+      - uses: actions/checkout@master
+        if: ${{ ! steps.cache-rpm.outputs.cache-hit }}
+        with:
+          path: v6-test
+      - name: Build v6 rpm with Docker
+        if: ${{ ! steps.cache-rpm.outputs.cache-hit }}
+        run: |
+          cd v6-test
+          git config user.email "fluentd@googlegroups.com"
+          git config user.name "Fluentd developers"
+          git am fluent-package/bump-version-v6.patch
           rake yum:build YUM_TARGETS=${{ matrix.rake-job }}
       - name: Upload fluent-package rpm
         uses: actions/upload-artifact@v4
         with:
           name: packages-${{ matrix.rake-job }}
           path: fluent-package/yum/repositories
+      - name: Upload v6 fluent-package rpm
+        uses: actions/upload-artifact@v4
+        with:
+          name: v6-packages-${{ matrix.rake-job }}
+          path: v6-test/fluent-package/yum/repositories
       # TODO move the following steps to "Test" job
       - name: Check Package Size
         run: |
@@ -132,6 +151,7 @@ jobs:
           - "update-to-next-version-service-status.sh disabled active"
           - "update-to-next-version-service-status.sh disabled inactive"
           - "update-to-next-version-without-data-lost.sh"
+          - "update-to-next-major-version.sh"
         include:
           - label: AmazonLinux 2 x86_64
             rake-job: amazonlinux-2
@@ -151,6 +171,10 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: packages-${{ matrix.rake-job }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: v6-packages-${{ matrix.rake-job }}
+          path: v6-test
       - uses: canonical/setup-lxd@v0.1.1
       - name: Run diagnostic
         run: |
@@ -197,6 +221,7 @@ jobs:
           - "update-to-next-version-service-status.sh disabled active"
           - "update-to-next-version-service-status.sh disabled inactive"
           - "update-to-next-version-without-data-lost.sh"
+          - "update-to-next-major-version.sh"
         include:
           - label: RockyLinux 8 x86_64
             rake-job: rockylinux-8
@@ -209,6 +234,10 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: packages-${{ matrix.rake-job }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: v6-packages-${{ matrix.rake-job }}
+          path: v6-test
       - uses: canonical/setup-lxd@v0.1.1
       - name: Run Test ${{ matrix.test }} on ${{ matrix.lxc-image }}
         run: fluent-package/yum/systemd-test/test.sh ${{ matrix.lxc-image }} ${{ matrix.test }}

--- a/fluent-package/apt/systemd-test/update-to-next-major-version.sh
+++ b/fluent-package/apt/systemd-test/update-to-next-major-version.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -exu
+
+. $(dirname $0)/../commonvar.sh
+
+# Install the current
+sudo apt install -V -y \
+    /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb
+
+# Install plugin manually (plugin and gem)
+sudo /opt/fluent/bin/fluent-gem install --no-document fluent-plugin-concat
+sudo /opt/fluent/bin/fluent-gem install --no-document gqtp
+
+# Install next major version
+sudo apt install -V -y \
+    /host/v6-test/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb
+
+# Test: Check whether plugin/gem were installed during upgrading
+/opt/fluent/bin/fluent-gem list | grep fluent-plugin-concat
+# Non fluent-plugin- prefix gem should not be installed automatically
+(! /opt/fluent/bin/fluent-gem list | grep gqtp)

--- a/fluent-package/bump-version-v6.patch
+++ b/fluent-package/bump-version-v6.patch
@@ -1,0 +1,65 @@
+From 887c36b60822995aa889fea6a181f00975cdfff7 Mon Sep 17 00:00:00 2001
+From: Kentaro Hayashi <hayashi@clear-code.com>
+Date: Thu, 17 Oct 2024 19:45:02 +0900
+Subject: [PATCH 1/2] bump version
+
+Signed-off-by: Kentaro Hayashi <hayashi@clear-code.com>
+---
+ fluent-package/config.rb                  | 6 +++---
+ fluent-package/debian/changelog           | 6 ++++++
+ fluent-package/yum/fluent-package.spec.in | 3 +++
+ 3 files changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/fluent-package/config.rb b/fluent-package/config.rb
+index a9e13bc..e61bca4 100644
+--- a/fluent-package/config.rb
++++ b/fluent-package/config.rb
+@@ -1,5 +1,5 @@
+ PACKAGE_NAME = "fluent-package"
+-PACKAGE_VERSION = "5.1.0"
++PACKAGE_VERSION = "6.0.0"
+ 
+ # Keep internal path (/opt/td-agent) for package name migration
+ SERVICE_NAME = "fluentd"
+@@ -23,8 +23,8 @@ OPENSSL_FOR_MACOS_SHA256SUM = "6c13d2bf38fdf31eac3ce2a347073673f5d63263398f1f69d
+ BUNDLER_VERSION= "2.3.27"
+ 
+ # https://www.ruby-lang.org/en/downloads/ (tar.gz)
+-BUNDLED_RUBY_VERSION = "3.2.5"
+-BUNDLED_RUBY_SOURCE_SHA256SUM = "ef0610b498f60fb5cfd77b51adb3c10f4ca8ed9a17cb87c61e5bea314ac34a16"
++BUNDLED_RUBY_VERSION = "3.3.5"
++BUNDLED_RUBY_SOURCE_SHA256SUM = "3781a3504222c2f26cb4b9eb9c1a12dbf4944d366ce24a9ff8cf99ecbce75196"
+ 
+ BUNDLED_RUBY_PATCHES = [
+   # An example entry:
+diff --git a/fluent-package/debian/changelog b/fluent-package/debian/changelog
+index f24ec3e..0089f56 100644
+--- a/fluent-package/debian/changelog
++++ b/fluent-package/debian/changelog
+@@ -1,3 +1,9 @@
++fluent-package (6.0.0-1) unstable; urgency=low
++
++  * New upstream release.
++
++ -- Kentaro Hayashi <kenhys@xdump.org>  Tue, 8 Oct 2024 07:47:29 -0000
++
+ fluent-package (5.1.0-1) unstable; urgency=low
+ 
+   * New upstream release.
+diff --git a/fluent-package/yum/fluent-package.spec.in b/fluent-package/yum/fluent-package.spec.in
+index 4833f8e..da9da8c 100644
+--- a/fluent-package/yum/fluent-package.spec.in
++++ b/fluent-package/yum/fluent-package.spec.in
+@@ -478,6 +478,9 @@ fi
+ # NOTE: %{_tmpfilesdir} is available since CentOS 7
+ %attr(0755,fluentd,fluentd) %dir /tmp/@PACKAGE_DIR@
+ %changelog
++* Mon Oct 7 2024 Kentaro Hayashi <kenhys@xdump.org> - 6.0.0-1
++- New upstream release. (Dummy)
++
+ * Mon Jul 29 2024 Kentaro Hayashi <kenhys@xdump.org> - 5.1.0-1
+ - New upstream release.
+ 
+-- 
+2.45.2
+

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postinst
@@ -145,29 +145,26 @@ migration_from_v4_post_process() {
     fi
 }
 
-local_plugin_migration=/tmp/<%= package_dir %>/.local_plugin_migration
 local_base_plugins=/tmp/<%= package_dir %>/.local_base_plugins
-local_missing_plugins=/tmp/<%= package_dir %>/.local_missing_plugins
 install_missing_plugins() {
-    if [ -f $local_plugin_migration ]; then
-        echo "Checking network connectivity..."
-	if ! curl --fail --silent -O https://rubygems.org/specs.4.8.gz; then
-	    echo "Can't install missing plugins automatically, please install the following plugins manually."
-	    cat $local_plugin_migration
-	else
-	    echo "Install missing plugins automatically..."
-	    /usr/sbin/fluent-gem list | grep fluent-plugin | cut -d' ' -f1 > $local_base_plugins
-	    # NOTE: Do not install already bundled plugins
-	    diff -u $local_base_plugins $local_plugin_migration | grep '^+fluent' | sed -e 's/\+//' > $local_missing_plugins
-	    if [ -s $local_missing_plugins ]; then
-		cat $local_missing_plugins | xargs sudo /usr/sbin/fluent-gem install --no-document
-	    else
-		echo "No need to install missing plugins..."
-	    fi
-	    rm -f $local_base_plugins
-	    rm -f $local_missing_plugins
-	fi
-	rm -f $local_plugin_migration
+    # Install missing gems (even though systemd is not available, it works)
+    if [ -f $local_base_plugins ]; then
+        local_current_plugins=$(/usr/sbin/fluent-gem list '^fluent-plugin-' --no-versions --no-verbose)
+        if ! grep --fixed-strings --line-regexp --invert-match "$local_current_plugins" $local_base_plugins; then
+            echo "No missing plugins to install"
+        else
+            if ! curl --fail --silent -O https://rubygems.org/specs.4.8.gz; then
+                echo "No network connectivity..."
+            else
+                grep --fixed-strings --line-regexp --invert-match "$local_current_plugins" $local_base_plugins | while read missing_gem
+                do
+                    if ! /usr/sbin/fluent-gem install --no-document $missing_gem; then
+                        echo "Can't install missing plugin automatically: please install $missing_gem manually."
+                    fi
+                done
+            fi
+        fi
+        rm -f $local_base_plugins
     fi
 }
 
@@ -175,7 +172,7 @@ fluentd_auto_restart() {
     if [ -d /run/systemd/system ]; then
 	pid=$(systemctl show <%= service_name %> --property=MainPID --value)
 	if [ $pid -ne 0 ]; then
-	    env_vars=$(sudo sed -e 's/\x0/\n/g' /proc/$pid/environ)
+	    env_vars=$(sed -e 's/\x0/\n/g' /proc/$pid/environ)
 	    action=$(eval $env_vars && echo $FLUENT_PACKAGE_SERVICE_RESTART)
 	    case "$action" in
 		auto)

--- a/fluent-package/templates/package-scripts/fluent-package/deb/preinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/preinst
@@ -10,17 +10,15 @@ set -e
 # for details, see https://www.debian.org/doc/debian-policy/ or
 # the debian-policy package.
 
-local_plugin_migration=/tmp/<%= package_dir %>/.local_plugin_migration
+local_base_plugins=/tmp/<%= package_dir %>/.local_base_plugins
 migrate_local_plugins() {
-    # collect manually installed plugins
-    archive_path=$(sudo /opt/fluent/bin/fluent-diagtool -t fluentd -o /tmp | tail -n 1 | cut -d' ' -f10)
-    local_gem_output=$(echo $archive_path | sed -e 's/diagout-//' -e 's/.tar.gz//')/output/gem_local_list.output
-    if [ -f $local_gem_output ]; then
-        if [ -s $local_gem_output ]; then
-	    # If there are missing plugins, mark path to it
-	    cp $local_gem_output $local_plugin_migration
-	fi
+    if [ ! -d /run/systemd/system ]; then
+        # tmpfiles.d owns /tmp/<%= package_dir %>, but not created without systemd
+        mkdir -p /tmp/<%= package_dir %>
     fi
+    # collect list of gems
+    # We don't use fluent-diagtool here because it depends on systemd and piuparts fails
+    /opt/fluent/bin/fluent-gem list '^fluent-plugin-' --no-version --no-verbose > $local_base_plugins
 }
 
 case "$1" in

--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -32,8 +32,7 @@
 %define v4migration_with_restart /tmp/@PACKAGE_DIR@/.v4migration_with_restart
 %define v4migration_old_rotate_config_saved /tmp/@PACKAGE_DIR@/.old_rotate_config
 %define v4migration_enabled_service /tmp/@PACKAGE_DIR@/.v4migration_enabled_service
-%define local_plugin_migration /tmp/@PACKAGE_DIR@/.local_plugin_migration
-%define local_base_plugins /tmp/@PACKAGE_DIR@/.base-plugins
+%define local_base_plugins /tmp/@PACKAGE_DIR@/.local_base_plugins
 
 # Omit the brp-python-bytecompile automagic because post hook for ffi fails on AmazonLinux 2.
 %if %{_amazon_ver} == 2
@@ -189,23 +188,8 @@ else
     fi
 fi
 if [ $1 -eq 2 ]; then
-  # collect manually installed plugins during upgrading
-  archive_path=$(sudo /opt/fluent/bin/fluent-diagtool -t fluentd -o /tmp  | tail -n 1 | cut -d' ' -f10)
-  local_gem_output=$(echo $archive_path | sed -e 's/diagout-//' -e 's/.tar.gz//')/output/gem_local_list.output
-  if [ -f $local_gem_output ]; then
-      if [ -s $local_gem_output ]; then
-	  # If there are missing plugins, mark path to it
-	  echo "Detected missing plugins..."
-	  cp $local_gem_output %{local_plugin_migration}
-      else
-	  echo "Missing $local_gem_output"
-      fi
-  else
-      echo "Missing $local_gem_output to check locally installed plugins."
-  fi
-  rm -f $archive_path
-  archive_dir=$(echo $archive_path | sed -e 's/diagout-//' -e 's/.tar.gz//')
-  rm -rf $archive_dir
+  # collect installed gems during upgrading
+  /opt/fluent/bin/fluent-gem list '^fluent-plugin-' --no-versions --no-verbose > %{local_base_plugins}
 fi
 
 %preun
@@ -324,26 +308,23 @@ if [ -f "%{_sysconfdir}/prelink.conf" ]; then
 fi
 if [ $1 -eq 2 ]; then
   # install missing plugins during upgrading package
-  if [ -f %{local_plugin_migration} ]; then
-    echo "Checking network connectivity..."
-    curl --fail --silent -O https://rubygems.org/specs.4.8.gz
-    if [ $? -eq 0 ]; then
-      echo "Install missing plugins automatically..."
-      /usr/sbin/fluent-gem list | grep fluent-plugin | cut -d' ' -f1 > %{local_base_plugins}
-      # NOTE: Do not install already bundled plugins
-      diff -u %{local_base_plugins} %{local_plugin_migration} | grep '^+fluent' | sed -e 's/\+//' > %{local_missing_plugins}
-      if [ -s %{local_missing_plugins} ]; then
-        cat %{local_missing_plugins} | xargs sudo /usr/sbin/fluent-gem install --no-document
-      else
-         echo "No need to install missing plugins..."
-      fi
-      rm -f %{local_base_plugins}
-      rm -f %{local_missing_plugins}
+  if [ -f %{local_base_plugins} ]; then
+    local_current_plugins=$(/usr/sbin/fluent-gem list '^fluent-plugin-' --no-versions --no-verbose)
+    if ! grep --fixed-strings --line-regexp --invert-match "$local_current_plugins" %{local_base_plugins}; then
+      echo "No missing plugins to install"
     else
-      echo "Can't install missing plugins automatically, please install the following plugins manually."
-      cat %{local_plugin_migration}
+      if ! curl --fail --silent -O https://rubygems.org/specs.4.8.gz; then
+        echo "No network connectivity..."
+      else
+        grep --fixed-strings --line-regexp --invert-match "$local_current_plugins" %{local_base_plugins} | while read missing_gem
+        do
+          if ! /usr/sbin/fluent-gem install --no-document $missing_gem; then
+            echo "Can't install missing plugin automatically: please install $missing_gem manually."
+          fi
+        done
+      fi
     fi
-    rm -f %{local_plugin_migration}
+    rm -f %{local_base_plugins}
   fi
 fi
 
@@ -353,7 +334,9 @@ if [ $1 -eq 1 ]; then
   . %{_sysconfdir}/sysconfig/@SERVICE_NAME@
   echo "postun FLUENT_PACKAGE_SERVICE_RESTART: $FLUENT_PACKAGE_SERVICE_RESTART"
   if [ "$FLUENT_PACKAGE_SERVICE_RESTART" = "auto" ]; then
-    pid=$(systemctl show fluentd --property=MainPID --value)
+    # systemctl ... --property=MainPID --value is available since systemd 230 or later.
+    # thus for amazonlinux:2, it can not be used.
+    pid=$(systemctl show fluentd --property=MainPID | cut -d'=' -f2)
     if [ $pid -gt 0 ]; then
       echo "Kick auto service upgrade mode to MainPID:$pid"
       kill -USR2 $pid

--- a/fluent-package/yum/systemd-test/update-to-next-major-version.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-major-version.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -exu
+
+. $(dirname $0)/commonvar.sh
+
+# Install the current
+package="/host/${distribution}/${DISTRIBUTION_VERSION}/x86_64/Packages/fluent-package-*.rpm"
+sudo $DNF install -y $package
+
+# Install plugin manually (plugin and gem)
+sudo /opt/fluent/bin/fluent-gem install --no-document fluent-plugin-concat
+sudo /opt/fluent/bin/fluent-gem install --no-document gqtp
+
+# Install next major version
+package="/host/v6-test/${distribution}/${DISTRIBUTION_VERSION}/x86_64/Packages/fluent-package-*.rpm"
+sudo $DNF install -y $package
+
+# Test: Check whether plugin/gem were installed during upgrading
+/opt/fluent/bin/fluent-gem list | grep fluent-plugin-concat
+# Non fluent-plugin- prefix gem should not be installed automatically
+(! /opt/fluent/bin/fluent-gem list | grep gqtp)


### PR DESCRIPTION
Before:

* missing fluent-plugin was installed

After:

* missing fluent-plugin was installed
* missing dependency gem was also installed

NOTE:

* if missing gem requires development packages to build it, it will
fail.
* fluent-diagtool depends on highly systemd service, so it is simple
just to use fluent-gem detecting missing gems.

