### PR TITLE
Backport: rpm ci: collect diagnostic message for cgroup v1 (LTS)

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -174,5 +174,23 @@ jobs:
         with:
           name: packages-apt-source-${{ matrix.rake-job }}
       - uses: canonical/setup-lxd@v0.1.1
+      - name: Run diagnostic
+        run: |
+          uname -a
+          echo "::group::snap info lxd"
+          snap info lxd
+          echo "::endgroup::"
+          echo "::group::snap services lxd"
+          snap services lxd
+          echo "::endgroup::"
+          echo "::group::snap logs lxd"
+          sudo snap logs lxd
+          echo "::endgroup::"
+          echo "::group::lxc remote list"
+          lxc remote list
+          echo "::endgroup::"
+          echo "::group::lxc list images:"
+          lxc image list images:
+          echo "::endgroup::"
       - name: Run Test  ${{ matrix.test-file }} on ${{ matrix.test-lxc-image }}
         run: fluent-package/apt/systemd-test/test.sh ${{ matrix.test-lxc-image }} ${{ matrix.test-file }}

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -123,6 +123,24 @@ jobs:
         with:
           name: packages-${{ matrix.rake-job }}
       - uses: canonical/setup-lxd@v0.1.1
+      - name: Run diagnostic
+        run: |
+          uname -a
+          echo "::group::snap info lxd"
+          snap info lxd
+          echo "::endgroup::"
+          echo "::group::snap services lxd"
+          snap services lxd
+          echo "::endgroup::"
+          echo "::group::snap logs lxd"
+          sudo snap logs lxd
+          echo "::endgroup::"
+          echo "::group::lxc remote list"
+          lxc remote list
+          echo "::endgroup::"
+          echo "::group::lxc list images:"
+          lxc image list images:
+          echo "::endgroup::"
       - name: Run Test ${{ matrix.test-file }} on ${{ matrix.test-lxc-image }}
         run: fluent-package/yum/systemd-test/test.sh ${{ matrix.test-lxc-image }} ${{ matrix.test-file }}
 

--- a/fluent-package/apt/systemd-test/test.sh
+++ b/fluent-package/apt/systemd-test/test.sh
@@ -15,7 +15,7 @@ dir="/host/fluent-package/apt/systemd-test"
 set -eux
 
 echo "::group::Run test: launch $image"
-lxc launch $image target
+lxc launch $image target --debug
 sleep 5
 echo "::endgroup::"
 echo "::group::Run test: configure $image"

--- a/fluent-package/yum/systemd-test/test.sh
+++ b/fluent-package/yum/systemd-test/test.sh
@@ -14,7 +14,7 @@ dir="/host/fluent-package/yum/systemd-test"
 set -eux
 
 echo "::group::Run test: launch $image"
-lxc launch $image target
+lxc launch $image target --debug
 sleep 5
 echo "::endgroup::"
 echo "::group::Run test: configure $image"


### PR DESCRIPTION
rpm ci: collect diagnostic message for cgroup v1

lxc launch will fail (/var/snap/lxd/common/lxd/unix.socket: connect:
permission denied) in some cases, but not sure why yet.

To investigate further more, try to collect snap information when
workflow was failed.

ref. https://github.com/fluent/fluent-package-builder/pull/696
