### PR TITLE
ci: fix empty base_ref error

### DIFF
--- a/.github/workflows/maintenance-bundle-update.yml
+++ b/.github/workflows/maintenance-bundle-update.yml
@@ -34,4 +34,4 @@ jobs:
           git add fluent-package/Gemfile.lock
           git commit --message "Update Gemfile.lock" --signoff
           git push origin $branch
-          gh pr create --base ${{ github.base_ref }} --title "Update Gemfile.lock" --body "Update Gemfile.lock by maintenance workflow"
+          gh pr create --base $Env:GITHUB_REF_NAME --title "Update Gemfile.lock" --body "Update Gemfile.lock by maintenance workflow"


### PR DESCRIPTION
Try to use $Env:GITHUB_REF_NAME which contains branch name

github.base_ref is empty when executing via workflow_dispatch.