### PR TITLE
deb yum: use /usr/sbin/fluent-gem to migrate gems when upgrade

### DIFF
--- a/fluent-package/templates/package-scripts/fluent-package/deb/preinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/preinst
@@ -18,7 +18,7 @@ migrate_local_plugins() {
     fi
     # collect list of gems
     # We don't use fluent-diagtool here because it depends on systemd and piuparts fails
-    /opt/fluent/bin/fluent-gem list '^fluent-plugin-' --no-version --no-verbose > $local_base_plugins
+    /usr/sbin/fluent-gem list '^fluent-plugin-' --no-version --no-verbose > $local_base_plugins
 }
 
 case "$1" in

--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -189,7 +189,7 @@ else
 fi
 if [ $1 -eq 2 ]; then
   # collect installed gems during upgrading
-  /opt/fluent/bin/fluent-gem list '^fluent-plugin-' --no-versions --no-verbose > %{local_base_plugins}
+  /usr/sbin/fluent-gem list '^fluent-plugin-' --no-versions --no-verbose > %{local_base_plugins}
 fi
 
 %preun


### PR DESCRIPTION
If user defined the custom GEM_HOME / GEM_PATH environment variables,
there is an error in gem migration when upgrading a package.

```
$ apt install ./fluent-package_5.1.0-1_amd64.deb
---(snip)---

$ apt install ./fluent-package_6.0.0-1_amd64.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'fluent-package' instead of './fluent-package_6.0.0-1_amd64.deb'
The following packages will be upgraded:
  fluent-package
1 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/17.6 MB of archives.
After this operation, 2336 kB of additional disk space will be used.
Get:1 /root/fluent-package_6.0.0-1_amd64.deb fluent-package amd64 6.0.0-1 [17.6 MB]
(Reading database ... 46220 files and directories currently installed.)
Preparing to unpack .../fluent-package_6.0.0-1_amd64.deb ...
/opt/fluent/lib/ruby/3.2.0/rubygems.rb:264:in `find_spec_for_exe': can't find gem fluentd (>= 0.a) with executable fluent-gem (Gem::GemNotFoundException)
        from /opt/fluent/lib/ruby/3.2.0/rubygems.rb:283:in `activate_bin_path'
        from /opt/fluent/bin/fluent-gem:25:in `<main>'
dpkg: error processing archive /root/fluent-package_6.0.0-1_amd64.deb (--unpack):
 new fluent-package package pre-installation script subprocess returned error exit status 1
FLUENT_PACKAGE_SERVICE_RESTART: auto
FLUENT_PACKAGE_SERVICE_RESTART: auto
Errors were encountered while processing:
 /root/fluent-package_6.0.0-1_amd64.deb
N: Download is performed unsandboxed as root as file '/root/fluent-package_6.0.0-1_amd64.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

To avoid this error, this PR use `/usr/sbin/fluent-gem` instead of `/opt/fluent/bin/fluent-gem`