### PR TITLE
auto plugin install: disable unless auto

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -176,7 +176,9 @@ jobs:
           - "update-to-next-version-service-status.sh disabled active"
           - "update-to-next-version-service-status.sh disabled inactive"
           - "update-to-next-version-with-auto-and-manual.sh"
-          - "update-to-next-major-version.sh"
+          - "update-to-next-major-version.sh auto"
+          - "update-to-next-major-version.sh manual"
+          - "update-to-next-major-version.sh etc"
           - "update-without-data-lost.sh v5 v6"
           - "update-without-data-lost.sh v6 v5"
         include:

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -151,7 +151,9 @@ jobs:
           - "update-to-next-version-service-status.sh disabled active"
           - "update-to-next-version-service-status.sh disabled inactive"
           - "update-to-next-version-with-auto-and-manual.sh"
-          - "update-to-next-major-version.sh"
+          - "update-to-next-major-version.sh auto"
+          - "update-to-next-major-version.sh manual"
+          - "update-to-next-major-version.sh etc"
           - "update-without-data-lost.sh v5 v6"
           - "update-without-data-lost.sh v6 v5"
         include:
@@ -223,7 +225,9 @@ jobs:
           - "update-to-next-version-service-status.sh disabled active"
           - "update-to-next-version-service-status.sh disabled inactive"
           - "update-to-next-version-with-auto-and-manual.sh"
-          - "update-to-next-major-version.sh"
+          - "update-to-next-major-version.sh auto"
+          - "update-to-next-major-version.sh manual"
+          - "update-to-next-major-version.sh etc"
           - "update-without-data-lost.sh v5 v6"
           - "update-without-data-lost.sh v6 v5"
         include:

--- a/fluent-package/templates/package-scripts/fluent-package/deb/preinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/preinst
@@ -12,6 +12,9 @@ set -e
 
 local_base_plugins=/tmp/<%= package_dir %>/.local_base_plugins
 migrate_local_plugins() {
+    if [ "$FLUENT_PACKAGE_SERVICE_RESTART" != auto ]; then
+        return
+    fi
     if [ ! -d /run/systemd/system ]; then
         # tmpfiles.d owns /tmp/<%= package_dir %>, but not created without systemd
         mkdir -p /tmp/<%= package_dir %>
@@ -37,6 +40,8 @@ check_whether_zero_downtime_restart_supported() {
 
 case "$1" in
     upgrade)
+        . /etc/default/<%= service_name %>
+        echo "preinst FLUENT_PACKAGE_SERVICE_RESTART: $FLUENT_PACKAGE_SERVICE_RESTART"
         migrate_local_plugins
         check_whether_zero_downtime_restart_supported
 	;;

--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -188,8 +188,12 @@ else
     fi
 fi
 if [ $1 -eq 2 ]; then
-  # collect installed gems during upgrading
-  /usr/sbin/fluent-gem list '^fluent-plugin-' --no-versions --no-verbose > %{local_base_plugins}
+  . %{_sysconfdir}/sysconfig/@SERVICE_NAME@
+  echo "pre FLUENT_PACKAGE_SERVICE_RESTART: $FLUENT_PACKAGE_SERVICE_RESTART"
+  if [ "$FLUENT_PACKAGE_SERVICE_RESTART" = auto ]; then
+    # collect installed gems during upgrading
+    /usr/sbin/fluent-gem list '^fluent-plugin-' --no-versions --no-verbose > %{local_base_plugins}
+  fi
 fi
 
 %preun

--- a/fluent-package/yum/systemd-test/update-to-next-major-version.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-major-version.sh
@@ -4,9 +4,14 @@ set -exu
 
 . $(dirname $0)/commonvar.sh
 
+service_restart=$1
+
 # Install the current
 package="/host/${distribution}/${DISTRIBUTION_VERSION}/x86_64/Packages/fluent-package-*.rpm"
 sudo $DNF install -y $package
+
+# Set FLUENT_PACKAGE_SERVICE_RESTART
+sed -i "s/=auto/=$service_restart/" /etc/sysconfig/fluentd
 
 # Install plugin manually (plugin and gem)
 sudo /opt/fluent/bin/fluent-gem install --no-document fluent-plugin-concat
@@ -17,6 +22,12 @@ package="/host/v6-test/${distribution}/${DISTRIBUTION_VERSION}/x86_64/Packages/f
 sudo $DNF install -y $package
 
 # Test: Check whether plugin/gem were installed during upgrading
-/opt/fluent/bin/fluent-gem list | grep fluent-plugin-concat
-# Non fluent-plugin- prefix gem should not be installed automatically
-(! /opt/fluent/bin/fluent-gem list | grep gqtp)
+if [ "$service_restart" = auto ]; then
+    # plugin gem should be installed automatically
+    /opt/fluent/bin/fluent-gem list | grep fluent-plugin-concat
+    # Non fluent-plugin- prefix gem should not be installed automatically
+    (! /opt/fluent/bin/fluent-gem list | grep gqtp)
+else
+    # plugin gem should not be installed automatically
+    (! /opt/fluent/bin/fluent-gem list | grep fluent-plugin-concat)
+fi


### PR DESCRIPTION
This allows users to manually manage plugins by setting FLUENT_PACKAGE_SERVICE_RESTART to manual.

For example, there will be cases where a user wants to use a particular plugin version.