### PR TITLE
ci: switch CGroup v1 test with VirtualBox

### DIFF
--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -130,7 +130,10 @@ jobs:
   v1test:
     name: Test ${{ matrix.label }} ${{ matrix.test }} (CGroup V1)
     needs: build
-    runs-on: ubuntu-20.04
+    # Ubuntu 20.04 is not available anymore, so can't use container based
+    # approach. Instead, use vagrant on Ubuntu 24.04.
+    # (NOTE: nested VM is executable on macos-13, but it is too slow)
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -164,10 +167,8 @@ jobs:
         include:
           - label: AmazonLinux 2 x86_64
             rake-job: amazonlinux-2
-            container-image: images:amazonlinux/2
           - label: AmazonLinux 2023 x86_64
             rake-job: amazonlinux-2023
-            container-image: images:amazonlinux/2023
         exclude:
           - label: AmazonLinux 2023 x86_64
             test: update-from-v4.sh
@@ -184,31 +185,29 @@ jobs:
         with:
           name: v6-packages-${{ matrix.rake-job }}
           path: v6-test
-      - name: Install Incus
+      - name: Show host runner information
         run: |
-          sudo curl -fsSL https://pkgs.zabbly.com/key.asc -o /etc/apt/keyrings/zabbly.asc
-          cat <<SOURCES | sudo tee /etc/apt/sources.list.d/zabbly-incus-stable.sources
-          Enabled: yes
-          Types: deb
-          URIs: https://pkgs.zabbly.com/incus/stable
-          Suites: $(. /etc/os-release && echo ${VERSION_CODENAME})
-          Components: main
-          Architectures: $(dpkg --print-architecture)
-          Signed-By: /etc/apt/keyrings/zabbly.asc
-          SOURCES
-
+          cat /proc/cpuinfo | grep -E "vmx|svm"
+          lsmod | grep kvm
+      - name: Set up virtualbox
+        run: |
           sudo apt-get update
-          sudo apt-get install -y -V incus
-      - name: Allow egress network traffic flows for Incus
-        # https://linuxcontainers.org/incus/docs/main/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-incus-and-docker
+          sudo apt-get install -y virtualbox
+      - name: Set up vagrant
         run: |
-          sudo iptables -I DOCKER-USER -i incusbr0 -j ACCEPT
-          sudo iptables -I DOCKER-USER -o incusbr0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-      - name: Setup Incus
+          sudo apt-get update
+          wget -O - https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          sudo apt-get update && sudo apt install -y vagrant
+          vagrant --version
+          vagrant status
+      - name: Spin up vagrant
         run: |
-          sudo incus admin init --auto
-      - name: Run Test ${{ matrix.test }} on ${{ matrix.container-image }}
-        run: fluent-package/yum/systemd-test/test.sh ${{ matrix.container-image }} ${{ matrix.test }}
+          vagrant up --provider virtualbox ${{ matrix.rake-job }}
+      # Run tests based on AlmaLinux 8 (CGroup v1)
+      - name: Run Test ${{ matrix.test }} on ${{ matrix.rake-job }}
+        run: |
+          BOX_MOUNT_DIR=fluent-package/yum/repositories vagrant ssh ${{ matrix.rake-job }} -- /host/fluent-package/yum/systemd-test/${{ matrix.test }}
 
   v2test:
     name: Test ${{ matrix.label }} ${{ matrix.test }} (CGroup V2)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,6 +38,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       :id => "amazonlinux-2",
       :box => "bento/amazonlinux-2",
     },
+    {
+      :id => "amazonlinux-2023",
+      :box => "bento/amazonlinux-2023",
+    },
   ]
 
   n_cpus = ENV["BOX_N_CPUS"]&.to_i || 2
@@ -52,5 +56,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         virtual_box.memory = memory if memory
       end
     end
+    mount_dir = ENV["BOX_MOUNT_DIR"] || "."
+    config.vm.synced_folder mount_dir, "/host"
   end
 end

--- a/fluent-package/yum/systemd-test/downgrade-to-v5-lts.sh
+++ b/fluent-package/yum/systemd-test/downgrade-to-v5-lts.sh
@@ -29,7 +29,7 @@ sudo $DNF install -y \
 
 # Customize the env file to prevent replacing by downgrade.
 # Need this to test the case where some tmp files is left.
-echo "FOO=foo" >> /etc/sysconfig/fluentd
+echo "FOO=foo" | sudo tee -a /etc/sysconfig/fluentd
 
 sudo systemctl enable --now fluentd
 systemctl status --no-pager fluentd

--- a/fluent-package/yum/systemd-test/update-from-v4.sh
+++ b/fluent-package/yum/systemd-test/update-from-v4.sh
@@ -20,11 +20,11 @@ systemctl status --no-pager td-agent
 main_pid=$(eval $(systemctl show td-agent --property=MainPID) && echo $MainPID)
 
 # Generate garbage files
-touch /etc/td-agent/a\ b\ c
-touch /var/log/td-agent/a\ b\ c.log
-touch /etc/td-agent/plugin/in_fake.rb
+sudo touch /etc/td-agent/a\ b\ c
+sudo touch /var/log/td-agent/a\ b\ c.log
+sudo touch /etc/td-agent/plugin/in_fake.rb
 for d in $(seq 1 10); do
-    touch /var/log/td-agent/$d.log
+    sudo touch /var/log/td-agent/$d.log
 done
 
 # Install the current

--- a/fluent-package/yum/systemd-test/update-to-next-major-version.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-major-version.sh
@@ -16,7 +16,7 @@ if [ "$status_before_update" = active ]; then
 fi
 
 # Set FLUENT_PACKAGE_SERVICE_RESTART
-sed -i "s/=auto/=$service_restart/" /etc/sysconfig/fluentd
+sudo sed -i "s/=auto/=$service_restart/" /etc/sysconfig/fluentd
 
 # Install plugin manually (plugin and gem)
 sudo /opt/fluent/bin/fluent-gem install --no-document fluent-plugin-concat

--- a/fluent-package/yum/systemd-test/update-to-next-version-with-auto-and-manual.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version-with-auto-and-manual.sh
@@ -56,7 +56,7 @@ sudo $DNF remove -y fluent-package
 # Upgrade package with manual feature
 sudo $DNF install -y $package
 sudo systemctl enable --now fluentd
-sed -i 's/=auto/=manual/' /etc/sysconfig/fluentd
+sudo sed -i 's/=auto/=manual/' /etc/sysconfig/fluentd
 main_pid=$(eval $(systemctl show fluentd --property=MainPID) && echo $MainPID)
 
 sudo $DNF install -y ./$next_package
@@ -66,7 +66,7 @@ test $main_pid -eq $(eval $(systemctl show fluentd --property=MainPID) && echo $
 sleep 15
 test $main_pid -eq $(eval $(systemctl show fluentd --property=MainPID) && echo $MainPID)
 
-kill -USR2 $main_pid
+sudo kill -USR2 $main_pid
 
 # Main process should be replaced by USR2 signal
 sleep 15

--- a/fluent-package/yum/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
@@ -19,11 +19,11 @@ sudo systemctl enable --now td-agent
 systemctl status --no-pager td-agent
 
 # Generate garbage files
-touch /etc/td-agent/a\ b\ c
-touch /var/log/td-agent/a\ b\ c.log
-touch /etc/td-agent/plugin/in_fake.rb
+sudo touch /etc/td-agent/a\ b\ c
+sudo touch /var/log/td-agent/a\ b\ c.log
+sudo touch /etc/td-agent/plugin/in_fake.rb
 for d in $(seq 1 10); do
-    touch /var/log/td-agent/$d.log
+    sudo touch /var/log/td-agent/$d.log
 done
 
 # Install the current

--- a/fluent-package/yum/systemd-test/update-without-data-lost.sh
+++ b/fluent-package/yum/systemd-test/update-without-data-lost.sh
@@ -41,8 +41,8 @@ sudo $DNF install -y rsyslog
 sudo $DNF install -y $package
 
 # Set up configuration
-cat < $(dirname $0)/../../test-tools/rsyslog.conf >> /etc/rsyslog.conf
-cp $(dirname $0)/../../test-tools/fluentd.conf /etc/fluent/fluentd.conf
+cat < $(dirname $0)/../../test-tools/rsyslog.conf | sudo tee -a /etc/rsyslog.conf
+sudo cp $(dirname $0)/../../test-tools/fluentd.conf /etc/fluent/fluentd.conf
 
 # Launch rsyslog
 sudo systemctl restart rsyslog
@@ -69,7 +69,7 @@ sleep 20
 test $main_pid -ne $(eval $(systemctl show fluentd --property=MainPID) && echo $MainPID)
 
 # Stop fluentd to flush the logs and check
-systemctl stop fluentd
+sudo systemctl stop fluentd
 test $(wc -l /var/log/fluent/test_udp*.log | tail -n 1 | awk '{print $1}') = "50"
 test $(wc -l /var/log/fluent/test_tcp*.log | tail -n 1 | awk '{print $1}') = "60"
 test $(grep "test-syslog" /var/log/fluent/test_syslog*.log | wc -l) = "70"


### PR DESCRIPTION
ci: switch CGroup v1 test on vagrant (VirtualBox)

In the previous versions, AmazonLinux:2 image
was lost from LXD, so switched from LXD to Incus.

In this time, Ubuntu 20.04 runner will be removed from
GitHub Actions, so need to give up using 20.04 runner
for upcoming EOL (2025/04/15).
Thus, there is no CGroup V1 host runner available on GitHub Actions.
As a result, it means that there is no straightforward way to test package
on CGroup v1 host. (such as AmazonLinux:2, AmazonLinux:2023)

Instead, use vagrant (VirtualBox) to test fluent-package.
It enables to run VM with CGroup v1 to keep CI alive.
