### PR TITLE
Revert "Embed fluent package info into environment variable"

### DIFF
--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -135,33 +135,10 @@ def template_params(params = nil)
   end
 
   if params
-    if params[:fluentd_version]
-      config.merge!({fluentd_version: params[:fluentd_version],
-                     fluentd_revision: FLUENTD_REVISION})
-    end
     config.merge(params)
   else
     config
   end
-end
-
-def fluent_package_info(version)
-  "#{PACKAGE_NAME} #{PACKAGE_VERSION} fluentd #{version} (#{FLUENTD_REVISION})"
-end
-
-def extract_fluentd_version(archive_path)
-  puts "::group::Extract fluentd version from: #{archive_path}" if ENV["CI"]
-  fluentd_version = ""
-  sh("tar", "xvf", archive_path, "-C", File.dirname(archive_path), "--no-same-owner")
-  archive_dir = File.join(File.dirname(archive_path),
-                          File.basename(archive_path, ".tar.gz"))
-  Dir.chdir(archive_dir) do
-    IO.popen("git tag --contains #{FLUENTD_REVISION}") do |tags|
-      fluentd_version = tags.readlines.last.chomp.delete_prefix("v")
-    end
-  end
-  puts "::endgroup::" if ENV["CI"]
-  fluentd_version
 end
 
 def template_path(*path_parts)
@@ -609,8 +586,7 @@ class BuildTask
       desc "Create systemd unit file for Red Hat like systems"
       task :rpm_systemd do
         dest =  File.join(STAGING_DIR, 'usr', 'lib', 'systemd', 'system', SERVICE_NAME + ".service")
-        version = extract_fluentd_version(@download_task.file_fluentd_archive)
-        params = {pkg_type: "rpm", fluentd_version: version}
+        params = {pkg_type: "rpm"}
         render_systemd_unit_file(dest, template_params(params))
         render_systemd_environment_file(template_params(params))
       end
@@ -618,8 +594,7 @@ class BuildTask
       desc "Create systemd unit file for Debian like systems"
       task :deb_systemd do
         dest = File.join(STAGING_DIR, 'lib', 'systemd', 'system', SERVICE_NAME + ".service")
-        version = extract_fluentd_version(@download_task.file_fluentd_archive)
-        params = {pkg_type: "deb", fluentd_version: version}
+        params = {pkg_type: "deb"}
         render_systemd_unit_file(dest, template_params(params))
         render_systemd_environment_file(template_params(params))
       end

--- a/fluent-package/apt/systemd-test/update-to-next-version.sh
+++ b/fluent-package/apt/systemd-test/update-to-next-version.sh
@@ -12,10 +12,6 @@ sudo apt install -V -y \
 dpkg-deb -R /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb tmp
 last_ver=$(cat tmp/DEBIAN/control | grep "Version: " | sed -E "s/Version: ([0-9.]+)-([0-9]+)/\2/g")
 sed -i -E "s/Version: ([0-9.]+)-([0-9]+)/Version: \1-$(($last_ver+1))/g" tmp/DEBIAN/control
-# Bump up x.y.w.z to check whether FLUENT_PACKAGE_VERSION was updated correctly later
-sed -i -E "s/FLUENT_PACKAGE_VERSION=([0-9.]+)/FLUENT_PACKAGE_VERSION=\1.1/g" tmp/lib/systemd/system/fluentd.service
-next_package_ver=$(cat tmp/lib/systemd/system/fluentd.service | grep "FLUENT_PACKAGE_VERSION" | sed -E "s/Environment=FLUENT_PACKAGE_VERSION=(.+)/\1/")
-echo "repacked next fluent-package version: $next_package_ver"
 dpkg-deb --build tmp next_version.deb
 
 # Install the dummy package
@@ -42,7 +38,6 @@ test $(eval $env_vars && echo $FLUENT_CONF) = "/etc/fluent/fluentd.conf"
 test $(eval $env_vars && echo $FLUENT_PACKAGE_LOG_FILE) = "/var/log/fluent/fluentd.log"
 test $(eval $env_vars && echo $FLUENT_PLUGIN) = "/etc/fluent/plugin"
 test $(eval $env_vars && echo $FLUENT_SOCKET) = "/var/run/fluent/fluentd.sock"
-test $(eval $env_vars && echo $FLUENT_PACKAGE_VERSION) = "$next_package_ver"
 
 # Test: fluent-diagtool
 sudo fluent-gem install fluent-plugin-concat

--- a/fluent-package/templates/etc/systemd/fluentd.service.erb
+++ b/fluent-package/templates/etc/systemd/fluentd.service.erb
@@ -20,9 +20,6 @@ Environment=FLUENT_CONF=/etc/<%= package_dir %>/<%= service_name %>.conf
 Environment=FLUENT_PLUGIN=/etc/<%= package_dir %>/plugin
 Environment=FLUENT_SOCKET=/var/run/<%= package_dir %>/<%= service_name %>.sock
 Environment=FLUENT_PACKAGE_LOG_FILE=/var/log/<%= package_dir %>/<%= service_name %>.log
-Environment=FLUENT_PACKAGE_VERSION=<%= version %>
-Environment=FLUENT_PACKAGE_FLUENTD_VERSION=<%= fluentd_version %>
-Environment=FLUENT_PACKAGE_FLUENTD_REVISION=<%= fluentd_revision %>
 <% if pkg_type == 'deb' %>
 EnvironmentFile=-/etc/default/<%= service_name %>
 <% else %>

--- a/fluent-package/yum/systemd-test/update-to-next-version.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version.sh
@@ -35,11 +35,8 @@ release=$(rpmquery --queryformat="%{Release}" -p $package)
 release_ver=$(echo $release | cut -d . -f1)
 # Example: "2.el9"
 next_release=$(($release_ver+1)).$(echo $release | cut -d. -f2)
-rpmrebuild --release=$next_release --modify="find $HOME -name fluentd.service | xargs sed -i -E 's/FLUENT_PACKAGE_VERSION=([0-9.]+)/FLUENT_PACKAGE_VERSION=\1.1/g'" --package $package
+rpmrebuild --release=$next_release --package $package
 next_package=$(find rpmbuild -name "*.rpm")
-rpm2cpio $next_package | cpio -id ./usr/lib/systemd/system/fluentd.service
-next_package_ver=$(cat ./usr/lib/systemd/system/fluentd.service | grep "FLUENT_PACKAGE_VERSION" | sed -E "s/Environment=FLUENT_PACKAGE_VERSION=(.+)/\1/")
-echo "repacked next fluent-package version: $next_package_ver"
 
 # Install the dummy package of the next version
 sudo $DNF install -y ./$next_package
@@ -65,18 +62,6 @@ test $(eval $env_vars && echo $FLUENT_CONF) = "/etc/fluent/fluentd.conf"
 test $(eval $env_vars && echo $FLUENT_PACKAGE_LOG_FILE) = "/var/log/fluent/fluentd.log"
 test $(eval $env_vars && echo $FLUENT_PLUGIN) = "/etc/fluent/plugin"
 test $(eval $env_vars && echo $FLUENT_SOCKET) = "/var/run/fluent/fluentd.sock"
-cpe_name=$(grep CPE_NAME /etc/os-release | cut -d'=' -f2)
-case $cpe_name in
-    *rocky:8*)
-	# RHEL8 %systemd_postun_with_restart doesn't restart when already service is running
-	# thus, FLUENT_PACKAGE_VERSION will be kept.
-	release=$(rpmquery --queryformat="%{Version}" -p $package)
-	test $(eval $env_vars && echo $FLUENT_PACKAGE_VERSION) = "$release"
-    ;;
-    *)
-	test $(eval $env_vars && echo $FLUENT_PACKAGE_VERSION) = "$next_package_ver"
-	;;
-esac
 
 # Test: logs
 sleep 3


### PR DESCRIPTION
This reverts commit c13789b9961cc102549ffc502c30ae564ddc91a7.

We discussed FLUENT_PACKAGE_VERSION and other environemnment variables.
we decided to revert the variables because we are not used them and we have to continue to migrate them when the package will be upgraded using zero downtime restart feature.