### PR TITLE
ci: fix wrong grouping about CGroup v1

### DIFF
--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -195,7 +195,6 @@ jobs:
       matrix:
         label:
           - AmazonLinux 2 x86_64
-          - AmazonLinux 2023 x86_64
         test:
           - "update-from-v4.sh"
           - "update-from-v5-lts.sh"
@@ -222,15 +221,6 @@ jobs:
         include:
           - label: AmazonLinux 2 x86_64
             rake-job: amazonlinux-2
-          - label: AmazonLinux 2023 x86_64
-            rake-job: amazonlinux-2023
-        exclude:
-          - label: AmazonLinux 2023 x86_64
-            test: update-from-v4.sh
-          - label: AmazonLinux 2023 x86_64
-            test: update-to-next-version-with-backward-compat-for-v4.sh
-          - label: AmazonLinux 2023 x86_64
-            test: downgrade-to-v4.sh
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -275,6 +265,7 @@ jobs:
         label:
           - RockyLinux 8 x86_64
           - AlmaLinux 9 x86_64
+          - AmazonLinux 2023 x86_64
         test:
           - "update-from-v4.sh"
           - "update-from-v5-lts.sh"
@@ -305,6 +296,16 @@ jobs:
           - label: AlmaLinux 9 x86_64
             rake-job: almalinux-9
             container-image: images:almalinux/9
+          - label: AmazonLinux 2023 x86_64
+            rake-job: amazonlinux-2023
+            container-image: images:amazonlinux/2023
+        exclude:
+          - label: AmazonLinux 2023 x86_64
+            test: update-from-v4.sh
+          - label: AmazonLinux 2023 x86_64
+            test: update-to-next-version-with-backward-compat-for-v4.sh
+          - label: AmazonLinux 2023 x86_64
+            test: downgrade-to-v4.sh
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
AmazonLinux 2023 contains code for CGroup v1, but it is not officially supported.

See https://docs.aws.amazon.com/eks/latest/userguide/al2023.html

    While AL2023 still includes code that can make the system run using
    cgroupv1, this isn’t a recommended or supported configuration. This
    configuration will be completely removed in a future major release of
    Amazon Linux.