### PR TITLE
Gemfile.lock: fix dependency due to fix build error on windows

### DIFF
--- a/fluent-package/Gemfile.lock
+++ b/fluent-package/Gemfile.lock
@@ -20,6 +20,7 @@ GIT
       csv (~> 3.2)
       drb (~> 2.2)
       http_parser.rb (>= 0.5.1, < 0.9.0)
+      logger (~> 1.6)
       msgpack (>= 1.3.1, < 2.0.0)
       serverengine (>= 2.3.2, < 3.0.0)
       sigdump (~> 0.2.5)


### PR DESCRIPTION
This should fix following error when build Windows package on `feature-nodowntime` branch.

```
Downloading fluentd-1.17.1 revealed dependencies not in the API or the lockfile 
(logger (~> 1.6)).
Either installing with `--full-index` or running `bundle update fluentd` should 
fix the problem.

rake aborted! 

Command failed with status (34): [C:/opt/fluent/bin/bundle _2.3.27_ install ...]
C:/fluent-package-5.1.0/fluent-package/Rakefile:462:in `block (2 levels) in defi
ne'
Tasks: TOP => msi:selfbuild => build:all => build:licenses => build:gems => buil
d:ruby_gems
(See full trace by running task with --trace)
rake aborted!
```