### PR TITLE
package: improve verify helper

### DIFF
--- a/fluent-package/test-install-in-docker.sh
+++ b/fluent-package/test-install-in-docker.sh
@@ -74,7 +74,7 @@ function check_installed_version()
 	    echo "Succeeded to install $TARGET on $ID from $REPO"
 	    ;;
 	*)
-	    echo "Failed to install $TARGET from $REPO"
+	    echo "Failed to install $TARGET on $ID from $REPO"
 	    exit 1
 	    ;;
     esac

--- a/fluent-package/test-verify-repo.sh
+++ b/fluent-package/test-verify-repo.sh
@@ -9,10 +9,14 @@
 
 function test_deb() {
     for d in $DEB_TARGETS; do
+	if [ $d = "dummy" ]; then
+	    continue
+	fi
 	for r in $REPO_TARGETS; do
 	    echo "TEST: on $d $r"
-	    docker run --rm -v $(pwd):/work $d /work/test-install-in-docker.sh $USER $r $VERSION
-	    if [ $? -eq 0 ]; then
+	    LOG=install-${d/:/-}-on-${r//\//-}.log
+	    docker run --rm -v $(pwd):/work $d /work/test-install-in-docker.sh $USER $r $VERSION 2>&1 | tee $LOG
+	    if [ ${PIPESTATUS[0]} -eq 0 ]; then
 		RESULTS="$RESULTS\nOK: $d $r"
 	    else
 		RESULTS="$RESULTS\nNG: $d $r"
@@ -23,10 +27,14 @@ function test_deb() {
 
 function test_rpm() {
     for d in $RPM_TARGETS; do
+	if [ $d = "dummy" ]; then
+	    continue
+	fi
 	for r in $REPO_TARGETS; do
 	    echo "TEST: on $d $r"
-	    docker run --rm -v $(pwd):/work $d /work/test-install-in-docker.sh $USER $r $VERSION
-	    if [ $? -eq 0 ]; then
+	    LOG=install-${d/:/-}-on-${r//\//-}.log
+	    docker run --rm -v $(pwd):/work $d /work/test-install-in-docker.sh $USER $r $VERSION 2>&1 | tee $LOG
+	    if [ ${PIPESTATUS[0]} -eq 0 ]; then
 		RESULTS="$RESULTS\nOK: $d $r"
 	    else
 		RESULTS="$RESULTS\nNG: $d $r"
@@ -52,7 +60,13 @@ if [ -z "$REPO_TARGETS" ]; then
     REPO_TARGETS="exp/5 exp/lts/5"
 fi
 
+echo "DEB_TARGETS: $DEB_TARGETS"
+echo "RPM_TARGETS: $RPM_TARGETS"
+echo "REPO_TARGETS: $REPO_TARGETS"
+# give a grace period to terminate (Ctrl+C)
+sleep 3
 RESULTS=""
 test_deb
 test_rpm
+grep "Failed to install" install-*.log
 echo -e $RESULTS


### PR DESCRIPTION
* show targets on startup
* show ID (e.g. debian:bookworm) when failed to compare versions
* skip test when "dummy" was specified for DEB_TARGETS/RPM_TARGETS
* logging for each test case (e.g. install-debian-bookworm-on-exp-lts-5.log)