### PR TITLE
ci: extract setup rpmrebuild and fix rebuild

### DIFF
--- a/fluent-package/yum/systemd-test/setup-rpmrebuild.sh
+++ b/fluent-package/yum/systemd-test/setup-rpmrebuild.sh
@@ -1,0 +1,28 @@
+case $distribution in
+    amazon)
+        case $version in
+            2023)
+                curl -L -o rpmrebuild.noarch.rpm https://sourceforge.net/projects/rpmrebuild/files/latest/download
+                sudo $DNF install -y ./rpmrebuild.noarch.rpm
+                ;;
+            2)
+                sudo amazon-linux-extras install -y epel
+                sudo $DNF install -y rpmrebuild
+                ;;
+        esac
+        ;;
+    *)
+        sudo $DNF install -y epel-release
+        sudo $DNF install -y rpmrebuild
+        # hotfix for rpmrebuild 2.20 bug
+        # See https://sourceforge.net/p/rpmrebuild/bugs/18/
+        pkg_version=$(rpm -q rpmrebuild)
+        case $pkg_version in
+            rpmrebuild-2.20*)
+                curl -LO https://sourceforge.net/p/rpmrebuild/bugs/18/attachment/rpmrebuild-2.20-rpm2archive-bug.patch
+                hotfix=$(realpath rpmrebuild-2.20-rpm2archive-bug.patch)
+                (cd /usr/lib/rpmrebuild && sudo patch -p2 < $hotfix)
+                ;;
+        esac
+        ;;
+esac

--- a/fluent-package/yum/systemd-test/update-to-next-version-service-status.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version-service-status.sh
@@ -27,24 +27,8 @@ fi
 main_pid=$(eval $(systemctl show fluentd --property=MainPID) && echo $MainPID)
 
 # Make a dummy pacakge for the next version
-case $distribution in
-    amazon)
-        case $version in
-            2023)
-                curl -L -o rpmrebuild.noarch.rpm https://sourceforge.net/projects/rpmrebuild/files/latest/download
-                sudo $DNF install -y ./rpmrebuild.noarch.rpm
-                ;;
-            2)
-                sudo amazon-linux-extras install -y epel
-                sudo $DNF install -y rpmrebuild
-                ;;
-        esac
-        ;;
-    *)
-        sudo $DNF install -y epel-release
-        sudo $DNF install -y rpmrebuild
-        ;;
-esac
+. $(dirname $0)/setup-rpmrebuild.sh
+
 # Example: "1.el9"
 release=$(rpmquery --queryformat="%{Release}" -p $package)
 # Example: "1"

--- a/fluent-package/yum/systemd-test/update-to-next-version-with-auto-and-manual.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version-with-auto-and-manual.sh
@@ -7,25 +7,7 @@ set -exu
 package="/host/${distribution}/${DISTRIBUTION_VERSION}/x86_64/Packages/fluent-package-[0-9]*.rpm"
 
 # Make a dummy pacakge for the next version
-case $distribution in
-    amazon)
-        case $version in
-            2023)
-                curl -L -o rpmrebuild.noarch.rpm https://sourceforge.net/projects/rpmrebuild/files/latest/download
-                sudo $DNF install -y ./rpmrebuild.noarch.rpm
-                ;;
-            2)
-                sudo amazon-linux-extras install -y epel
-                sudo $DNF install -y rpmrebuild
-                ;;
-        esac
-        ;;
-    *)
-        sudo $DNF install -y epel-release
-        sudo $DNF install -y rpmrebuild
-        ;;
-esac
-
+. $(dirname $0)/setup-rpmrebuild.sh
 
 # Example: "1.el9"
 release=$(rpmquery --queryformat="%{Release}" -p $package)

--- a/fluent-package/yum/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
@@ -38,15 +38,8 @@ sudo systemctl enable fluentd # Enable the unit name alias
 systemctl status --no-pager td-agent
 
 # Make a dummy pacakge for the next version
-case $distribution in
-    amazon)
-        sudo amazon-linux-extras install -y epel
-        ;;
-    *)
-        sudo $DNF install -y epel-release
-        ;;
-esac
-sudo $DNF install -y rpmrebuild
+. $(dirname $0)/setup-rpmrebuild.sh
+
 # Example: "1.el9"
 release=$(rpmquery --queryformat="%{Release}" -p $package)
 # Example: "1"

--- a/fluent-package/yum/systemd-test/update-to-next-version.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version.sh
@@ -11,24 +11,8 @@ sudo systemctl enable --now fluentd
 systemctl status --no-pager fluentd
 
 # Make a dummy pacakge for the next version
-case $distribution in
-    amazon)
-        case $version in
-	    2023)
-		curl -L -o rpmrebuild.noarch.rpm https://sourceforge.net/projects/rpmrebuild/files/latest/download
-		sudo $DNF install -y ./rpmrebuild.noarch.rpm
-		;;
-	    2)
-		sudo amazon-linux-extras install -y epel
-		sudo $DNF install -y rpmrebuild
-	;;
-	esac
-        ;;
-    *)
-        sudo $DNF install -y epel-release
-	sudo $DNF install -y rpmrebuild
-        ;;
-esac
+. $(dirname $0)/setup-rpmrebuild.sh
+
 # Example: "1.el9"
 release=$(rpmquery --queryformat="%{Release}" -p $package)
 # Example: "1"


### PR DESCRIPTION
RpmUnpack implementation was changed from rpm2cpio to rpm2archive, but it can't rebuild RPM because it handles outcome of rpm2archive wrongly. It will be fixed in rpmrebuild 2.21.

See
  rpmrebuild 2.20: rpm2archive called with incorrect arguments
  https://sourceforge.net/p/rpmrebuild/bugs/18/