### PR TITLE
github: fix target branch name

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - fluent-package-lts-v5
+      - fluent-package-v5
   pull_request:
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - fluent-package-lts-v5
+      - fluent-package-v5
   pull_request:
 jobs:
   build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - fluent-package-lts-v5
+      - fluent-package-v5
   pull_request:
 jobs:
   build:

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - fluent-package-lts-v5
+      - fluent-package-v5
   pull_request:
 jobs:
   build:


### PR DESCRIPTION
At first, assumed 3 branchs master, v5, lts-v5, but it might be enough for master (v5.x) and lts-v5 for a while.
Already branch name was changed, so follow it.
