### PR TITLE
Backport ci deb: tweak downgrade test case

### DIFF
--- a/fluent-package/apt/systemd-test/downgrade-to-v4.sh
+++ b/fluent-package/apt/systemd-test/downgrade-to-v4.sh
@@ -20,14 +20,17 @@ sudo apt install -V -y \
     /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb \
     /host/${distribution}/pool/${code_name}/${channel}/*/*/td-agent_*_all.deb
 
-# td-agent.service is already masked (link to /dev/null), and remove td-agent.service alias not to conflict with v4
-sudo systemctl unmask td-agent
+sudo systemctl is-active fluentd
+sudo systemctl is-active td-agent
+sudo systemctl stop fluentd
 
 # Even though removing fluent-package, log and .conf are kept. dpkg reports "rc fluent-package" and "rc td-agent" status.
 sudo apt remove -y fluent-package td-agent
 
 # fluentd.service is already masked (link to /dev/null), then remove it.
 sudo systemctl unmask fluentd
+# purge inacive (dead) symbolic links
+sudo systemctl disable td-agent
 
 # Drop symbolic links and recreate real directory.
 sudo rm -f /var/log/td-agent
@@ -44,6 +47,9 @@ sudo mkdir -p /etc/td-agent
 sudo chown td-agent:td-agent /etc/td-agent
 sudo mv /etc/fluent/td-agent.conf /etc/td-agent/
 curl -fsSL https://toolbelt.treasuredata.com/sh/install-${distribution}-${code_name}-td-agent4.sh | sh
+
+# re-create symlink to point service file again
+sudo systemctl enable td-agent --now
 
 # Test: service status
 (! systemctl status --no-pager fluentd)


### PR DESCRIPTION
After removing fluent-package and td-agent,
fluentd.service file is linked to nonexistent file (masked), but td-agent service is still active unexpectedly, so explicitly stop that service.