### PR TITLE
ci: skip "Install dependencies" conditionally

### DIFF
--- a/.github/workflows/apt-arm.yml
+++ b/.github/workflows/apt-arm.yml
@@ -37,12 +37,6 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt -V install ruby ruby-bundler ruby-serverspec
-          sudo gem install bundler:2.2.9 --no-document
-          sudo gem uninstall fileutils
       - name: cache deb
         uses: actions/cache@v4
         id: cache-deb
@@ -50,7 +44,15 @@ jobs:
           path: |
             fluent-package/apt/repositories
           key: ${{ runner.os }}-cache-${{ matrix.rake-job }}-arm64-${{ hashFiles('**/config.rb', '**/Rakefile', '**/Gemfile*', 'fluent-package/templates/**', 'fluent-package/debian/**', 'fluent-package/apt/**/Dockerfile') }}
+      - name: Install dependencies
+        if: ${{ ! steps.cache-deb.outputs.cache-hit }}
+        run: |
+          sudo apt update
+          sudo apt -V install ruby ruby-bundler ruby-serverspec
+          sudo gem install bundler:2.2.9 --no-document
+          sudo gem uninstall fileutils
       - name: Build deb with Docker
+        if: ${{ ! steps.cache-deb.outputs.cache-hit }}
         run: |
           rake apt:build APT_TARGETS=${{ matrix.rake-job }}-arm64 ${{ matrix.rake-options }}
       - name: Upload fluent-package deb

--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -29,12 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt -V install ruby ruby-bundler ruby-serverspec
-          sudo gem install bundler:2.2.9 --no-document
-          sudo gem uninstall fileutils
       - name: cache deb
         uses: actions/cache@v4
         id: cache-deb
@@ -45,6 +39,13 @@ jobs:
             fluent-lts-apt-source/apt/repositories
             v6-test/fluent-package/apt/repositories
           key: ${{ runner.os }}-cache-${{ matrix.rake-job }}-${{ hashFiles('**/config.rb', '**/Rakefile', '**/Gemfile*', 'fluent-package/templates/**', 'fluent-package/debian/**', 'fluent-package/apt/**/Dockerfile') }}
+      - name: Install dependencies
+        if: ${{ ! steps.cache-deb.outputs.cache-hit }}
+        run: |
+          sudo apt update
+          sudo apt -V install ruby ruby-bundler ruby-serverspec
+          sudo gem install bundler:2.2.9 --no-document
+          sudo gem uninstall fileutils
       - name: Build deb with Docker
         if: ${{ ! steps.cache-deb.outputs.cache-hit }}
         run: |

--- a/.github/workflows/yum-arm.yml
+++ b/.github/workflows/yum-arm.yml
@@ -35,12 +35,6 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt -V install ruby ruby-bundler ruby-serverspec
-          sudo gem install bundler:2.2.9 --no-document
-          sudo gem uninstall fileutils
       - name: cache rpm
         uses: actions/cache@v4
         id: cache-rpm
@@ -48,7 +42,15 @@ jobs:
           path: |
             fluent-package/yum/repositories
           key: ${{ runner.os }}-cache-${{ matrix.rake-job }}-aarch64-${{ hashFiles('**/config.rb', '**/Rakefile', '**/Gemfile*', '**/*.spec.in', 'fluent-package/templates/**', 'fluent-package/yum/**/Dockerfile') }}
+      - name: Install dependencies
+        if: ${{ ! steps.cache-rpm.outputs.cache-hit }}
+        run: |
+          sudo apt update
+          sudo apt -V install ruby ruby-bundler ruby-serverspec
+          sudo gem install bundler:2.2.9 --no-document
+          sudo gem uninstall fileutils
       - name: Build rpm with Docker
+        if: ${{ ! steps.cache-rpm.outputs.cache-hit }}
         run: |
           rake yum:build YUM_TARGETS=${{ matrix.rake-job }}-aarch64
       - name: Upload fluent-package rpm

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -29,12 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt -V install ruby ruby-bundler ruby-serverspec
-          sudo gem install bundler:2.2.9 --no-document
-          sudo gem uninstall fileutils
       - name: cache rpm
         uses: actions/cache@v4
         id: cache-rpm
@@ -43,6 +37,13 @@ jobs:
             fluent-package/yum/repositories
             v6-test/fluent-package/yum/repositories
           key: ${{ runner.os }}-cache-${{ matrix.rake-job }}-${{ hashFiles('**/config.rb', '**/Rakefile', '**/Gemfile*', '**/*.spec.in', 'fluent-package/templates/**', 'fluent-package/yum/**/Dockerfile') }}
+      - name: Install dependencies
+        if: ${{ ! steps.cache-rpm.outputs.cache-hit }}
+        run: |
+          sudo apt update
+          sudo apt -V install ruby ruby-bundler ruby-serverspec
+          sudo gem install bundler:2.2.9 --no-document
+          sudo gem uninstall fileutils
       - name: Build rpm with Docker
         if: ${{ ! steps.cache-rpm.outputs.cache-hit }}
         run: |


### PR DESCRIPTION
Before:
 Always execute "Install dependencies" even though build step
 could be skipped.

After:
 Skip "Install dependencies" step if build step is omitted.

It will reduces workflow execution times.