### PR TITLE
dependency: update rdkafka

### DIFF
--- a/fluent-package/Gemfile
+++ b/fluent-package/Gemfile
@@ -95,7 +95,7 @@ gem "fluent-plugin-windows-eventlog", "0.8.3", platforms: windows_platforms
 gem "fluent-plugin-windows-exporter", "1.0.0", platforms: windows_platforms
 
 not_windows_platforms = [:ruby]
-gem "rdkafka", "0.12.0", platforms: not_windows_platforms
+gem "rdkafka", "0.12.1", platforms: not_windows_platforms
 gem "systemd-journal", "2.0.0", platforms: not_windows_platforms
 gem "fluent-plugin-systemd", "1.1.0", platforms: not_windows_platforms
 gem "fluent-plugin-utmpx", "0.5.0", platforms: not_windows_platforms

--- a/fluent-package/Gemfile.lock
+++ b/fluent-package/Gemfile.lock
@@ -225,7 +225,7 @@ GEM
     public_suffix (5.0.5)
     racc (1.7.3)
     rake (13.1.0)
-    rdkafka (0.12.0)
+    rdkafka (0.12.1)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
@@ -334,7 +334,7 @@ DEPENDENCIES
   opensearch-ruby (= 2.1.0)
   prometheus-client (= 2.1.0)
   rake
-  rdkafka (= 0.12.0)
+  rdkafka (= 0.12.1)
   ruby-kafka (= 1.5.0)
   serverengine (= 2.3.2)
   sigdump (= 0.2.5)


### PR DESCRIPTION
Build error occurs in AmazonLinux 2023.

    Extracting v1.9.0 into tmp/x86_64-amazon-linux/ports/librdkafka/1.9.0... OK
    Running 'configure' for librdkafka 1.9.0... OK
    Running 'compile' for librdkafka 1.9.0... OK
    Running 'install' for librdkafka 1.9.0... ERROR. Please review logs to see what happened:
    ----- contents of '/root/rpmbuild/BUILDROOT/fluent-package-5.0.5-1.amzn2023.x86_64/opt/fluent/lib/ruby/gems/3.2.0/gems/rdkafka-0.12.0/ext/tmp/x86_64-amazon-linux/ports/librdkafka/    1.9.0/install.log' -----
    make[1]: Entering directory '/root/rpmbuild/BUILDROOT/fluent-package-5.0.5-1.amzn2023.x86_64/opt/fluent/lib/ruby/gems/3.2.0/gems/rdkafka-0.12.0/ext/tmp/x86_64-amazon-linux/ports/    librdkafka/1.9.0/librdkafka-1.9.0/src'
    Install librdkafka to /root/rpmbuild/BUILDROOT/fluent-package-5.0.5-1.amzn2023.x86_64/opt/fluent/lib/ruby/gems/3.2.0/gems/rdkafka-0.12.0/ext/ports/x86_64-amazon-linux/librdkafka/    1.9.0
    d $DESTDIR/root/rpmbuild/BUILDROOT/fluent-package-5.0.5-1.amzn2023.x86_64/opt/fluent/lib/ruby/gems/3.2.0/gems/rdkafka-0.12.0/ext/ports/x86_64-amazon-linux/librdkafka/1.9.0/include    /librdkafka
    /bin/sh: line 1: d: command not found
    make[1]: [../mklove/Makefile.base:269: lib-install] Error 127 (ignored)
    d $DESTDIR/root/rpmbuild/BUILDROOT/fluent-package-5.0.5-1.amzn2023.x86_64/opt/fluent/lib/ruby/gems/3.2.0/gems/rdkafka-0.12.0/ext/ports/x86_64-amazon-linux/librdkafka/1.9.0/lib
    /bin/sh: line 1: d: command not found
    make[1]: [../mklove/Makefile.base:270: lib-install] Error 127 (ignored)
    rdkafka.h rdkafka_mock.h $DESTDIR/root/rpmbuild/BUILDROOT/fluent-package-5.0.5-1.amzn2023.x86_64/opt/fluent/lib/ruby/gems/3.2.0/gems/rdkafka-0.12.0/ext/ports/x86_64-amazon-linux/    librdkafka/1.9.0/include/librdkafka
    /bin/sh: line 1: rdkafka.h: command not found
    make[1]: *** [../mklove/Makefile.base:271: lib-install] Error 127
    make[1]: Leaving directory '/root/rpmbuild/BUILDROOT/fluent-package-5.0.5-1.amzn2023.x86_64/opt/fluent/lib/ruby/gems/3.2.0/gems/rdkafka-0.12.0/ext/tmp/x86_64-amazon-linux/ports/    librdkafka/1.9.0/librdkafka-1.9.0/src'
    make: *** [Makefile:44: install-subdirs] Error 2
    ----- end of file -----