### PR TITLE
deb: use auto/manual feature when old package supports

### DIFF
--- a/fluent-package/apt/systemd-test/update-to-next-version-with-auto-and-manual.sh
+++ b/fluent-package/apt/systemd-test/update-to-next-version-with-auto-and-manual.sh
@@ -27,9 +27,8 @@ sudo apt purge -y fluent-package
 
 # Upgrade package with manual feature
 sudo apt install -V -y $package
+sudo systemctl enable --now fluentd
 sed -i 's/=auto/=manual/' /etc/default/fluentd
-# TODO: Clarify the specification of FLUENT_PACKAGE_SERVICE_RESTART environment variable
-sudo systemctl restart fluentd
 main_pid=$(eval $(systemctl show fluentd --property=MainPID) && echo $MainPID)
 
 sudo apt install -V -y ./next_version.deb

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postinst
@@ -168,13 +168,17 @@ install_missing_plugins() {
     fi
 }
 
+zero_downtime_restart_supported=/tmp/<%= package_dir %>/.zero_downtime_restart_supported
 fluentd_auto_restart() {
+    if [ ! -e "$zero_downtime_restart_supported" ]; then
+        return
+    fi
+
     if [ -d /run/systemd/system ]; then
 	pid=$(systemctl show <%= service_name %> --property=MainPID --value)
 	if [ $pid -ne 0 ]; then
-	    env_vars=$(sed -e 's/\x0/\n/g' /proc/$pid/environ)
-	    action=$(eval $env_vars && echo $FLUENT_PACKAGE_SERVICE_RESTART)
-	    case "$action" in
+	    . /etc/default/<%= service_name %>
+	    case "$FLUENT_PACKAGE_SERVICE_RESTART" in
 		auto)
 		    echo "Kick auto service upgrade mode to MainPID:$pid"
 		    kill -USR2 $pid
@@ -188,6 +192,7 @@ fluentd_auto_restart() {
 	    esac
 	fi
     fi
+    rm -rf $zero_downtime_restart_supported
 }
 
 case "$1" in

--- a/fluent-package/templates/package-scripts/fluent-package/deb/preinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/preinst
@@ -21,9 +21,24 @@ migrate_local_plugins() {
     /usr/sbin/fluent-gem list '^fluent-plugin-' --no-version --no-verbose > $local_base_plugins
 }
 
+zero_downtime_restart_supported_version="1.18.0"
+zero_downtime_restart_supported=/tmp/<%= package_dir %>/.zero_downtime_restart_supported
+check_version() {
+    printf '%s\n' "$zero_downtime_restart_supported_version" "$1" | sort -C -V
+}
+check_whether_zero_downtime_restart_supported() {
+    current_version=$(/usr/sbin/fluentd --version | cut -d' ' -f 4)
+    if check_version $current_version; then
+        echo "Fluentd $current_version supports zero downtime restart."
+        mkdir -p /tmp/<%= package_dir %>
+        touch $zero_downtime_restart_supported
+    fi
+}
+
 case "$1" in
     upgrade)
         migrate_local_plugins
+        check_whether_zero_downtime_restart_supported
 	;;
     abort-upgrade)
         ;;

--- a/fluent-package/templates/package-scripts/fluent-package/deb/preinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/preinst
@@ -24,7 +24,7 @@ migrate_local_plugins() {
 zero_downtime_restart_supported_version="1.18.0"
 zero_downtime_restart_supported=/tmp/<%= package_dir %>/.zero_downtime_restart_supported
 check_version() {
-    printf '%s\n' "$zero_downtime_restart_supported_version" "$1" | sort -C -V
+    printf '%s\n' "$zero_downtime_restart_supported_version" "$1" | sort --check=quiet --version-sort
 }
 check_whether_zero_downtime_restart_supported() {
     current_version=$(/usr/sbin/fluentd --version | cut -d' ' -f 4)

--- a/fluent-package/yum/systemd-test/update-to-next-version-with-auto-and-manual.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version-with-auto-and-manual.sh
@@ -55,9 +55,8 @@ sudo $DNF remove -y fluent-package
 
 # Upgrade package with manual feature
 sudo $DNF install -y $package
-sed -i 's/=auto/=manual/' /etc/sysconfig/fluentd
-# TODO: Clarify the specification of FLUENT_PACKAGE_SERVICE_RESTART environment variable
 sudo systemctl enable --now fluentd
+sed -i 's/=auto/=manual/' /etc/sysconfig/fluentd
 main_pid=$(eval $(systemctl show fluentd --property=MainPID) && echo $MainPID)
 
 sudo $DNF install -y ./$next_package


### PR DESCRIPTION
This PR will allow to switch auto/manual restart settings with DEB package even when Fluentd is running.