### PR TITLE
deb: improve process timing for safety and simplicity

### DIFF
--- a/fluent-package/templates/package-scripts/fluent-package/deb/postinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postinst
@@ -145,7 +145,7 @@ migration_from_v4_post_process() {
     fi
 }
 
-local_base_plugins=/tmp/<%= package_dir %>/.local_base_plugins
+local_base_plugins="/tmp/<%= package_dir %>/.previous_plugin_list"
 install_missing_plugins() {
     # Install missing gems (even though systemd is not available, it works)
     if [ -f $local_base_plugins ]; then
@@ -168,31 +168,17 @@ install_missing_plugins() {
     fi
 }
 
-zero_downtime_restart_supported=/tmp/<%= package_dir %>/.zero_downtime_restart_supported
+pid_for_auto_restart="/tmp/<%= package_dir %>/.pid_for_auto_restart"
 fluentd_auto_restart() {
-    if [ ! -e "$zero_downtime_restart_supported" ]; then
+    if [ ! -f "$pid_for_auto_restart" ]; then
         return
     fi
 
-    if [ -d /run/systemd/system ]; then
-	pid=$(systemctl show <%= service_name %> --property=MainPID --value)
-	if [ $pid -ne 0 ]; then
-	    . /etc/default/<%= service_name %>
-	    case "$FLUENT_PACKAGE_SERVICE_RESTART" in
-		auto)
-		    echo "Kick auto service upgrade mode to MainPID:$pid"
-		    kill -USR2 $pid
-		    ;;
-		manual)
-		    echo "No need to restart service in manual mode..."
-		    ;;
-		*)
-		    echo "Nothing to be done..."
-		    ;;
-	    esac
-	fi
-    fi
-    rm -rf $zero_downtime_restart_supported
+    pid=$(cat "$pid_for_auto_restart")
+    echo "Kick auto restart to MainPID:$pid"
+    kill -USR2 $pid
+
+    rm -f "$pid_for_auto_restart"
 }
 
 case "$1" in

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postrm
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postrm
@@ -60,6 +60,11 @@ purge_bin_symlinks() {
 	fi
 }
 
+purge_tmp_files_for_upgrade() {
+    rm -f "/tmp/<%= package_dir %>/.plugin_list"
+    rm -f "/tmp/<%= package_dir %>/.main_pid"
+}
+
 case $1 in
     remove)
 	purge_var_run
@@ -72,6 +77,9 @@ case $1 in
 	purge_users
 	purge_bin_symlinks
 	;;
+    upgrade)
+        purge_tmp_files_for_upgrade
+        ;;
     *)
 	# nothing to do for upgrade, failed-upgrade, abort-install, abort-upgrade
 	;;

--- a/fluent-package/templates/package-scripts/fluent-package/deb/preinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/preinst
@@ -10,40 +10,25 @@ set -e
 # for details, see https://www.debian.org/doc/debian-policy/ or
 # the debian-policy package.
 
-local_base_plugins=/tmp/<%= package_dir %>/.local_base_plugins
-migrate_local_plugins() {
-    if [ "$FLUENT_PACKAGE_SERVICE_RESTART" != auto ]; then
-        return
+mark_auto_restart_ready() {
+    # Copy tmp files made by FROM-side because they should be cleaned postrm of FROM-side.
+    # (To ensure cleanup, tmp files should be cleaned by its own-side).
+    # The sequence of these tmp files is as follows:
+    #   1. FROM-prerm(upgrade): Leave tmp files if need.
+    #   2. TO-preinst(upgrade): Copy tmp files for TO-side.
+    #   3. FROM-postrm(upgrade): Clean tmp files of FROM-side(1.).
+    #   4. TO-postinst(configure): Use and clean tmp files of TO-side(2.).
+    if [ -f "/tmp/<%= package_dir %>/.plugin_list" ]; then
+        cp "/tmp/<%= package_dir %>/.plugin_list" "/tmp/<%= package_dir %>/.previous_plugin_list"
     fi
-    if [ ! -d /run/systemd/system ]; then
-        # tmpfiles.d owns /tmp/<%= package_dir %>, but not created without systemd
-        mkdir -p /tmp/<%= package_dir %>
-    fi
-    # collect list of gems
-    # We don't use fluent-diagtool here because it depends on systemd and piuparts fails
-    /usr/sbin/fluent-gem list '^fluent-plugin-' --no-version --no-verbose > $local_base_plugins
-}
-
-zero_downtime_restart_supported_version="1.18.0"
-zero_downtime_restart_supported=/tmp/<%= package_dir %>/.zero_downtime_restart_supported
-check_version() {
-    printf '%s\n' "$zero_downtime_restart_supported_version" "$1" | sort --check=quiet --version-sort
-}
-check_whether_zero_downtime_restart_supported() {
-    current_version=$(/usr/sbin/fluentd --version | cut -d' ' -f 4)
-    if check_version $current_version; then
-        echo "Fluentd $current_version supports zero downtime restart."
-        mkdir -p /tmp/<%= package_dir %>
-        touch $zero_downtime_restart_supported
+    if [ -f "/tmp/<%= package_dir %>/.main_pid" ]; then
+        cp "/tmp/<%= package_dir %>/.main_pid" "/tmp/<%= package_dir %>/.pid_for_auto_restart"
     fi
 }
 
 case "$1" in
     upgrade)
-        . /etc/default/<%= service_name %>
-        echo "preinst FLUENT_PACKAGE_SERVICE_RESTART: $FLUENT_PACKAGE_SERVICE_RESTART"
-        migrate_local_plugins
-        check_whether_zero_downtime_restart_supported
+        mark_auto_restart_ready
 	;;
     abort-upgrade)
         ;;

--- a/fluent-package/templates/package-scripts/fluent-package/deb/prerm
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/prerm
@@ -16,18 +16,52 @@ set -e
 # for details, see https://www.debian.org/doc/debian-policy/ or
 # the debian-policy package.
 
+make_sure_working_dir_exists() {
+    # This func is for CI ONLY.
+    # Some CI cases don't provide env with systemd.
+    # tmpfiles.d owns /tmp/<%= package_dir %>, but not created without systemd
+    if [ -d /run/systemd/system ]; then
+        return
+    fi
+    mkdir -p "/tmp/<%= package_dir %>"
+}
+
+leave_info_for_auto_restart_if_need() {
+    # Some CI cases that don't provide env with systemd, so disable auto restart feature in those cases.
+    if [ ! -d /run/systemd/system ]; then
+        return
+    fi
+
+    pid="$(systemctl show "<%= service_name %>" --property=MainPID --value)"
+    if [ $pid -eq 0 ]; then
+        echo "Do not use auto restart because the service is not active"
+        return
+    fi
+
+    . "/etc/default/<%= service_name %>"
+    echo "FLUENT_PACKAGE_SERVICE_RESTART: $FLUENT_PACKAGE_SERVICE_RESTART"
+    if [ "$FLUENT_PACKAGE_SERVICE_RESTART" != auto ]; then
+        return
+    fi
+
+    /usr/sbin/fluent-gem list '^fluent-plugin-' --no-version --no-verbose > "/tmp/<%= package_dir %>/.plugin_list"
+
+    echo "$pid" > "/tmp/<%= package_dir %>/.main_pid"
+}
 
 case "$1" in
-    remove|upgrade|deconfigure)
-    ;;
-
+    upgrade)
+        make_sure_working_dir_exists
+        leave_info_for_auto_restart_if_need
+        ;;
+    remove|deconfigure)
+        ;;
     failed-upgrade)
-    ;;
-
+        ;;
     *)
         echo "prerm called with unknown argument '$1'" >&2
         exit 1
-    ;;
+        ;;
 esac
 
 # dh_installdeb will replace this with shell code automatically


### PR DESCRIPTION
Points

* FROM-package just leaves tmp files if it supports the features.
* TO-package trigger the features if there are those tmp files.
* Thus, we don't need to check the version.
* Make installing plugin and restarting the same condition.

Before

1. from-prerm(upgrade): Do nothing.
2. to-preinst(upgrade): Collect plugin-list. Confirm version.
3. Install TO-package
4. from-postrm(upgrade): Do nothing.
5. Uninstall FROM-package
6. to-postinst(configure): Install plugin and restart if need.

After

1. from-prerm(upgrade):
   * Check auto or not.
   * Leave plugin-list and pid if need.
2. to-preinst(upgrade): Set tmp files for TO-package.
3. Install TO-package
4. from-postrm(upgrade): Clean tmp files of FROM-package.
5. Uninstall FROM-package
6. to-postinst(configure): Install plugin and restart if need.