### PR TITLE
ci: skip test when cache is enabled

### DIFF
--- a/.github/workflows/apt-arm.yml
+++ b/.github/workflows/apt-arm.yml
@@ -5,6 +5,7 @@ on:
       - master
       - fluent-package-v5
   pull_request:
+  workflow_dispatch:
 concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true
@@ -64,9 +65,11 @@ jobs:
           name: packages-${{ matrix.rake-job }}-arm64
           path: fluent-package/apt/repositories
       - name: Check Package Size
+        if: ${{ ! steps.cache-deb.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           fluent-package/apt/pkgsize-test.sh ${{ matrix.rake-job }} arm64
       - name: Binstubs Test
+        if: ${{ ! steps.cache-deb.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           mkdir -p .bundle
           docker run \
@@ -77,6 +80,7 @@ jobs:
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/binstubs-test.sh
       - name: Installation Test
+        if: ${{ ! steps.cache-deb.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           mkdir -p .bundle
           docker run \
@@ -87,6 +91,7 @@ jobs:
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/install-test.sh
       - name: Piuparts (Install/Remove/Upgrade) Test
+        if: ${{ ! steps.cache-deb.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           mkdir -p .bundle
           docker run \
@@ -98,6 +103,7 @@ jobs:
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/piuparts-test.sh
       - name: Serverspec Test
+        if: ${{ ! steps.cache-deb.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           mkdir -p .bundle
           docker run \
@@ -108,6 +114,7 @@ jobs:
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/serverspec-test.sh
       - name: Confluent Test
+        if: ${{ ! steps.cache-deb.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           mkdir -p .bundle
           docker run \
@@ -118,6 +125,7 @@ jobs:
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/confluent-test.sh
       - name: Binstubs Test
+        if: ${{ ! steps.cache-deb.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           mkdir -p .bundle
           docker run \

--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -5,6 +5,7 @@ on:
       - master
       - fluent-package-v5
   pull_request:
+  workflow_dispatch:
 concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true
@@ -94,9 +95,11 @@ jobs:
           path: fluent-lts-apt-source/apt/repositories
       # TODO move the following steps to "Test" job
       - name: Check Package Size
+        if: ${{ ! steps.cache-deb.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           fluent-package/apt/pkgsize-test.sh ${{ matrix.rake-job }} amd64
       - name: Installation Test
+        if: ${{ ! steps.cache-deb.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           mkdir -p .bundle
           docker run \
@@ -107,6 +110,7 @@ jobs:
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/install-test.sh
       - name: Piuparts (Install/Remove/Upgrade) Test
+        if: ${{ ! steps.cache-deb.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           mkdir -p .bundle
           docker run \
@@ -118,6 +122,7 @@ jobs:
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/piuparts-test.sh
       - name: Serverspec Test
+        if: ${{ ! steps.cache-deb.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           mkdir -p .bundle
           docker run \
@@ -128,6 +133,7 @@ jobs:
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/serverspec-test.sh
       - name: Confluent Test
+        if: ${{ ! steps.cache-deb.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           mkdir -p .bundle
           docker run \
@@ -138,6 +144,7 @@ jobs:
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/confluent-test.sh
       - name: Binstubs Test
+        if: ${{ ! steps.cache-deb.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           mkdir -p .bundle
           docker run \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,6 +5,7 @@ on:
       - master
       - fluent-package-v5
   pull_request:
+  workflow_dispatch:
 concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true
@@ -39,10 +40,12 @@ jobs:
           name: packages-windows-x86_64
           path: fluent-package/msi/repositories
       - name: Check Package Size
+        if: ${{ ! steps.cache-msi.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         shell: pwsh
         run: |
           powershell -ExecutionPolicy Bypass -Command ".\fluent-package\msi\pkgsize-test.ps1"
       - name: Installation Test
+        if: ${{ ! steps.cache-msi.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         shell: pwsh
         run: |
           mkdir -p .bundle
@@ -53,6 +56,7 @@ jobs:
           mcr.microsoft.com/dotnet/framework/runtime:3.5 `
           powershell -ExecutionPolicy Bypass -Command "C:\fluentd\fluent-package\msi\install-test.ps1"
       - name: Migration From v4 Test
+        if: ${{ ! steps.cache-msi.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         shell: pwsh
         run: |
           docker run `
@@ -62,6 +66,7 @@ jobs:
           mcr.microsoft.com/dotnet/framework/runtime:3.5 `
           powershell -ExecutionPolicy Bypass -Command "C:\fluentd\fluent-package\msi\update-from-v4-test.ps1"
       - name: Update From v5 Test
+        if: ${{ ! steps.cache-msi.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         shell: pwsh
         run: |
           docker run `
@@ -71,6 +76,7 @@ jobs:
           mcr.microsoft.com/dotnet/framework/runtime:3.5 `
           powershell -ExecutionPolicy Bypass -Command "C:\fluentd\fluent-package\msi\update-from-v5-test.ps1"
       - name: Serverspec Test
+        if: ${{ ! steps.cache-msi.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         shell: pwsh
         run: |
           docker run `

--- a/.github/workflows/yum-arm.yml
+++ b/.github/workflows/yum-arm.yml
@@ -5,6 +5,7 @@ on:
       - master
       - fluent-package-v5
   pull_request:
+  workflow_dispatch:
 concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true
@@ -57,9 +58,11 @@ jobs:
           name: packages-${{ matrix.rake-job }}-aarch64
           path: fluent-package/yum/repositories
       - name: Check Package Size
+        if: ${{ ! steps.cache-rpm.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           fluent-package/yum/pkgsize-test.sh ${{ matrix.rake-job }} aarch64
       - name: Installation Test
+        if: ${{ ! steps.cache-rpm.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           mkdir -p .bundle
           docker run \
@@ -70,6 +73,7 @@ jobs:
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/yum/install-test.sh
       - name: Serverspec Test
+        if: ${{ ! steps.cache-rpm.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           mkdir -p .bundle
           docker run \
@@ -80,6 +84,7 @@ jobs:
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/yum/serverspec-test.sh
       - name: Confluent Test
+        if: ${{ ! steps.cache-rpm.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           mkdir -p .bundle
           docker run \
@@ -90,6 +95,7 @@ jobs:
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/yum/confluent-test.sh
       - name: Binstubs Test
+        if: ${{ ! steps.cache-rpm.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           mkdir -p .bundle
           docker run \

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -5,6 +5,7 @@ on:
       - master
       - fluent-package-v5
   pull_request:
+  workflow_dispatch:
 concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true
@@ -82,9 +83,11 @@ jobs:
           path: v6-test/fluent-package/yum/repositories
       # TODO move the following steps to "Test" job
       - name: Check Package Size
+        if: ${{ ! steps.cache-rpm.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           fluent-package/yum/pkgsize-test.sh ${{ matrix.rake-job }} x86_64
       - name: Installation Test
+        if: ${{ ! steps.cache-rpm.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           mkdir -p .bundle
           docker run \
@@ -96,6 +99,7 @@ jobs:
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/yum/install-test.sh
       - name: Serverspec Test
+        if: ${{ ! steps.cache-rpm.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           mkdir -p .bundle
           docker run \
@@ -107,6 +111,7 @@ jobs:
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/yum/serverspec-test.sh
       - name: Confluent Test
+        if: ${{ ! steps.cache-rpm.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           mkdir -p .bundle
           docker run \
@@ -117,6 +122,7 @@ jobs:
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/yum/confluent-test.sh
       - name: Binstubs Test
+        if: ${{ ! steps.cache-rpm.outputs.cache-hit }} || ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           mkdir -p .bundle
           docker run \


### PR DESCRIPTION
It omits redundant tests.

* Usually source code was changed, and always ci tests them. It might be redundant when it will be tested with subsequent commits during development.
* When they were cached, ci skip tests. It assumes that CI pass test case in the previous commit
   * If you want to ensure CI results in that commit again, invoke workflow dispatch.