### PR TITLE
Revert "ci: add compiler flag to avoid build error"

### DIFF
--- a/.github/workflows/maintenance-bundle-update.yml
+++ b/.github/workflows/maintenance-bundle-update.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: windows-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      CFLAGS: '-Wno-error=sign-conversion' # Compiler flag to avoid build error in libiconv
     steps:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Reverts fluent/fluent-package-builder#880

Unfortunately, this workflow still causes build error when compile libiconv.

```
2025-08-23T04:57:37.3576074Z -Wno-error=sign-conversion -O2 -g -fPIC
2025-08-23T04:57:37.3576954Z -DLIBDIR=\"C:/hostedtoolcache/windows/Ruby/3.4.5/x64/lib/ruby/gems/3.4.0/gems/nokogiri-1.18.9/ports/x64-mingw-ucrt/libiconv/1.17/lib\"
2025-08-23T04:57:37.3577964Z -DBUILDING_LIBICONV -DBUILDING_LIBCHARSET -DBUILDING_DLL -DENABLE_RELOCATABLE=1
2025-08-23T04:57:37.3578483Z -DIN_LIBRARY
2025-08-23T04:57:37.3579197Z -DINSTALLDIR=\"C:/hostedtoolcache/windows/Ruby/3.4.5/x64/lib/ruby/gems/3.4.0/gems/nokogiri-1.18.9/ports/x64-mingw-ucrt/libiconv/1.17/lib\"
2025-08-23T04:57:37.3580176Z -DNO_XMALLOC -Dset_relocation_prefix=libiconv_set_relocation_prefix
2025-08-23T04:57:37.3580832Z -Drelocate=libiconv_relocate -Drelocate2=libiconv_relocate2 -DHAVE_CONFIG_H -c
2025-08-23T04:57:37.3581376Z ./iconv.c -o iconv.o
2025-08-23T04:57:37.3581646Z In file included from ./loops.h:23,
2025-08-23T04:57:37.3581982Z                  from ./iconv.c:148:
2025-08-23T04:57:37.3582411Z ./loop_wchar.h:39:17: error: conflicting types for 'mbrtowc'; have
2025-08-23T04:57:37.3582923Z 'size_t(void)' {aka 'long long unsigned int(void)'}
2025-08-23T04:57:37.3584151Z    39 |   extern size_t mbrtowc ();
2025-08-23T04:57:37.3584503Z       |                 ^~~~~~~
2025-08-23T04:57:37.3584835Z In file included from ../include/iconv.h:118,
2025-08-23T04:57:37.3585189Z                  from ./iconv.c:20:
2025-08-23T04:57:37.3585692Z D:/a/_temp/msys64/ucrt64/include/wchar.h:1212:18: note: previous declaration of
2025-08-23T04:57:37.3586384Z 'mbrtowc' with type 'size_t(wchar_t * restrict,  const char * restrict,  size_t,
2025-08-23T04:57:37.3587010Z mbstate_t * restrict)' {aka 'long long unsigned int(short unsigned int *
2025-08-23T04:57:37.3587604Z restrict,  const char * restrict,  long long unsigned int,  mbstate_t *
2025-08-23T04:57:37.3588045Z restrict)'}
2025-08-23T04:57:37.3588392Z 1212 |   size_t __cdecl mbrtowc(wchar_t * __restrict__ _DstCh,const char *
2025-08-23T04:57:37.3588985Z __restrict__ _SrcCh,size_t _SizeInBytes,mbstate_t * __restrict__ _State);
2025-08-23T04:57:37.3589441Z       |                  ^~~~~~~
2025-08-23T04:57:37.3589788Z ./loop_wchar.h: In function 'wchar_to_loop_convert':
2025-08-23T04:57:37.3590325Z ./loop_wchar.h:356:15: error: too many arguments to function 'mbrtowc'; expected
2025-08-23T04:57:37.3590746Z 0, have 4
2025-08-23T04:57:37.3590963Z   356 |         res = mbrtowc(&wc,buf,bufcount,&state);
2025-08-23T04:57:37.3591246Z       |               ^~~~~~~ ~~~

```

To build libiconv1.17, seems we need to either downgrade the gcc version or modify the source code.

If libiconv 1.18, looks like we can be able to build with gcc 15.2. 
So, we need to wait for a release of nokogiri that uses libiconv 1.18.


Reported to https://github.com/sparklemotion/nokogiri/issues/3543