### PR TITLE
Exclude dependency for ruby packages

### DIFF
--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -40,7 +40,7 @@
 %global _python_bytecompile_errors_terminate_build 0
 
 %global __provides_exclude_from ^/opt/%{name}/.*\\.so.*
-%global __requires_exclude libjemalloc.*|libruby.*|/opt/%{name}/.*
+%global __requires_exclude libjemalloc.*|libruby.*|/opt/%{name}/.*|^/usr/bin/ruby
 # Omit build_id links (/usr/lib/.build-id/xx/yy) from td-agent package
 # They are bundled in td-agent-debuginfo. It is intended not to
 # conflict with other packages


### PR DESCRIPTION
When install fluent-package on rhel8 and other,
it will install unnecessary ruby packages as dependencies.

```
Last metadata expiration check: 0:00:02 ago on Thu Jul 31 03:28:14 2025.                                                                    
Dependencies resolved.                                                                                                                      
===============================================================================================                                             
 Package                Arch    Version                                   Repository       Size                                             
===============================================================================================                                             
Installing:                                                                                                                                 
 fluent-package         x86_64  6.0.0-1.el8                               fluent-package   23 M                                             
Installing dependencies:                                                                                                                    
 ruby                   x86_64  2.5.9-114.module+el8.10.0+1979+815637df   appstream        88 k                                             
 ruby-irb               noarch  2.5.9-114.module+el8.10.0+1979+815637df   appstream       103 k                                             
 ruby-libs              x86_64  2.5.9-114.module+el8.10.0+1979+815637df   appstream       2.9 M                                             
 rubygem-json           x86_64  2.1.0-114.module+el8.10.0+1979+815637df   appstream        92 k                                             
 rubygem-psych          x86_64  3.0.2-114.module+el8.10.0+1979+815637df   appstream        96 k                                             
Installing weak dependencies:                                                                                                               
 rubygem-bigdecimal     x86_64  1.3.4-114.module+el8.10.0+1979+815637df   appstream        98 k                                             
 rubygem-did_you_mean   noarch  1.2.0-114.module+el8.10.0+1979+815637df   appstream        82 k                                             
 rubygem-io-console     x86_64  0.4.6-114.module+el8.10.0+1979+815637df   appstream        68 k                                             
 rubygem-openssl        x86_64  2.1.2-114.module+el8.10.0+1979+815637df   appstream       190 k                                             
 rubygem-rdoc           noarch  6.0.1.1-114.module+el8.10.0+1979+815637df appstream       457 k                                             
 rubygems               noarch  2.7.6.3-114.module+el8.10.0+1979+815637df appstream       309 k                                             
Enabling module streams:                                                                                                                    
 ruby                           2.5                                                                                                         
```

This PR will exclude the dependencies.

The cause would be https://github.com/protocolbuffers/protobuf/blob/a93259a6ffa6749dfe40aa5ffacc29b2d502d888/ruby/lib/google/protobuf/well_known_types.rb#L1.
It seems that RPM detects this shebang and adds `/usr/bin/ruby` to the dependencies.