### PR TITLE
ci: add compiler flag to avoid build error

### DIFF
--- a/.github/workflows/maintenance-bundle-update.yml
+++ b/.github/workflows/maintenance-bundle-update.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: windows-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CFLAGS: '-Wno-error=sign-conversion' # Compiler flag to avoid build error in libiconv
     steps:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
If it compile libiconv.1.17 with gcc 15, it causes error.
https://github.com/fluent/fluent-package-builder/actions/runs/17146495450/job/48643742000

To suppress error, this patch will add compiler flags through `CFLAGS` environment variable.