### PR TITLE
ci: install transitional package

### DIFF
--- a/fluent-package/apt/systemd-test/downgrade-to-v4.sh
+++ b/fluent-package/apt/systemd-test/downgrade-to-v4.sh
@@ -17,7 +17,8 @@ systemctl status --no-pager td-agent
 
 # Ensure to install the current
 sudo apt install -V -y \
-    /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb
+    /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb \
+    /host/${distribution}/pool/${code_name}/${channel}/*/*/td-agent_*_all.deb
 
 # td-agent.service is already masked (link to /dev/null), and remove td-agent.service alias not to conflict with v4
 sudo systemctl unmask td-agent

--- a/fluent-package/apt/systemd-test/update-from-v4.sh
+++ b/fluent-package/apt/systemd-test/update-from-v4.sh
@@ -31,7 +31,8 @@ done
 case $1 in
   local)
     sudo apt install -V -y \
-      /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb
+      /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb \
+      /host/${distribution}/pool/${code_name}/${channel}/*/*/td-agent_*_all.deb
     ;;
   v5)
     curl --fail --silent --show-error --location https://toolbelt.treasuredata.com/sh/install-${distribution}-${code_name}-fluent-package5.sh | sh

--- a/fluent-package/apt/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
+++ b/fluent-package/apt/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
@@ -29,7 +29,8 @@ done
 
 # Install the current
 sudo apt install -V -y \
-    /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb
+    /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb \
+    /host/${distribution}/pool/${code_name}/${channel}/*/*/td-agent_*_all.deb
 systemctl status --no-pager fluentd
 
 sudo systemctl stop fluentd


### PR DESCRIPTION
Usually, transitional package (td-agent) will be installed when upgrading from v4. so it should be installed at the same time　
to test in practical use case.
