### PR TITLE
ci: use Incus instead of LXD

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -189,19 +189,19 @@ jobs:
         include:
           - label: Debian bullseye amd64
             rake-job: debian-bullseye
-            lxc-image: images:debian/11
+            container-image: images:debian/11
           - label: Debian bookworm amd64
             rake-job: debian-bookworm
-            lxc-image: images:debian/12
+            container-image: images:debian/12
           - label: Ubuntu Focal amd64
             rake-job: ubuntu-focal
-            lxc-image: ubuntu:20.04
+            container-image: images:ubuntu/20.04
           - label: Ubuntu Jammy amd64
             rake-job: ubuntu-jammy
-            lxc-image: ubuntu:22.04
+            container-image: images:ubuntu/22.04
           - label: Ubuntu Noble amd64
             rake-job: ubuntu-noble
-            lxc-image: ubuntu:24.04
+            container-image: images:ubuntu/24.04
         exclude:
           - label: Debian bookworm amd64
             test: update-from-v4.sh local
@@ -235,24 +235,17 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: packages-apt-source-${{ matrix.rake-job }}
-      - uses: canonical/setup-lxd@v0.1.2
-      - name: Run diagnostic
+      - name: Setup Incus
         run: |
-          uname -a
-          echo "::group::snap info lxd"
-          snap info lxd
-          echo "::endgroup::"
-          echo "::group::snap services lxd"
-          snap services lxd
-          echo "::endgroup::"
-          echo "::group::snap logs lxd"
-          sudo snap logs lxd
-          echo "::endgroup::"
-          echo "::group::lxc remote list"
-          lxc remote list
-          echo "::endgroup::"
-          echo "::group::lxc list images:"
-          lxc image list images:
-          echo "::endgroup::"
-      - name: Run Test  ${{ matrix.test }} on ${{ matrix.lxc-image }}
-        run: fluent-package/apt/systemd-test/test.sh ${{ matrix.lxc-image }} ${{ matrix.test }}
+          sudo apt update
+          sudo apt install -y -V incus
+      - name: Allow egress network traffic flows for Incus
+        # https://linuxcontainers.org/incus/docs/main/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-incus-and-docker
+        run: |
+          sudo iptables -I DOCKER-USER -i incusbr0 -j ACCEPT
+          sudo iptables -I DOCKER-USER -o incusbr0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+      - name: Setup Incus
+        run: |
+          sudo incus admin init --auto
+      - name: Run Test  ${{ matrix.test }} on ${{ matrix.container-image }}
+        run: fluent-package/apt/systemd-test/test.sh ${{ matrix.container-image }} ${{ matrix.test }}

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -164,10 +164,10 @@ jobs:
         include:
           - label: AmazonLinux 2 x86_64
             rake-job: amazonlinux-2
-            lxc-image: images:amazonlinux/2
+            container-image: images:amazonlinux/2
           - label: AmazonLinux 2023 x86_64
             rake-job: amazonlinux-2023
-            lxc-image: images:amazonlinux/2023
+            container-image: images:amazonlinux/2023
         exclude:
           - label: AmazonLinux 2023 x86_64
             test: update-from-v4.sh
@@ -184,27 +184,31 @@ jobs:
         with:
           name: v6-packages-${{ matrix.rake-job }}
           path: v6-test
-      - uses: canonical/setup-lxd@v0.1.2
-      - name: Run diagnostic
+      - name: Install Incus
         run: |
-          uname -a
-          echo "::group::snap info lxd"
-          snap info lxd
-          echo "::endgroup::"
-          echo "::group::snap services lxd"
-          snap services lxd
-          echo "::endgroup::"
-          echo "::group::snap logs lxd"
-          sudo snap logs lxd
-          echo "::endgroup::"
-          echo "::group::lxc remote list"
-          lxc remote list
-          echo "::endgroup::"
-          echo "::group::lxc list images:"
-          lxc image list images:
-          echo "::endgroup::"
-      - name: Run Test ${{ matrix.test }} on ${{ matrix.lxc-image }}
-        run: fluent-package/yum/systemd-test/test.sh ${{ matrix.lxc-image }} ${{ matrix.test }}
+          sudo curl -fsSL https://pkgs.zabbly.com/key.asc -o /etc/apt/keyrings/zabbly.asc
+          cat <<SOURCES | sudo tee /etc/apt/sources.list.d/zabbly-incus-stable.sources
+          Enabled: yes
+          Types: deb
+          URIs: https://pkgs.zabbly.com/incus/stable
+          Suites: $(. /etc/os-release && echo ${VERSION_CODENAME})
+          Components: main
+          Architectures: $(dpkg --print-architecture)
+          Signed-By: /etc/apt/keyrings/zabbly.asc
+          SOURCES
+
+          sudo apt-get update
+          sudo apt-get install -y -V incus
+      - name: Allow egress network traffic flows for Incus
+        # https://linuxcontainers.org/incus/docs/main/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-incus-and-docker
+        run: |
+          sudo iptables -I DOCKER-USER -i incusbr0 -j ACCEPT
+          sudo iptables -I DOCKER-USER -o incusbr0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+      - name: Setup Incus
+        run: |
+          sudo incus admin init --auto
+      - name: Run Test ${{ matrix.test }} on ${{ matrix.container-image }}
+        run: fluent-package/yum/systemd-test/test.sh ${{ matrix.container-image }} ${{ matrix.test }}
 
   v2test:
     name: Test ${{ matrix.label }} ${{ matrix.test }} (CGroup V2)
@@ -243,10 +247,10 @@ jobs:
         include:
           - label: RockyLinux 8 x86_64
             rake-job: rockylinux-8
-            lxc-image: images:rockylinux/8
+            container-image: images:rockylinux/8
           - label: AlmaLinux 9 x86_64
             rake-job: almalinux-9
-            lxc-image: images:almalinux/9
+            container-image: images:almalinux/9
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -256,6 +260,17 @@ jobs:
         with:
           name: v6-packages-${{ matrix.rake-job }}
           path: v6-test
-      - uses: canonical/setup-lxd@v0.1.2
-      - name: Run Test ${{ matrix.test }} on ${{ matrix.lxc-image }}
-        run: fluent-package/yum/systemd-test/test.sh ${{ matrix.lxc-image }} ${{ matrix.test }}
+      - name: Install Incus
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y -V incus
+      - name: Allow egress network traffic flows for Incus
+        # https://linuxcontainers.org/incus/docs/main/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-incus-and-docker
+        run: |
+          sudo iptables -I DOCKER-USER -i incusbr0 -j ACCEPT
+          sudo iptables -I DOCKER-USER -o incusbr0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+      - name: Setup Incus
+        run: |
+          sudo incus admin init --auto
+      - name: Run Test ${{ matrix.test }} on ${{ matrix.container-image }}
+        run: fluent-package/yum/systemd-test/test.sh ${{ matrix.container-image }} ${{ matrix.test }}

--- a/fluent-package/apt/systemd-test/test.sh
+++ b/fluent-package/apt/systemd-test/test.sh
@@ -15,21 +15,21 @@ dir="/host/fluent-package/apt/systemd-test"
 set -eux
 
 echo "::group::Run test: launch $image"
-lxc launch $image target --debug
+sudo incus launch $image target --debug
 sleep 5
 echo "::endgroup::"
 echo "::group::Run test: configure $image"
-lxc config device add target host disk source=$PWD path=/host
-lxc list
+sudo incus config device add target host disk source=$PWD path=/host
+sudo incus list
 echo "::endgroup::"
 echo "::group::Run test: setup $image"
-lxc exec target -- $dir/setup.sh
+sudo incus exec target -- $dir/setup.sh
 echo "::endgroup::"
 echo "::group::Run test: $test_file $other_args on $image"
-lxc exec target -- $dir/$test_file $other_args
+sudo incus exec target -- $dir/$test_file $other_args
 echo "::endgroup::"
 echo "::group::Run test: cleanup $image"
-lxc stop target
-lxc delete target
+sudo incus stop target
+sudo incus delete target
 echo "::endgroup::"
 echo -e "\nAll Success!\n"

--- a/fluent-package/yum/systemd-test/test.sh
+++ b/fluent-package/yum/systemd-test/test.sh
@@ -15,18 +15,18 @@ dir="/host/fluent-package/yum/systemd-test"
 set -eux
 
 echo "::group::Run test: launch $image"
-lxc launch $image target --debug
+sudo incus launch $image target --debug
 sleep 5
 echo "::endgroup::"
 echo "::group::Run test: configure $image"
-lxc config device add target host disk source=$PWD path=/host
-lxc list
+sudo incus config device add target host disk source=$PWD path=/host
+sudo incus list
 echo "::endgroup::"
 echo "::group::Run test: $test_file $other_args on $image"
-lxc exec target -- $dir/$test_file $other_args
+sudo incus exec target -- $dir/$test_file $other_args
 echo "::endgroup::"
 echo "::group::Run test: cleanup $image"
-lxc stop target
-lxc delete target
+sudo incus stop target
+sudo incus delete target
 echo "::endgroup::"
 echo -e "\nAll Success!\n"


### PR DESCRIPTION
It seems that AmazonLinux:2 container image is not available anymore from https://images.lxd.canonical.com/.
AmazonLinux:2 is still available from
https://images.linuxcontainers.org,
but it can't be added without interactive operation for LXD.

It seems that it is easy to use Incus as a workaround.