### PR TITLE
Backport rpm: keep compatibility with createrepo

### DIFF
--- a/fluent-package/manage-fluent-repositories.sh
+++ b/fluent-package/manage-fluent-repositories.sh
@@ -178,7 +178,7 @@ EOF
 	# update & sign rpm repository
 	repodirs=`find "${FLUENT_RELEASE_DIR}" -regex "^${FLUENT_RELEASE_DIR}/5/\(redhat\|amazon\)/\([2789]\|2023\)/\(x86_64\|aarch64\)$"`
 	for repodir in $repodirs; do
-	    createrepo_c -v "${repodir}"
+	    createrepo_c -v --compatibility "${repodir}"
 
 	    repofile="${repodir}/repodata/repomd.xml"
 	    if [ -f "${repofile}.asc" ]; then


### PR DESCRIPTION
Latest createrepo-c breaks compatibility with createrepo. For example, it does not create metadata (repodata/*) which can be handled yum in AmazonLinux 2.

To keep compatibility for such a distribution, need to specify --compatibility explicitly.

See https://github.com/rpm-software-management/createrepo_c/issues/383