### PR TITLE
deb: include prerm script in debian package

### DIFF
--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -494,7 +494,7 @@ class BuildTask
         remove_needless_files
       end
 
-      debian_pkg_scripts = ["preinst", "postinst", "postrm"]
+      debian_pkg_scripts = ["preinst", "postinst", "prerm", "postrm"]
       debian_pkg_scripts.each do |script|
         CLEAN.include(File.join("..", "debian", script))
       end


### PR DESCRIPTION
Add missing `prerm` script to include it in debian package