### PR TITLE
Use armored keyring for APT repository

### DIFF
--- a/fluent-apt-source/Rakefile
+++ b/fluent-apt-source/Rakefile
@@ -34,7 +34,7 @@ class FluentdAptSourcePackageTask < PackageTask
   end
 
   def repository_version
-    "2023.6.29"
+    "2025.1.8"
   end
 
   def repository_name

--- a/fluent-apt-source/Rakefile
+++ b/fluent-apt-source/Rakefile
@@ -86,11 +86,8 @@ class FluentdAptSourcePackageTask < PackageTask
 
   def apt_targets_default
     [
-      "debian-buster",
       "debian-bulleye",
       "debian-bookworm",
-      "ubuntu-xenial",
-      "ubuntu-bionic",
       "ubuntu-focal",
       "ubuntu-jammy",
       "ubuntu-noble"

--- a/fluent-apt-source/debian/changelog
+++ b/fluent-apt-source/debian/changelog
@@ -1,3 +1,10 @@
+fluent-apt-source (2025.1.8-1) unstable; urgency=medium
+
+  * New upstream release.
+  * Use armored keyring for APT repository to support newer apt.
+
+ -- Kentaro Hayashi <hayashi@clear-code.com>  Wed, 08 Jan 2025 16:31:51 +0900
+
 fluent-apt-source (2023.6.29-1) unstable; urgency=medium
 
   * New upstream release.

--- a/fluent-apt-source/debian/rules
+++ b/fluent-apt-source/debian/rules
@@ -18,12 +18,17 @@ override_dh_builddeb:
 override_dh_auto_build:
 	gpg \
 	  --no-default-keyring \
-	  --keyring ./fluent-archive-keyring.gpg \
+	  --keyring ./fluent-archive-keyring.kbx \
 	  --import keys
 	gpg \
 	  --no-default-keyring \
-	  --keyring ./fluent-archive-keyring.gpg \
+	  --keyring ./fluent-archive-keyring.kbx \
 	  --import fluent-package.pub
+	gpg \
+	  --no-default-keyring \
+	  --keyring ./fluent-archive-keyring.kbx \
+	  --armor \
+	  --export > ./fluent-archive-keyring.asc
 
 	( \
 	  distribution=$$(lsb_release --id --short | tr 'A-Z' 'a-z'); \
@@ -37,12 +42,12 @@ override_dh_auto_build:
 	  echo "URIs: https://packages.treasuredata.com/5/$${distribution}/$${code_name}/"; \
 	  echo "Suites: $${code_name}"; \
 	  echo "Components: contrib"; \
-	  echo "Signed-By: /usr/share/keyrings/fluent-archive-keyring.gpg"; \
+	  echo "Signed-By: /usr/share/keyrings/fluent-archive-keyring.asc"; \
 	) > fluent.sources
 
 override_dh_install:
 	install -d debian/tmp/usr/share/keyrings/
-	install -m 0644 fluent-archive-keyring.gpg \
+	install -m 0644 fluent-archive-keyring.asc \
 	  debian/tmp/usr/share/keyrings/
 
 	install -d debian/tmp/etc/apt/sources.list.d/

--- a/fluent-lts-apt-source/Rakefile
+++ b/fluent-lts-apt-source/Rakefile
@@ -86,11 +86,8 @@ class FluentdAptLtsSourcePackageTask < PackageTask
 
   def apt_targets_default
     [
-      "debian-buster",
       "debian-bulleye",
       "debian-bookworm",
-      "ubuntu-xenial",
-      "ubuntu-bionic",
       "ubuntu-focal",
       "ubuntu-jammy",
       "ubuntu-noble"

--- a/fluent-lts-apt-source/Rakefile
+++ b/fluent-lts-apt-source/Rakefile
@@ -34,7 +34,7 @@ class FluentdAptLtsSourcePackageTask < PackageTask
   end
 
   def repository_version
-    "2023.7.29"
+    "2025.1.8"
   end
 
   def repository_name

--- a/fluent-lts-apt-source/debian/changelog
+++ b/fluent-lts-apt-source/debian/changelog
@@ -1,6 +1,13 @@
+fluent-lts-apt-source (2025.1.8-1) unstable; urgency=medium
+
+  * New upstream release.
+  * Use armored keyring for APT repository to support newer apt.
+
+ -- Kentaro Hayashi <hayashi@clear-code.com>  Wed, 08 Jan 2025 16:31:51 +0900
+
 fluent-lts-apt-source (2023.7.29-1) unstable; urgency=medium
 
   * New upstream release.
   * Added new Fluent Package Official Signing Key.
 
- -- Kentaro Hayashi <kenhys@xdump.org>  Mon, 24 Jul 2023 17:02:55 +0900
+ -- Kentaro Hayashi <kenhys@xdump.org>  Wed, 08 Jan 2025 16:31:21 +0900

--- a/fluent-lts-apt-source/debian/rules
+++ b/fluent-lts-apt-source/debian/rules
@@ -18,12 +18,17 @@ override_dh_builddeb:
 override_dh_auto_build:
 	gpg \
 	  --no-default-keyring \
-	  --keyring ./fluent-lts-archive-keyring.gpg \
+	  --keyring ./fluent-lts-archive-keyring.kbx \
 	  --import keys
 	gpg \
 	  --no-default-keyring \
-	  --keyring ./fluent-lts-archive-keyring.gpg \
+	  --keyring ./fluent-lts-archive-keyring.kbx \
 	  --import fluent-package.pub
+	gpg \
+	  --no-default-keyring \
+	  --keyring ./fluent-lts-archive-keyring.kbx \
+	  --armor \
+	  --export > ./fluent-lts-archive-keyring.asc
 
 	( \
 	  distribution=$$(lsb_release --id --short | tr 'A-Z' 'a-z'); \
@@ -37,12 +42,12 @@ override_dh_auto_build:
 	  echo "URIs: https://packages.treasuredata.com/lts/5/$${distribution}/$${code_name}/"; \
 	  echo "Suites: $${code_name}"; \
 	  echo "Components: contrib"; \
-	  echo "Signed-By: /usr/share/keyrings/fluent-lts-archive-keyring.gpg"; \
+	  echo "Signed-By: /usr/share/keyrings/fluent-lts-archive-keyring.asc"; \
 	) > fluent-lts.sources
 
 override_dh_install:
 	install -d debian/tmp/usr/share/keyrings/
-	install -m 0644 fluent-lts-archive-keyring.gpg \
+	install -m 0644 fluent-lts-archive-keyring.asc \
 	  debian/tmp/usr/share/keyrings/
 
 	install -d debian/tmp/etc/apt/sources.list.d/


### PR DESCRIPTION
Since apt 2.9.16, it rejects the keybox format files. So we should use
    the armored format instead.

ref. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1088656#35

    > The only format which is GnuPG specific, are for example its internal
    > keybox keyrings, which I don't think has ever been used as any kind
    > of public interchange format.

In practical use case, Debian 13 (trixie) or Ubuntu 25.04 will be
    affected. Without it, it causes verification error with apt-get update.
