### PR TITLE
ci: check whether needrestart was suppressed for v5

### DIFF
--- a/fluent-package/apt/commonvar.sh
+++ b/fluent-package/apt/commonvar.sh
@@ -29,3 +29,20 @@ case ${code_name} in
     java_jdk=openjdk-17-jre
     ;;
 esac
+
+function test_suppressed_needrestart()
+{
+    LOG_FILE=$1
+    # Test: needrestart was suppressed
+    if dpkg-query --show --showformat='${Version}' needrestart ; then
+        case $code_name in
+            focal)
+                # dpkg-query succeeds even though needrestart is not installed.
+                (! grep "No services need to be restarted." $LOG_FILE)
+                ;;
+            *)
+                grep "No services need to be restarted." $LOG_FILE
+                ;;
+        esac
+    fi
+}

--- a/fluent-package/apt/systemd-test/update-from-v4.sh
+++ b/fluent-package/apt/systemd-test/update-from-v4.sh
@@ -31,20 +31,11 @@ case $1 in
       /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb \
       /host/${distribution}/pool/${code_name}/${channel}/*/*/td-agent_*_all.deb 2>&1 | tee upgrade.log
     # Test: needrestart was suppressed
-    if dpkg-query --show --showformat='${Version}' needrestart ; then
-      case $code_name in
-        focal)
-          # dpkg-query succeeds even though needrestart is not installed.
-          (! grep "No services need to be restarted." upgrade.log)
-          ;;
-        *)
-          grep "No services need to be restarted." upgrade.log
-          ;;
-      esac
-    fi
+    test_suppressed_needrestart upgrade.log
     ;;
   v5)
-    curl --fail --silent --show-error --location https://toolbelt.treasuredata.com/sh/install-${distribution}-${code_name}-fluent-package5.sh | sh
+    curl --fail --silent --show-error --location https://toolbelt.treasuredata.com/sh/install-${distribution}-${code_name}-fluent-package5.sh | sh 2>&1 | tee upgrade.log
+    test_suppressed_needrestart upgrade.log
     ;;
   lts)
     curl --fail --silent --show-error --location https://toolbelt.treasuredata.com/sh/install-${distribution}-${code_name}-fluent-package5-lts.sh | sh

--- a/fluent-package/apt/systemd-test/update-to-next-major-version.sh
+++ b/fluent-package/apt/systemd-test/update-to-next-major-version.sh
@@ -27,17 +27,7 @@ sudo apt install -V -y \
     /host/v6-test/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb 2>&1 | tee upgrade.log
 
 # Test: needrestart was suppressed
-if dpkg-query --show --showformat='${Version}' needrestart ; then
-  case $code_name in
-    focal)
-      # dpkg-query succeeds even though needrestart is not installed.
-      (! grep "No services need to be restarted." upgrade.log)
-      ;;
-    *)
-      grep "No services need to be restarted." upgrade.log
-      ;;
-  esac
-fi
+test_suppressed_needrestart upgrade.log
 
 # Test: Check whether plugin/gem were installed during upgrading
 if [ "$service_restart" != manual ] && [ "$status_before_update" = active ]; then

--- a/fluent-package/apt/systemd-test/update-to-next-version-service-status.sh
+++ b/fluent-package/apt/systemd-test/update-to-next-version-service-status.sh
@@ -36,17 +36,7 @@ main_pid=$(systemctl show --value --property=MainPID fluentd)
 sudo apt install -V -y ./next_version.deb 2>&1 | tee upgrade.log
 
 # Test: needrestart was suppressed
-if dpkg-query --show --showformat='${Version}' needrestart ; then
-  case $code_name in
-    focal)
-      # dpkg-query succeeds even though needrestart is not installed.
-      (! grep "No services need to be restarted." upgrade.log)
-      ;;
-    *)
-      grep "No services need to be restarted." upgrade.log
-      ;;
-  esac
-fi
+test_suppressed_needrestart upgrade.log
 
 # The service should take over the state
 if [ "$enabled_before_update" = enabled ]; then


### PR DESCRIPTION
As v5.2.0 was released,  needrestart suppression should be also checked.

Additionally extract check logic as common helper function.