### PR TITLE
ci: add test to check the service status with updating from v4

### DIFF
--- a/fluent-package/apt/systemd-test/update-from-v4.sh
+++ b/fluent-package/apt/systemd-test/update-from-v4.sh
@@ -9,6 +9,7 @@ sudo apt install -y curl ca-certificates
 curl -fsSL https://toolbelt.treasuredata.com/sh/install-${distribution}-${code_name}-td-agent4.sh | sh
 
 systemctl status --no-pager td-agent
+main_pid=$(eval $(systemctl show td-agent --property=MainPID) && echo $MainPID)
 
 # Generate garbage files
 touch /etc/td-agent/a\ b\ c
@@ -17,6 +18,9 @@ touch /etc/td-agent/plugin/in_fake.rb
 for d in $(seq 1 10); do
     touch /var/log/td-agent/$d.log
 done
+
+# When it updates from v4, the service needs to be stopped to restart fluentd after installation.
+sudo systemctl stop td-agent
 
 # Install the current
 case $1 in
@@ -48,6 +52,9 @@ esac
 # Test: service status
 systemctl status --no-pager fluentd
 systemctl status --no-pager td-agent
+
+# Fluentd should be restarted when update from v4.
+test $main_pid -ne $(eval $(systemctl show fluentd --property=MainPID) && echo $MainPID)
 
 # Test: restoring td-agent service alias
 sudo systemctl stop fluentd

--- a/fluent-package/apt/systemd-test/update-from-v4.sh
+++ b/fluent-package/apt/systemd-test/update-from-v4.sh
@@ -20,6 +20,8 @@ for d in $(seq 1 10); do
 done
 
 # When it updates from v4, the service needs to be stopped to restart fluentd after installation.
+# Note: This behavior is not expected, and maybe it should be fixed.
+# The cause is unknown. For deb, usually, restart should happen when the service was active before the update.
 sudo systemctl stop td-agent
 
 # Install the current

--- a/fluent-package/yum/systemd-test/update-from-v4.sh
+++ b/fluent-package/yum/systemd-test/update-from-v4.sh
@@ -19,6 +19,7 @@ sudo $DNF install -y td-agent-${td_agent_version}-1.*.x86_64
 
 sudo systemctl enable --now td-agent
 systemctl status --no-pager td-agent
+main_pid=$(eval $(systemctl show td-agent --property=MainPID) && echo $MainPID)
 
 # Generate garbage files
 touch /etc/td-agent/a\ b\ c
@@ -39,6 +40,9 @@ systemctl is-enabled fluentd
 systemctl status --no-pager fluentd # Migration process starts the service automatically
 sudo systemctl enable fluentd # Enable the unit name alias
 systemctl status --no-pager td-agent
+
+# Fluentd should be restarted when update from v4.
+test $main_pid -ne $(eval $(systemctl show fluentd --property=MainPID) && echo $MainPID)
 
 # Test: config migration
 test -h /etc/td-agent


### PR DESCRIPTION
This PR will add test to confirm that fluentd should be restarted with updating from v4