### PR TITLE
Rakefile: fix build error of windows package

### DIFF
--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -1183,16 +1183,18 @@ class BuildTask
     fluentd_conf = "etc/#{PACKAGE_DIR}/#{SERVICE_NAME}.conf"
     fluentd_conf_default = "opt/#{PACKAGE_DIR}/share/#{SERVICE_NAME}.conf"
     configs = [fluentd_conf]
-    configs.concat([
-                     "etc/logrotate.d/#{SERVICE_NAME}",
-                     fluentd_conf_default,
-                   ]) unless windows? || macos?
-    File.readlines("/etc/os-release").each do |line|
-      if line.include?("ID=")
-        distribution = line.split(/=/).last.chomp
-        if ["debian", "ubuntu"].include?(distribution)
-          puts "Suppress needrestart on #{distribution}"
-          configs.concat(["etc/needrestart/conf.d/50-fluent-package.conf"])
+    unless windows? || macos?
+      configs.concat([
+                      "etc/logrotate.d/#{SERVICE_NAME}",
+                      fluentd_conf_default,
+                    ])
+      File.readlines("/etc/os-release").each do |line|
+        if line.include?("ID=")
+          distribution = line.split(/=/).last.chomp
+          if ["debian", "ubuntu"].include?(distribution)
+            puts "Suppress needrestart on #{distribution}"
+            configs.concat(["etc/needrestart/conf.d/50-fluent-package.conf"])
+          end
         end
       end
     end


### PR DESCRIPTION
This PR will fix build error as following when build windows package:
```
Errno::ENOENT: No such file or directory @ rb_sysopen - /etc/os-release
C:/fluent-package-5.1.0/fluent-package/Rakefile:1190:in `readlines'
C:/fluent-package-5.1.0/fluent-package/Rakefile:1190:in `render_fluent_package_c
onfig'
C:/fluent-package-5.1.0/fluent-package/Rakefile:547:in `block (2 levels) in defi
ne'
Tasks: TOP => msi:selfbuild => build:msi_config => build:rpm_fluent_package_conf
ig
(See full trace by running task with --trace)
rake aborted!
```
https://github.com/fluent/fluent-package-builder/actions/runs/11734401644/job/32690358756?pr=722#step:5:2539