### PR TITLE
Backport: ci: fix failing Test (CGroup V1) (LTS)

### DIFF
--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -123,10 +123,6 @@ jobs:
         with:
           name: packages-${{ matrix.rake-job }}
       - uses: canonical/setup-lxd@v0.1.1
-      - name: Update image server
-        run: |
-          lxc remote remove images
-          lxc remote add images https://images.lxd.canonical.com --protocol=simplestreams
       - name: Run Test ${{ matrix.test-file }} on ${{ matrix.test-lxc-image }}
         run: fluent-package/yum/systemd-test/test.sh ${{ matrix.test-lxc-image }} ${{ matrix.test-file }}
 


### PR DESCRIPTION
It appears that now the default `remote images` is https://images.lxd.canonical.com.

I don't know why, but we can't remove `images`.
The following command do nothing, so this step fails.

    lxc remote remove images


ref. https://github.com/fluent/fluent-package-builder/pull/675