### PR TITLE
update Fluentd and ServerEngine and other dependencies

### DIFF
--- a/fluent-package/Gemfile
+++ b/fluent-package/Gemfile
@@ -13,7 +13,7 @@ gem "cool.io", "1.8.1",  platforms: no_fat_gem
 gem "sigdump", "0.2.5"
 gem "http_parser.rb", "0.8.0"
 gem "yajl-ruby", "1.4.3"
-gem "serverengine", '2.3.2'
+gem "serverengine", '2.4.0'
 gem "msgpack", "1.7.2"
 gem "oj", "3.16.4"
 gem "tzinfo", "2.0.6"

--- a/fluent-package/Gemfile.lock
+++ b/fluent-package/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/fluent/fluentd
-  revision: e763c0761c44d9734b6aa374371387a2e8406522
-  ref: e763c0761c44d9734b6aa374371387a2e8406522
+  revision: 46372ddd521870f6a203baefb5a598209486d0bc
+  ref: 46372ddd521870f6a203baefb5a598209486d0bc
   specs:
-    fluentd (1.17.0)
+    fluentd (1.18.0)
       base64 (~> 0.2)
       bundler
       certstore_c (~> 0.1.7)
@@ -20,6 +20,7 @@ GIT
       csv (~> 3.2)
       drb (~> 2.2)
       http_parser.rb (>= 0.5.1, < 0.9.0)
+      logger (~> 1.6)
       msgpack (>= 1.3.1, < 2.0.0)
       serverengine (>= 2.3.2, < 3.0.0)
       sigdump (~> 0.2.5)
@@ -51,8 +52,9 @@ GEM
       traces (>= 0.10.0)
     async-io (1.43.2)
       async
-    async-pool (0.7.0)
+    async-pool (0.10.2)
       async (>= 1.25)
+      traces
     aws-eventstream (1.3.0)
     aws-partitions (1.957.0)
     aws-sdk-core (3.201.2)
@@ -78,8 +80,8 @@ GEM
     certstore_c (0.1.7)
     cmetrics (0.3.3)
       mini_portile2 (~> 2.7)
-    concurrent-ruby (1.3.3)
-    console (1.27.0)
+    concurrent-ruby (1.3.4)
+    console (1.29.0)
       fiber-annotation
       fiber-local (~> 1.1)
       json
@@ -97,15 +99,16 @@ GEM
       elasticsearch-api (= 8.14.0)
     elasticsearch-api (8.14.0)
       multi_json
-    excon (0.111.0)
-    faraday (2.10.0)
-      faraday-net_http (>= 2.0, < 3.2)
+    excon (1.2.2)
+    faraday (2.12.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
       logger
-    faraday-excon (2.1.0)
-      excon (>= 0.27.4)
-      faraday (~> 2.0)
-    faraday-net_http (3.1.0)
-      net-http
+    faraday-excon (2.3.0)
+      excon (>= 1.0.0)
+      faraday (>= 2.11.0, < 3)
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
     faraday_middleware-aws-sigv4 (1.0.1)
       aws-sigv4 (~> 1.0)
       faraday (>= 2.0, < 3)
@@ -115,8 +118,8 @@ GEM
     fiber-annotation (0.2.0)
     fiber-local (1.1.0)
       fiber-storage
-    fiber-storage (0.1.2)
-    fileutils (1.7.2)
+    fiber-storage (1.0.0)
+    fileutils (1.7.3)
     fluent-config-regexp-type (1.0.0)
       fluentd (> 1.0.0, < 2)
     fluent-diagtool (1.0.5)
@@ -195,17 +198,17 @@ GEM
     http_parser.rb (0.8.0)
     httpclient (2.8.3)
     jmespath (1.6.2)
-    json (2.7.2)
+    json (2.8.2)
     linux-utmpx (0.3.0)
       bindata (~> 2.4.8)
-    logger (1.6.0)
+    logger (1.6.1)
     ltsv (0.1.2)
     mini_portile2 (2.8.7)
     msgpack (1.7.2)
     multi_json (1.15.0)
-    net-http (0.4.1)
+    net-http (0.5.0)
       uri
-    nio4r (2.7.3)
+    nio4r (2.7.4)
     nokogiri (1.16.7)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -216,31 +219,31 @@ GEM
       multi_json (>= 1.0)
     parallel (1.20.1)
     prometheus-client (2.1.0)
-    protocol-hpack (1.4.3)
+    protocol-hpack (1.5.1)
     protocol-http (0.26.8)
     protocol-http1 (0.19.1)
       protocol-http (~> 0.22)
     protocol-http2 (0.16.0)
       protocol-hpack (~> 1.4)
       protocol-http (~> 0.18)
-    public_suffix (6.0.0)
-    racc (1.7.3)
+    public_suffix (6.0.1)
+    racc (1.8.1)
     rake (13.2.1)
     rdkafka (0.16.1)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
-    rexml (3.3.2)
-      strscan
+    rexml (3.3.9)
     ruby-kafka (1.5.0)
       digest-crc
     ruby-progressbar (1.13.0)
     rubyzip (1.3.0)
-    serverengine (2.3.2)
+    serverengine (2.4.0)
+      base64 (~> 0.1)
+      logger (~> 1.4)
       sigdump (~> 0.2.2)
     sigdump (0.2.5)
     strptime (0.2.5)
-    strscan (3.1.0)
     systemd-journal (1.4.2)
       ffi (~> 1.9)
     td (0.17.1)
@@ -262,12 +265,12 @@ GEM
       msgpack (>= 0.5.6, < 2.0)
       td-client (>= 0.8.66, < 2.0)
     timers (4.3.5)
-    traces (0.11.1)
+    traces (0.14.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2024.1)
       tzinfo (>= 1.0.0)
-    uri (0.13.0)
+    uri (1.0.2)
     webhdfs (0.11.0)
       addressable
     webrick (1.8.1)
@@ -337,7 +340,7 @@ DEPENDENCIES
   rake
   rdkafka (= 0.16.1)
   ruby-kafka (= 1.5.0)
-  serverengine (= 2.3.2)
+  serverengine (= 2.4.0)
   sigdump (= 0.2.5)
   systemd-journal (= 1.4.2)
   td (= 0.17.1)

--- a/fluent-package/config.rb
+++ b/fluent-package/config.rb
@@ -7,7 +7,7 @@ COMPAT_SERVICE_NAME = "td-agent"
 PACKAGE_DIR = "fluent"
 COMPAT_PACKAGE_DIR = COMPAT_SERVICE_NAME
 
-FLUENTD_REVISION = 'e763c0761c44d9734b6aa374371387a2e8406522' # v1.17.0
+FLUENTD_REVISION = '46372ddd521870f6a203baefb5a598209486d0bc' # v1.18.0
 FLUENTD_LOCAL_GEM_REPO = "file://" + File.expand_path(File.join(__dir__, "local_gem_repo"))
 
 # https://github.com/jemalloc/jemalloc/releases


### PR DESCRIPTION
* Update Fluentd to v1.18.0 (https://github.com/fluent/fluentd/releases/tag/v1.18.0).
* Update ServerEngine to v2.4.0 (https://github.com/treasure-data/serverengine/commit/c93a592bb9642cdb8880fe9366bbee37e5b764cd).
* Update the lock file by `bundle update` on Windows.

Note: Normally, we update dependencies at the time of release, but this time, we should do it first since we will add a new feature #713 that depends on these new versions.
