### PR TITLE
replace Fluentd for 1.18 test

### DIFF
--- a/fluent-package/Gemfile.lock
+++ b/fluent-package/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/fluent/fluentd
-  revision: f8755d09b747d054302c0e12a3b0962a11f1045e
-  ref: f8755d09b747d054302c0e12a3b0962a11f1045e
+  revision: 759bb582a1d4a1b1d163197870669f7bee0aa148
+  ref: 759bb582a1d4a1b1d163197870669f7bee0aa148
   specs:
-    fluentd (1.17.1)
+    fluentd (1.18.0)
       base64 (~> 0.2)
       bundler
       certstore_c (~> 0.1.7)

--- a/fluent-package/config.rb
+++ b/fluent-package/config.rb
@@ -7,7 +7,7 @@ COMPAT_SERVICE_NAME = "td-agent"
 PACKAGE_DIR = "fluent"
 COMPAT_PACKAGE_DIR = COMPAT_SERVICE_NAME
 
-FLUENTD_REVISION = 'f8755d09b747d054302c0e12a3b0962a11f1045e' # test no-downtime (TODO fix later)
+FLUENTD_REVISION = '759bb582a1d4a1b1d163197870669f7bee0aa148' # test no-downtime (TODO fix later)
 FLUENTD_LOCAL_GEM_REPO = "file://" + File.expand_path(File.join(__dir__, "local_gem_repo"))
 
 # https://github.com/jemalloc/jemalloc/releases


### PR DESCRIPTION
Use https://github.com/fluent/fluentd/tree/restart-without-downtime-test-for-1.18 for test as version 1.18.