### PR TITLE
ci: extend timeout for v6 workflow

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   build:
     name: Build
-    timeout-minutes: 60
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   build:
     name: Build
-    timeout-minutes: 60
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
To verify major upgrade in workflow, it needs
more package build time.