### PR TITLE
ci: refer base branch name

### DIFF
--- a/.github/workflows/maintenance-bundle-update.yml
+++ b/.github/workflows/maintenance-bundle-update.yml
@@ -34,4 +34,4 @@ jobs:
           git add fluent-package/Gemfile.lock
           git commit --message "Update Gemfile.lock" --signoff
           git push origin $branch
-          gh pr create --title "Update Gemfile.lock" --body "Update Gemfile.lock by maintenance workflow"
+          gh pr create --base ${{ github.base_ref }} --title "Update Gemfile.lock" --body "Update Gemfile.lock by maintenance workflow"


### PR DESCRIPTION
When kicked from LTS branch, base branch should be set explicitly, otherwise PR will be created against main branch.