### PR TITLE
rpm ci: collect diagnostic message for cgroup v1

### DIFF
--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -141,6 +141,18 @@ jobs:
         with:
           name: packages-${{ matrix.rake-job }}
       - uses: canonical/setup-lxd@v0.1.1
+      - name: Run diagnostic
+        run: |
+          uname -a
+          echo "::group::snap info lxd"
+          snap info lxd
+          echo "::endgroup::"
+          echo "::group::snap services lxd"
+          snap services lxd
+          echo "::endgroup::"
+          echo "::group::snap logs lxd"
+          sudo snap logs lxd
+          echo "::endgroup::"
       - name: Run Test ${{ matrix.test }} on ${{ matrix.lxc-image }}
         run: fluent-package/yum/systemd-test/test.sh ${{ matrix.lxc-image }} ${{ matrix.test }}
 


### PR DESCRIPTION
lxc launch will fail (/var/snap/lxd/common/lxd/unix.socket: connect: permission denied) in some cases, but not sure why yet.

To investigate further more, try to collect snap information when workflow was failed.