### PR TITLE
Backport: Rakefile: install ruby gems with parallel (LTS)

### DIFF
--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -433,7 +433,7 @@ class BuildTask
         gem_home = ENV["GEM_HOME"]
         ENV["GEM_HOME"] = gem_staging_dir
         ENV["INSTALL_GEM_FROM_LOCAL_REPO"] = "yes"
-        sh(bundle_command, "_#{BUNDLER_VERSION}_", "install")
+        sh(bundle_command, "_#{BUNDLER_VERSION}_", "install", "-j#{Etc.nprocessors}")
         # Ensure to install binstubs under /opt/td-agent/bin
         sh(gem_command, "pristine", "--only-executables", "--all", "--bindir", staging_bindir)
         ENV["GEM_HOME"] = gem_home


### PR DESCRIPTION
Seems It appears to be taking a long time to install ruby gems on windows environment. So this patch will introduce parallel install to reduce installation time.


See https://github.com/fluent/fluent-package-builder/pull/674
