### PR TITLE
Backport: msi: update toolchains (#815)

### DIFF
--- a/fluent-package/msi/Dockerfile
+++ b/fluent-package/msi/Dockerfile
@@ -31,8 +31,8 @@ RUN \
   choco install -y git wixtoolset 7zip && \
   # Required CMake 3.x to build cmetrics gem
   choco install -y cmake --version=3.31.6 --installargs 'ADD_CMAKE_TO_PATH=System' && \
-  choco install -y msys2 --params /NoUpdate --version=20230718.0.0 && \
-  choco install ruby -y --version=3.2.6.1 && \
+  choco install -y msys2 --params /NoUpdate --version=20241208.0.0 && \
+  choco install ruby -y --version=3.2.8.1 && \
   refreshenv && \
   ridk install 3 && \
   gem install --no-document --force bundler builder


### PR DESCRIPTION
* https://community.chocolatey.org/packages/msys2/20250221.0.0 
* https://community.chocolatey.org/packages/ruby/3.2.8.1

20230718 is too old, so it causes missing archives on mirror sites.