### PR TITLE
Backport ci: make parallel jobs on arm (#813)

### DIFF
--- a/.github/workflows/apt-arm.matrix.json
+++ b/.github/workflows/apt-arm.matrix.json
@@ -1,0 +1,32 @@
+{
+  "include": [
+    {
+      "label": "Debian bullseye arm64",
+      "rake-job": "debian-bullseye",
+      "test-docker-image": "arm64v8/debian:bullseye"
+    },
+    {
+      "label": "Debian bookworm arm64",
+      "rake-job": "debian-bookworm",
+      "test-docker-image": "arm64v8/debian:bookworm"
+    },
+    {
+      "label": "Ubuntu Focal arm64",
+      "rake-job": "ubuntu-focal",
+      "rake-options": "LINTIAN=no",
+      "test-docker-image": "arm64v8/ubuntu:focal"
+    },
+    {
+      "label": "Ubuntu Jammy arm64",
+      "rake-job": "ubuntu-jammy",
+      "rake-options": "LINTIAN=no",
+      "test-docker-image": "arm64v8/ubuntu:jammy"
+    },
+    {
+      "label": "Ubuntu Noble arm64",
+      "rake-job": "ubuntu-noble",
+      "rake-options": "LINTIAN=no",
+      "test-docker-image": "arm64v8/ubuntu:noble"
+    }
+  ]
+}

--- a/.github/workflows/apt-arm.yml
+++ b/.github/workflows/apt-arm.yml
@@ -9,36 +9,22 @@ concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true
 jobs:
+  define-matrix:
+    runs-on: ubuntu-24.04-arm
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: set-matrix
+        # See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#example-returning-a-json-object
+        run: echo "matrix=$(cat apt-arm.matrix.json | jq --compact-output)" >> $GITHUB_OUTPUT
+        working-directory: .github/workflows/
   build:
     name: Build
+    needs: define-matrix
     strategy:
       fail-fast: false
-      matrix:
-        label:
-          - Debian GNU/Linux bullseye arm64
-          - Debian GNU/Linux bookworm arm64
-          - Ubuntu Focal arm64
-          - Ubuntu Jammy arm64
-          - Ubuntu Noble arm64
-        include:
-          - label: Debian GNU/Linux bullseye arm64
-            rake-job: debian-bullseye
-            test-docker-image: arm64v8/debian:bullseye
-          - label: Debian GNU/Linux bookworm arm64
-            rake-job: debian-bookworm
-            test-docker-image: arm64v8/debian:bookworm
-          - label: Ubuntu Focal arm64
-            rake-job: ubuntu-focal
-            rake-options: LINTIAN=no
-            test-docker-image: arm64v8/ubuntu:focal
-          - label: Ubuntu Jammy arm64
-            rake-job: ubuntu-jammy
-            rake-options: LINTIAN=no
-            test-docker-image: arm64v8/ubuntu:jammy
-          - label: Ubuntu Noble arm64
-            rake-job: ubuntu-noble
-            rake-options: LINTIAN=no
-            test-docker-image: arm64v8/ubuntu:noble
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
@@ -65,9 +51,35 @@ jobs:
         with:
           name: packages-${{ matrix.rake-job }}-arm64
           path: fluent-package/apt/repositories
+  check_package_size:
+    name: Check Package Size
+    runs-on: ubuntu-24.04-arm
+    needs: [define-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-${{ matrix.rake-job }}-arm64
+          path: fluent-package/apt/repositories
       - name: Check Package Size
         run: |
           fluent-package/apt/pkgsize-test.sh ${{ matrix.rake-job }} arm64
+  binstubs_test:
+    name: Binstubs Test
+    runs-on: ubuntu-24.04-arm
+    needs: [define-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-${{ matrix.rake-job }}-arm64
+          path: fluent-package/apt/repositories
       - name: Binstubs Test
         run: |
           mkdir -p .bundle
@@ -78,6 +90,19 @@ jobs:
           --volume ${PWD}:/fluentd:ro \
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/binstubs-test.sh
+  installation_test:
+    name: Installation Test
+    runs-on: ubuntu-24.04-arm
+    needs: [define-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-${{ matrix.rake-job }}-arm64
+          path: fluent-package/apt/repositories
       - name: Installation Test
         run: |
           mkdir -p .bundle
@@ -88,6 +113,19 @@ jobs:
           --volume ${PWD}:/fluentd:ro \
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/install-test.sh
+  piuparts_test:
+    name: Piuparts Test
+    runs-on: ubuntu-24.04-arm
+    needs: [define-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-${{ matrix.rake-job }}-arm64
+          path: fluent-package/apt/repositories
       - name: Piuparts (Install/Remove/Upgrade) Test
         run: |
           mkdir -p .bundle
@@ -99,6 +137,19 @@ jobs:
           --volume ${PWD}:/fluentd:ro \
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/piuparts-test.sh
+  serverspec_test:
+    name: Serverspec Test
+    runs-on: ubuntu-24.04-arm
+    needs: [define-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-${{ matrix.rake-job }}-arm64
+          path: fluent-package/apt/repositories
       - name: Serverspec Test
         run: |
           mkdir -p .bundle
@@ -109,6 +160,19 @@ jobs:
           --volume ${PWD}:/fluentd:ro \
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/serverspec-test.sh
+  confluent_test:
+    name: Confluent Test
+    runs-on: ubuntu-24.04-arm
+    needs: [define-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-${{ matrix.rake-job }}-arm64
+          path: fluent-package/apt/repositories
       - name: Confluent Test
         run: |
           mkdir -p .bundle
@@ -119,13 +183,3 @@ jobs:
           --volume ${PWD}:/fluentd:ro \
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/apt/confluent-test.sh
-      - name: Binstubs Test
-        run: |
-          mkdir -p .bundle
-          docker run \
-          --rm \
-          --tty \
-          --env CI=true \
-          --volume ${PWD}:/fluentd:ro \
-          ${{ matrix.test-docker-image }} \
-          /fluentd/fluent-package/apt/binstubs-test.sh

--- a/.github/workflows/yum-arm.matrix.json
+++ b/.github/workflows/yum-arm.matrix.json
@@ -1,0 +1,24 @@
+{
+  "include": [
+    {
+      "label": "RockyLinux 8 aarch64",
+      "rake-job": "rockylinux-8",
+      "test-docker-image": "arm64v8/rockylinux:8"
+    },
+    {
+      "label": "AlmaLinux 9 aarch64",
+      "rake-job": "almalinux-9",
+      "test-docker-image": "arm64v8/almalinux:9"
+    },
+    {
+      "label": "Amazon Linux 2 aarch64",
+      "rake-job": "amazonlinux-2",
+      "test-docker-image": "arm64v8/amazonlinux:2"
+    },
+    {
+      "label": "Amazon Linux 2023 aarch64",
+      "rake-job": "amazonlinux-2023",
+      "test-docker-image": "arm64v8/amazonlinux:2023"
+    }
+  ]
+}

--- a/.github/workflows/yum-arm.yml
+++ b/.github/workflows/yum-arm.yml
@@ -9,29 +9,22 @@ concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true
 jobs:
+  define-matrix:
+    runs-on: ubuntu-24.04-arm
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: set-matrix
+        # See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#example-returning-a-json-object
+        run: echo "matrix=$(cat yum-arm.matrix.json | jq --compact-output)" >> $GITHUB_OUTPUT
+        working-directory: .github/workflows/
   build:
     name: Build
+    needs: define-matrix
     strategy:
       fail-fast: false
-      matrix:
-        label:
-          - RockyLinux 8 aarch64
-          - AlmaLinux 9 aarch64
-          - Amazon Linux 2 aarch64
-          - Amazon Linux 2023 aarch64
-        include:
-          - label: RockyLinux 8 aarch64
-            rake-job: rockylinux-8
-            test-docker-image: arm64v8/rockylinux:8
-          - label: AlmaLinux 9 aarch64
-            rake-job: almalinux-9
-            test-docker-image: arm64v8/almalinux:9
-          - label: Amazon Linux 2 aarch64
-            rake-job: amazonlinux-2
-            test-docker-image: arm64v8/amazonlinux:2
-          - label: Amazon Linux 2023 aarch64
-            rake-job: amazonlinux-2023
-            test-docker-image: arm64v8/amazonlinux:2023
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
@@ -58,9 +51,35 @@ jobs:
         with:
           name: packages-${{ matrix.rake-job }}-aarch64
           path: fluent-package/yum/repositories
+  check_package_size:
+    name: Check Package Size
+    runs-on: ubuntu-24.04-arm
+    needs: [define-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-${{ matrix.rake-job }}-aarch64
+          path: fluent-package/yum/repositories
       - name: Check Package Size
         run: |
           fluent-package/yum/pkgsize-test.sh ${{ matrix.rake-job }} aarch64
+  installation_test:
+    name: Installation Test
+    runs-on: ubuntu-24.04-arm
+    needs: [define-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-${{ matrix.rake-job }}-aarch64
+          path: fluent-package/yum/repositories
       - name: Installation Test
         run: |
           mkdir -p .bundle
@@ -71,6 +90,19 @@ jobs:
           --volume ${PWD}:/fluentd:ro \
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/yum/install-test.sh
+  serverspec_test:
+    name: Serverspec Test
+    runs-on: ubuntu-24.04-arm
+    needs: [define-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-${{ matrix.rake-job }}-aarch64
+          path: fluent-package/yum/repositories
       - name: Serverspec Test
         run: |
           mkdir -p .bundle
@@ -81,6 +113,19 @@ jobs:
           --volume ${PWD}:/fluentd:ro \
           ${{ matrix.test-docker-image }} \
           /fluentd/fluent-package/yum/serverspec-test.sh
+  binstubs_test:
+    name: Binstubs Test
+    runs-on: ubuntu-24.04-arm
+    needs: [define-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-${{ matrix.rake-job }}-aarch64
+          path: fluent-package/yum/repositories
       - name: Binstubs Test
         run: |
           mkdir -p .bundle


### PR DESCRIPTION
follow-up #809

In this PR, I've found apt-arm executes duplicated binstubs test.