### PR TITLE
deb: use appropriate separator for lintian

### DIFF
--- a/fluent-package/debian/lintian/fluent-package/ubuntu.profile
+++ b/fluent-package/debian/lintian/fluent-package/ubuntu.profile
@@ -8,5 +8,5 @@ Extends: ubuntu/main
 #   the old tag name of custom-library-search-path
 #   (binary-or-shlib-defines-rpath) must be specified.
 #
-Disable-Tags: dir-or-file-in-opt,
+Disable-Tags: dir-or-file-in-opt
  binary-or-shlib-defines-rpath


### PR DESCRIPTION
It fixes the following error:

```
  Please use spaces as separators in field Disable-Tags instead of commas in profile /root/.lintian/profiles/fluent-package/ubuntu.profile
  Error: The operation was canceled.
```