### PR TITLE
deb: fix install plugin hook order correctly

### DIFF
--- a/fluent-package/templates/package-scripts/fluent-package/deb/postinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postinst
@@ -171,6 +171,30 @@ install_missing_plugins() {
     fi
 }
 
+fluentd_auto_restart() {
+    if [ -d /run/systemd/system ]; then
+	pid=$(systemctl show <%= service_name %> --property=MainPID --value)
+	if [ $pid -ne 0 ]; then
+	    env_vars=$(sudo sed -e 's/\x0/\n/g' /proc/$pid/environ)
+	    action=$(eval $env_vars && echo $FLUENT_PACKAGE_SERVICE_RESTART)
+	    case "$action" in
+		auto)
+		    if [ "$1" = "upgrade" ]; then
+			echo "Kick auto service upgrade mode to MainPID:$pid"
+			kill -USR2 $pid
+		    fi
+		    ;;
+		manual)
+		    echo "No need to restart service in manual mode..."
+		    ;;
+		*)
+		    echo "Nothing to be done..."
+		    ;;
+	    esac
+	fi
+    fi
+}
+
 case "$1" in
     configure)
         add_system_user
@@ -179,7 +203,8 @@ case "$1" in
         fixperms
         migration_from_v4_post_process
         install_missing_plugins
-        ;;
+        fluentd_auto_restart
+	;;
     abort-upgrade|abort-deconfigure|abort-remove)
         :
         ;;

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postrm
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postrm
@@ -79,22 +79,3 @@ esac
 
 #DEBHELPER#
 
-pid=$(systemctl show <%= service_name %> --property=MainPID --value)
-if [ $pid -ne 0 ]; then
-    env_vars=$(sudo sed -e 's/\x0/\n/g' /proc/$pid/environ)
-    action=$(eval $env_vars && echo $FLUENT_PACKAGE_SERVICE_RESTART)
-    case "$action" in
-	auto)
-	    if [ "$1" = "upgrade" ]; then
-		echo "Kick auto service upgrade mode to MainPID:$pid"
-		kill -USR2 $pid
-	    fi
-	    ;;
-	manual)
-	    echo "No need to restart service in manual mode..."
-	    ;;
-	*)
-	    echo "Nothing to be done..."
-	    ;;
-    esac
-fi


### PR DESCRIPTION
When upgrading package, the following hook is executed:
plugins should be installed before restarting service.

Before:

* old prerm
* new preinst collect plugin information
* old postrm auto restart
* new postinst install plugins

After:

* old prerm collect plugin information
* new preinst
* old postrm
* new postinst install plugins and auto restart

