### PR TITLE
Backport ci: bump hostedtoolcache Ruby to 3.2 (#806)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.2
       - uses: actions/checkout@v4
       - name: cache msi
         uses: actions/cache@v4


### PR DESCRIPTION
Backport #806 

Upcoming Fluentd requires Ruby 3.2 or later.
It fixes the following error:

```
  stderr: fluentd-1.18.0 requires ruby version >= 3.2, which is
  incompatible with the current version, 3.1.7
```

NOTE: Though v1.18 will not be shipped for v5 branch, it is better not to use EOL toolchain.