### PR TITLE
amazonlinux-2023: ensure to install `which` command

### DIFF
--- a/fluent-package/yum/amazonlinux-2023/Dockerfile
+++ b/fluent-package/yum/amazonlinux-2023/Dockerfile
@@ -47,6 +47,8 @@ RUN \
     ruby3.2 \
     ruby3.2-rubygems \
     ruby3.2-rubygem-rake \
+    # install which for building librdkafka 1.9.0 or later
+    which \
     && \
   # raise IPv4 priority
   echo "precedence ::ffff:0:0/96 100" > /etc/gai.conf && \


### PR DESCRIPTION
* It appears that the recent Amazon Linux 2023 image stops providing `which`.
* We need `which` to build `librdkafka 1.9.0` or later.
  * https://github.com/confluentinc/librdkafka/pull/4353