### PR TITLE
Use fluentd.cdn.cncf.io

### DIFF
--- a/fluent-apt-source/Rakefile
+++ b/fluent-apt-source/Rakefile
@@ -34,7 +34,7 @@ class FluentdAptSourcePackageTask < PackageTask
   end
 
   def repository_version
-    "2025.7.29"
+    "2025.8.29"
   end
 
   def repository_name
@@ -42,15 +42,15 @@ class FluentdAptSourcePackageTask < PackageTask
   end
 
   def repository_label
-    "Treasure Agent"
+    "Fluentd Project"
   end
 
   def repository_description
-    "Treasure Agent related packages"
+    "Fluentd Project related packages"
   end
 
   def repository_url
-    "https://packages.treasuredata.com"
+    "https://fluentd.cdn.cncf.io"
   end
 
   def repository_gpg_key_ids

--- a/fluent-apt-source/debian/changelog
+++ b/fluent-apt-source/debian/changelog
@@ -1,9 +1,9 @@
-fluent-apt-source (2025.7.29-1) unstable; urgency=medium
+fluent-apt-source (2025.8.29-1) unstable; urgency=medium
 
   * New upstream release.
   * Support fluent-package v6.
 
- -- Kentaro Hayashi <hayashi@clear-code.com>  Thu, 17 Jul 2025 14:52:37 +0900
+ -- Kentaro Hayashi <hayashi@clear-code.com>  Fri, 29 Aug 2025 14:52:37 +0900
 
 fluent-apt-source (2025.1.8-1) unstable; urgency=medium
 

--- a/fluent-apt-source/debian/rules
+++ b/fluent-apt-source/debian/rules
@@ -39,7 +39,7 @@ override_dh_auto_build:
 	    component=main; \
 	  fi; \
 	  echo "Types: deb"; \
-	  echo "URIs: https://packages.treasuredata.com/6/$${distribution}/$${code_name}/"; \
+	  echo "URIs: https://fluentd.cdn.cncf.io/6/$${distribution}/$${code_name}/"; \
 	  echo "Suites: $${code_name}"; \
 	  echo "Components: contrib"; \
 	  echo "Signed-By: /usr/share/keyrings/fluent-archive-keyring.asc"; \

--- a/fluent-lts-apt-source/Rakefile
+++ b/fluent-lts-apt-source/Rakefile
@@ -34,7 +34,7 @@ class FluentdAptLtsSourcePackageTask < PackageTask
   end
 
   def repository_version
-    "2025.7.29"
+    "2025.8.29"
   end
 
   def repository_name
@@ -42,15 +42,15 @@ class FluentdAptLtsSourcePackageTask < PackageTask
   end
 
   def repository_label
-    "Treasure Agent"
+    "Fluentd Project"
   end
 
   def repository_description
-    "Treasure Agent related packages"
+    "Fluentd Project related packages"
   end
 
   def repository_url
-    "https://packages.treasuredata.com"
+    "https://fluentd.cdn.cncf.io"
   end
 
   def repository_gpg_key_ids

--- a/fluent-lts-apt-source/debian/changelog
+++ b/fluent-lts-apt-source/debian/changelog
@@ -1,9 +1,9 @@
-fluent-lts-apt-source (2025.7.29-1) unstable; urgency=medium
+fluent-lts-apt-source (2025.8.29-1) unstable; urgency=medium
 
   * New upstream release.
   * Support fluent-package LTS v6.
 
- -- Kentaro Hayashi <hayashi@clear-code.com>  Thu, 17 Jul 2025 14:53:51 +0900
+ -- Kentaro Hayashi <hayashi@clear-code.com>  Fri, 29 Aug 2025 14:53:51 +0900
 
 fluent-lts-apt-source (2025.1.8-1) unstable; urgency=medium
 

--- a/fluent-lts-apt-source/debian/rules
+++ b/fluent-lts-apt-source/debian/rules
@@ -39,7 +39,7 @@ override_dh_auto_build:
 	    component=main; \
 	  fi; \
 	  echo "Types: deb"; \
-	  echo "URIs: https://packages.treasuredata.com/lts/6/$${distribution}/$${code_name}/"; \
+	  echo "URIs: https://fluentd.cdn.cncf.io/lts/6/$${distribution}/$${code_name}/"; \
 	  echo "Suites: $${code_name}"; \
 	  echo "Components: contrib"; \
 	  echo "Signed-By: /usr/share/keyrings/fluent-lts-archive-keyring.asc"; \


### PR DESCRIPTION
Since v6, we switch from packages.treasuredata.com to fluentd.cdn.cncf.io.

For a while, packages will be uploaded into both of them.