### PR TITLE
Backport: ci msi: cache package to reduce build time

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,7 +21,14 @@ jobs:
         with:
           ruby-version: 3.1
       - uses: actions/checkout@master
+      - name: cache msi
+        uses: actions/cache@v4
+        id: cache-msi
+        with:
+          path: fluent-package/msi/repositories
+          key: ${{ runner.os }}-v5cache-windows-${{ hashFiles('**/config.rb', '**/Rakefile', '**/Gemfile*', '!**/*.ps1') }}
       - name: Build
+        if: ${{ ! steps.cache-msi.outputs.cache-hit }}
         run: |
           gem install serverspec
           gem install bundler:2.2.9 --no-document


### PR DESCRIPTION
Even though GitHub Actions' cache over limitations easily, it might better to cache only Windows.
