### PR TITLE
ci: update Ruby version in maintenance workflow

### DIFF
--- a/.github/workflows/maintenance-bundle-update.yml
+++ b/.github/workflows/maintenance-bundle-update.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2 # Use same Ruby version with fluent-package bundled
+          ruby-version: 3.4 # Use same Ruby version with fluent-package bundled
       - uses: actions/checkout@v4
       - name: Bundle Update
         run: |


### PR DESCRIPTION
I forgot to update Ruby version in `maintenance-bundle-update.yml`

It should have same Ruby version in 
https://github.com/fluent/fluent-package-builder/blob/401960014daeb15ede44fcdc76ee373d65ffce34/fluent-package/config.rb#L26