### PR TITLE
deb: suppress service restart by needrestart

### DIFF
--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -1158,10 +1158,21 @@ class BuildTask
     fluentd_conf = "etc/#{PACKAGE_DIR}/#{SERVICE_NAME}.conf"
     fluentd_conf_default = "opt/#{PACKAGE_DIR}/share/#{SERVICE_NAME}.conf"
     configs = [fluentd_conf]
-    configs.concat([
-                     "etc/logrotate.d/#{SERVICE_NAME}",
-                     fluentd_conf_default,
-                   ]) unless windows? || macos?
+    unless windows? || macos?
+      configs.concat([
+                      "etc/logrotate.d/#{SERVICE_NAME}",
+                      fluentd_conf_default,
+                    ])
+      File.readlines("/etc/os-release").each do |line|
+        if line.include?("ID=")
+          distribution = line.split(/=/).last.chomp
+          if ["debian", "ubuntu"].include?(distribution)
+            puts "Suppress needrestart on #{distribution}"
+            configs.concat(["etc/needrestart/conf.d/50-fluent-package.conf"])
+          end
+        end
+      end
+    end
     configs.each do |config|
       src =
         if config == fluentd_conf_default

--- a/fluent-package/apt/systemd-test/update-from-v4.sh
+++ b/fluent-package/apt/systemd-test/update-from-v4.sh
@@ -23,7 +23,19 @@ case $1 in
   local)
     sudo apt install -V -y \
       /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb \
-      /host/${distribution}/pool/${code_name}/${channel}/*/*/td-agent_*_all.deb
+      /host/${distribution}/pool/${code_name}/${channel}/*/*/td-agent_*_all.deb 2>&1 | tee upgrade.log
+    # Test: needrestart was suppressed
+    if dpkg-query --show --showformat='${Version}' needrestart ; then
+      case $code_name in
+        focal)
+          # dpkg-query succeeds even though needrestart is not installed.
+          (! grep "No services need to be restarted." upgrade.log)
+          ;;
+        *)
+          grep "No services need to be restarted." upgrade.log
+          ;;
+      esac
+    fi
     ;;
   v5)
     curl --fail --silent --show-error --location https://toolbelt.treasuredata.com/sh/install-${distribution}-${code_name}-fluent-package5.sh | sh

--- a/fluent-package/apt/systemd-test/update-to-next-version-service-status.sh
+++ b/fluent-package/apt/systemd-test/update-to-next-version-service-status.sh
@@ -33,7 +33,20 @@ fi
 main_pid=$(systemctl show --value --property=MainPID fluentd)
 
 # Install the dummy package
-sudo apt install -V -y ./next_version.deb
+sudo apt install -V -y ./next_version.deb 2>&1 | tee upgrade.log
+
+# Test: needrestart was suppressed
+if dpkg-query --show --showformat='${Version}' needrestart ; then
+  case $code_name in
+    focal)
+      # dpkg-query succeeds even though needrestart is not installed.
+      (! grep "No services need to be restarted." upgrade.log)
+      ;;
+    *)
+      grep "No services need to be restarted." upgrade.log
+      ;;
+  esac
+fi
 
 # The service should take over the state
 if [ "$enabled_before_update" = enabled ]; then

--- a/fluent-package/debian/fluent-package.install
+++ b/fluent-package/debian/fluent-package.install
@@ -5,4 +5,5 @@ usr/lib/tmpfiles.d/*
 etc/logrotate.d/*
 etc/fluent/*
 etc/default/*
+etc/needrestart/conf.d/*
 lib/systemd/system/*

--- a/fluent-package/templates/etc/needrestart/conf.d/50-fluent-package.conf
+++ b/fluent-package/templates/etc/needrestart/conf.d/50-fluent-package.conf
@@ -1,0 +1,6 @@
+# Configuration for needrestart
+
+# Always suppress restarting by needrestart.
+$nrconf{blacklist_rc} = [
+  qr(^fluentd\.service$)
+];


### PR DESCRIPTION
Since Ubuntu 24.04, needrestart package kicks service restart out of package maintainer scripts.
Take back fluentd service under control for us,
it had better to suppress it.

NOTE: It seems that needrestart package is available from EPEL 8/9, but it is broken for a long time, so just ignore it.

Needrestart package missing dependency
https://bugzilla.redhat.com/show_bug.cgi?id=2154293

Note: Extracted changes from the following commits on `feature-nodowntime` branch.

* 91d28f206328770ad21ac1f58c6c42ea87bc64ab
* 65ed4e03808be48018be4455d8f94eb3ceb87690
* d7186ea346deb98d685e1ba866f337280eb270cd