### PR TITLE
Backport: windows: bump version to Windows Server 2022 (#849)

### DIFF
--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       fail-fast: false
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       fail-fast: false
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -41,7 +41,7 @@ jobs:
   check_package_size:
     name: Check Package Size
     needs: build
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -55,7 +55,7 @@ jobs:
   installation_test:
     name: Installation Test
     needs: build
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -75,7 +75,7 @@ jobs:
   update_from_v4_test:
     name: Migration From v4 Test
     needs: build
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -94,7 +94,7 @@ jobs:
   update_from_v5_test:
     name: Update From v5 Test
     needs: build
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -113,7 +113,7 @@ jobs:
   serverspec_test:
     name: Serverspec Test
     needs: build
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4

--- a/fluent-package/msi/Dockerfile
+++ b/fluent-package/msi/Dockerfile
@@ -16,7 +16,9 @@
 
 # The latest chocolatey requires .net 4.8, and wixtoolset requires .net 3.5,
 # To satisfy both of them without reboot, use sdk image.
-ARG FROM=mcr.microsoft.com/dotnet/framework/sdk:3.5-windowsservercore-ltsc2019
+# NOTE: Use 2022 container explicitly to fix the following error:
+#   The container operating system does not match the host operating system.
+ARG FROM=mcr.microsoft.com/dotnet/framework/sdk:3.5-windowsservercore-ltsc2022
 FROM ${FROM}
 
 # Launch the following command as if cmd /S /C ...


### PR DESCRIPTION
See Windows Server 2019 is closing down

https://github.blog/changelog/2025-04-15-upcoming-breaking-changes-and-releases-for-github-actions/

  We’re beginning the process of closing down the Windows server 2019
  hosted runner image, following our N-1 OS support policy. This image
  will be fully retired by June 30, 2025.

---------