### PR TITLE
rpm: drop AmazonLinux 2 from default target

### DIFF
--- a/.github/workflows/yum-arm.matrix.json
+++ b/.github/workflows/yum-arm.matrix.json
@@ -11,11 +11,6 @@
       "test-docker-image": "arm64v8/almalinux:9"
     },
     {
-      "label": "Amazon Linux 2 aarch64",
-      "rake-job": "amazonlinux-2",
-      "test-docker-image": "arm64v8/amazonlinux:2"
-    },
-    {
       "label": "Amazon Linux 2023 aarch64",
       "rake-job": "amazonlinux-2023",
       "test-docker-image": "arm64v8/amazonlinux:2023"

--- a/.github/workflows/yum.matrix.json
+++ b/.github/workflows/yum.matrix.json
@@ -13,12 +13,6 @@
       "centos-stream": false
     },
     {
-      "label": "Amazon Linux 2 x86_64",
-      "rake-job": "amazonlinux-2",
-      "test-docker-image": "amazonlinux:2",
-      "centos-stream": false
-    },
-    {
       "label": "Amazon Linux 2023 x86_64",
       "rake-job": "amazonlinux-2023",
       "test-docker-image": "amazonlinux:2023",

--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -1371,7 +1371,6 @@ EOS
       "centos-7",
       "rockylinux-8",
       "almalinux-9",
-      "amazonlinux-2",
       "amazonlinux-2023",
     ]
   end

--- a/fluent-package/test-verify-repo.sh
+++ b/fluent-package/test-verify-repo.sh
@@ -54,7 +54,7 @@ if [ -z "$DEB_TARGETS" ]; then
     DEB_TARGETS="debian:bullseye debian:bookworm ubuntu:focal ubuntu:jammy ubuntu:noble"
 fi
 if [ -z "$RPM_TARGETS" ]; then
-    RPM_TARGETS="almalinux:8 rockylinux:9 amazonlinux:2 amazonlinux:2023"
+    RPM_TARGETS="almalinux:8 rockylinux:9 amazonlinux:2023"
 fi
 if [ -z "$REPO_TARGETS" ]; then
     REPO_TARGETS="exp/5 exp/lts/5"


### PR DESCRIPTION
AL2 will not be supported for upcoming v6.

Keep the recipe as same as CentOS for a while.