### PR TITLE
Backport: ci: split some binary package tests (#809)

### DIFF
--- a/.github/workflows/apt.matrix.json
+++ b/.github/workflows/apt.matrix.json
@@ -1,0 +1,29 @@
+{
+  "include": [
+    {
+      "label": "Debian bullseye amd64",
+      "rake-job": "debian-bullseye",
+      "test-docker-image": "debian:bullseye"
+    },
+    {
+      "label": "Debian bookworm amd64",
+      "rake-job": "debian-bookworm",
+      "test-docker-image": "debian:bookworm"
+    },
+    {
+      "label": "Ubuntu Focal amd64",
+      "rake-job": "ubuntu-focal",
+      "test-docker-image": "ubuntu:focal"
+    },
+    {
+      "label": "Ubuntu Jammy amd64",
+      "rake-job": "ubuntu-jammy",
+      "test-docker-image": "ubuntu:jammy"
+    },
+    {
+      "label": "Ubuntu Noble amd64",
+      "rake-job": "ubuntu-noble",
+      "test-docker-image": "ubuntu:noble"
+    }
+  ]
+}

--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -9,34 +9,23 @@ concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true
 jobs:
+  define-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: set-matrix
+        # See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#example-returning-a-json-object
+        run: echo "matrix=$(cat apt.matrix.json | jq --compact-output)" >> $GITHUB_OUTPUT
+        working-directory: .github/workflows/
   build:
     name: Build
-    timeout-minutes: 60
+    timeout-minutes: 120
+    needs: define-matrix
     strategy:
       fail-fast: false
-      matrix:
-        label:
-          - Debian bullseye amd64
-          - Debian bookworm amd64
-          - Ubuntu Focal amd64
-          - Ubuntu Jammy amd64
-          - Ubuntu Noble amd64
-        include:
-          - label: Debian bullseye amd64
-            rake-job: debian-bullseye
-            test-docker-image: debian:bullseye
-          - label: Debian bookworm amd64
-            rake-job: debian-bookworm
-            test-docker-image: debian:bookworm
-          - label: Ubuntu Focal amd64
-            rake-job: ubuntu-focal
-            test-docker-image: ubuntu:focal
-          - label: Ubuntu Jammy amd64
-            rake-job: ubuntu-jammy
-            test-docker-image: ubuntu:jammy
-          - label: Ubuntu Noble amd64
-            rake-job: ubuntu-noble
-            test-docker-image: ubuntu:noble
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -64,10 +53,36 @@ jobs:
         with:
           name: packages-lts-apt-source-${{ matrix.rake-job }}
           path: fluent-lts-apt-source/apt/repositories
-      # TODO move the following steps to "Test" job
+
+  check_package_size:
+    name: Check Package Size
+    runs-on: ubuntu-latest
+    needs: [define-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-${{ matrix.rake-job }}
+          path: fluent-package/apt/repositories
       - name: Check Package Size
         run: |
           fluent-package/apt/pkgsize-test.sh ${{ matrix.rake-job }} amd64
+  installation_test:
+    name: Installation Test
+    runs-on: ubuntu-latest
+    needs: [define-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-${{ matrix.rake-job }}
+          path: fluent-package/apt/repositories
       - name: Installation Test
         run: |
           mkdir -p .bundle
@@ -77,6 +92,19 @@ jobs:
           --volume ${PWD}:/fluentd:ro \
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/install-test.sh
+  piuparts_test:
+    name: Piuparts Test
+    runs-on: ubuntu-latest
+    needs: [define-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-${{ matrix.rake-job }}
+          path: fluent-package/apt/repositories
       - name: Piuparts (Install/Remove/Upgrade) Test
         run: |
           mkdir -p .bundle
@@ -87,6 +115,19 @@ jobs:
           --volume ${PWD}:/fluentd:ro \
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/piuparts-test.sh
+  serverspec_test:
+    name: Serverspec Test
+    runs-on: ubuntu-latest
+    needs: [define-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-${{ matrix.rake-job }}
+          path: fluent-package/apt/repositories
       - name: Serverspec Test
         run: |
           mkdir -p .bundle
@@ -96,6 +137,19 @@ jobs:
           --volume ${PWD}:/fluentd:ro \
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/serverspec-test.sh
+  confluent_test:
+    name: Confluent Test
+    runs-on: ubuntu-latest
+    needs: [define-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-${{ matrix.rake-job }}
+          path: fluent-package/apt/repositories
       - name: Confluent Test
         run: |
           mkdir -p .bundle
@@ -105,6 +159,19 @@ jobs:
           --volume ${PWD}:/fluentd:ro \
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/confluent-test.sh
+  binstubs_test:
+    name: Binstubs Test
+    needs: [define-matrix, build]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-${{ matrix.rake-job }}
+          path: fluent-package/apt/repositories
       - name: Binstubs Test
         run: |
           mkdir -p .bundle
@@ -116,7 +183,7 @@ jobs:
           /fluentd/fluent-package/apt/binstubs-test.sh
   test:
     name: Test ${{ matrix.label }} ${{ matrix.test-file }}
-    needs: build
+    needs: [check_package_size, installation_test, piuparts_test, serverspec_test, confluent_test, binstubs_test]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,10 +38,30 @@ jobs:
         with:
           name: packages-windows-x86_64
           path: fluent-package/msi/repositories
+  check_package_size:
+    name: Check Package Size
+    needs: build
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-windows-x86_64
+          path: fluent-package/msi/repositories
       - name: Check Package Size
         shell: pwsh
         run: |
           powershell -ExecutionPolicy Bypass -Command ".\fluent-package\msi\pkgsize-test.ps1"
+  installation_test:
+    name: Installation Test
+    needs: build
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-windows-x86_64
+          path: fluent-package/msi/repositories
       - name: Installation Test
         shell: pwsh
         run: |
@@ -52,6 +72,16 @@ jobs:
           --volume ${PWD}:C:\fluentd:ro `
           mcr.microsoft.com/dotnet/framework/runtime:3.5 `
           powershell -ExecutionPolicy Bypass -Command "C:\fluentd\fluent-package\msi\install-test.ps1"
+  update_from_v4_test:
+    name: Migration From v4 Test
+    needs: build
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-windows-x86_64
+          path: fluent-package/msi/repositories
       - name: Migration From v4 Test
         shell: pwsh
         run: |
@@ -61,6 +91,16 @@ jobs:
           --volume ${PWD}:C:\fluentd:ro `
           mcr.microsoft.com/dotnet/framework/runtime:3.5 `
           powershell -ExecutionPolicy Bypass -Command "C:\fluentd\fluent-package\msi\update-from-v4-test.ps1"
+  update_from_v5_test:
+    name: Update From v5 Test
+    needs: build
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-windows-x86_64
+          path: fluent-package/msi/repositories
       - name: Update From v5 Test
         shell: pwsh
         run: |
@@ -70,6 +110,16 @@ jobs:
           --volume ${PWD}:C:\fluentd:ro `
           mcr.microsoft.com/dotnet/framework/runtime:3.5 `
           powershell -ExecutionPolicy Bypass -Command "C:\fluentd\fluent-package\msi\update-from-v5-test.ps1"
+  serverspec_test:
+    name: Serverspec Test
+    needs: build
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-windows-x86_64
+          path: fluent-package/msi/repositories
       - name: Serverspec Test
         shell: pwsh
         run: |

--- a/.github/workflows/yum.matrix.json
+++ b/.github/workflows/yum.matrix.json
@@ -1,0 +1,28 @@
+{
+  "include": [
+    {
+      "label": "RockyLinux 8 x86_64",
+      "rake-job": "rockylinux-8",
+      "test-docker-image": "rockylinux:8",
+      "centos-stream": false
+    },
+    {
+      "label": "AlmaLinux 9 x86_64",
+      "rake-job": "almalinux-9",
+      "test-docker-image": "almalinux:9",
+      "centos-stream": false
+    },
+    {
+      "label": "Amazon Linux 2 x86_64",
+      "rake-job": "amazonlinux-2",
+      "test-docker-image": "amazonlinux:2",
+      "centos-stream": false
+    },
+    {
+      "label": "Amazon Linux 2023 x86_64",
+      "rake-job": "amazonlinux-2023",
+      "test-docker-image": "amazonlinux:2023",
+      "centos-stream": false
+    }
+  ]
+}

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -9,34 +9,23 @@ concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true
 jobs:
+  define-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: set-matrix
+        # See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#example-returning-a-json-object
+        run: echo "matrix=$(cat yum.matrix.json | jq --compact-output)" >> $GITHUB_OUTPUT
+        working-directory: .github/workflows/
   build:
+    needs: define-matrix
     name: Build
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      matrix:
-        label:
-          - RockyLinux 8 x86_64
-          - AlmaLinux 9 x86_64
-          - Amazon Linux 2 x86_64
-          - Amazon Linux 2023 x86_64
-        include:
-          - label: RockyLinux 8 x86_64
-            rake-job: rockylinux-8
-            test-docker-image: rockylinux/rockylinux:8
-            centos-stream: false
-          - label: AlmaLinux 9 x86_64
-            rake-job: almalinux-9
-            test-docker-image: almalinux:9
-            centos-stream: false
-          - label: Amazon Linux 2 x86_64
-            rake-job: amazonlinux-2
-            test-docker-image: amazonlinux:2
-            centos-stream: false
-          - label: Amazon Linux 2023 x86_64
-            rake-job: amazonlinux-2023
-            test-docker-image: amazonlinux:2023
-            centos-stream: false
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -54,10 +43,36 @@ jobs:
         with:
           name: packages-${{ matrix.rake-job }}
           path: fluent-package/yum/repositories
-      # TODO move the following steps to "Test" job
+  check_package_size:
+    name: Check Package Size
+    runs-on: ubuntu-latest
+    needs: [define-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-${{ matrix.rake-job }}
+          path: fluent-package/yum/repositories
       - name: Check Package Size
         run: |
           fluent-package/yum/pkgsize-test.sh ${{ matrix.rake-job }} x86_64
+
+  installation_test:
+    name: Installation Test
+    runs-on: ubuntu-latest
+    needs: [define-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-${{ matrix.rake-job }}
+          path: fluent-package/yum/repositories
       - name: Installation Test
         run: |
           mkdir -p .bundle
@@ -68,6 +83,19 @@ jobs:
           --env CENTOS_STREAM=${{ matrix.centos-stream }} \
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/yum/install-test.sh
+  serverspec_test:
+    name: Serverspec Test
+    runs-on: ubuntu-latest
+    needs: [define-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-${{ matrix.rake-job }}
+          path: fluent-package/yum/repositories
       - name: Serverspec Test
         run: |
           mkdir -p .bundle
@@ -78,6 +106,19 @@ jobs:
           --env CENTOS_STREAM=${{ matrix.centos-stream }} \
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/yum/serverspec-test.sh
+  binstubs_test:
+    name: Binstubs Test
+    runs-on: ubuntu-latest
+    needs: [define-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-${{ matrix.rake-job }}
+          path: fluent-package/yum/repositories
       - name: Binstubs Test
         run: |
           mkdir -p .bundle
@@ -90,7 +131,7 @@ jobs:
           /fluentd/fluent-package/yum/binstubs-test.sh
   v1test:
     name: Test ${{ matrix.label }} ${{ matrix.test-file }} (CGroup V1)
-    needs: build
+    needs: [check_package_size, installation_test, serverspec_test, binstubs_test]
     # Ubuntu 20.04 is not available anymore, so can't use container based
     # approach. Instead, use vagrant on Ubuntu 24.04.
     # (NOTE: nested VM is executable on macos-13, but it is too slow)
@@ -152,7 +193,7 @@ jobs:
 
   v2test:
     name: Test ${{ matrix.label }} ${{ matrix.test-file }} (CGroup V2)
-    needs: build
+    needs: [check_package_size, installation_test, serverspec_test, binstubs_test]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:


### PR DESCRIPTION
Backport #809 

In the previous versions, some test cases are contained in Build job. It should be executed in a separate job by nature.