### PR TITLE
Backport: ci: install transitional package

### DIFF
--- a/fluent-package/apt/systemd-test/downgrade-to-v4.sh
+++ b/fluent-package/apt/systemd-test/downgrade-to-v4.sh
@@ -17,7 +17,8 @@ systemctl status --no-pager td-agent
 
 # Ensure to install the current
 sudo apt install -V -y \
-    /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb
+    /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb \
+    /host/${distribution}/pool/${code_name}/${channel}/*/*/td-agent_*_all.deb
 
 # td-agent.service is already masked (link to /dev/null), and remove td-agent.service alias not to conflict with v4
 sudo systemctl unmask td-agent

--- a/fluent-package/apt/systemd-test/downgrade-to-v4.sh
+++ b/fluent-package/apt/systemd-test/downgrade-to-v4.sh
@@ -24,7 +24,7 @@ sudo apt install -V -y \
 sudo systemctl unmask td-agent
 
 # Even though removing fluent-package, log and .conf are kept. dpkg reports "rc fluent-package" and "rc td-agent" status.
-sudo apt remove -y fluent-package
+sudo apt remove -y fluent-package td-agent
 
 # fluentd.service is already masked (link to /dev/null), then remove it.
 sudo systemctl unmask fluentd

--- a/fluent-package/apt/systemd-test/update-from-v4.sh
+++ b/fluent-package/apt/systemd-test/update-from-v4.sh
@@ -34,7 +34,10 @@ sudo apt install -V -y \
 
 # Test: service status
 systemctl status --no-pager fluentd
-(! systemctl status --no-pager td-agent)
+# BUG: v4 service restart logic will not launched usually because the
+# existence check of td-agent.service will always fail.
+# As a result, old service is still alive here.
+systemctl status --no-pager td-agent
 
 # Test: restoring td-agent service alias
 sudo systemctl stop fluentd

--- a/fluent-package/apt/systemd-test/update-from-v4.sh
+++ b/fluent-package/apt/systemd-test/update-from-v4.sh
@@ -29,7 +29,8 @@ done
 
 # Install the current
 sudo apt install -V -y \
-    /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb
+     /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb \
+     /host/${distribution}/pool/${code_name}/${channel}/*/*/td-agent_*_all.deb
 
 # Test: service status
 systemctl status --no-pager fluentd

--- a/fluent-package/apt/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
+++ b/fluent-package/apt/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
@@ -29,7 +29,8 @@ done
 
 # Install the current
 sudo apt install -V -y \
-    /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb
+    /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb \
+    /host/${distribution}/pool/${code_name}/${channel}/*/*/td-agent_*_all.deb
 systemctl status --no-pager fluentd
 
 sudo systemctl stop fluentd


### PR DESCRIPTION
Usually, transitional package (td-agent) will be installed when upgrading from v4. so it should be installed at the same time　 to test in practical use case.

ref. https://github.com/fluent/fluent-package-builder/pull/709
 https://github.com/fluent/fluent-package-builder/pull/711
