### PR TITLE
Remove unnecessary GEM_HOME/GEM_PATH settings

### DIFF
--- a/fluent-package/templates/etc/systemd/fluentd.service.erb
+++ b/fluent-package/templates/etc/systemd/fluentd.service.erb
@@ -14,8 +14,6 @@ Group=<%= Shellwords.shellescape(service_name) %>
 <% end %>
 LimitNOFILE=65536
 Environment=LD_PRELOAD=<%= install_path %>/lib/libjemalloc.so
-Environment=GEM_HOME=<%= gem_install_path %>/
-Environment=GEM_PATH=<%= gem_install_path %>/
 Environment=FLUENT_CONF=/etc/<%= package_dir %>/<%= service_name %>.conf
 Environment=FLUENT_PLUGIN=/etc/<%= package_dir %>/plugin
 Environment=FLUENT_SOCKET=/var/run/<%= package_dir %>/<%= service_name %>.sock


### PR DESCRIPTION
Remove environment variables that prevent the Update/Reload without downtime feature. This is because an upgrade with a Ruby version update will not work correctly due to environment variables for the old Ruby.