### PR TITLE
Use elasticsearch 8 series

### DIFF
--- a/fluent-package/Gemfile
+++ b/fluent-package/Gemfile
@@ -54,7 +54,7 @@ end
 
 # plugin gems
 
-gem "elasticsearch", "9.0.3"
+gem "elasticsearch", "8.19.0"
 gem "fluent-plugin-elasticsearch", "6.0.0"
 gem "ruby-kafka", "1.5.0"
 gem "digest-murmurhash", "1.1.1"

--- a/fluent-package/Gemfile.lock
+++ b/fluent-package/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
     cmetrics (0.3.3)
       mini_portile2 (~> 2.7)
     concurrent-ruby (1.3.5)
-    console (1.32.0)
+    console (1.33.0)
       fiber-annotation
       fiber-local (~> 1.1)
       json
@@ -104,14 +104,14 @@ GEM
     elastic-transport (8.4.0)
       faraday (< 3)
       multi_json
-    elasticsearch (9.0.3)
+    elasticsearch (8.19.0)
       elastic-transport (~> 8.3)
-      elasticsearch-api (= 9.0.3)
-    elasticsearch-api (9.0.3)
+      elasticsearch-api (= 8.19.0)
+    elasticsearch-api (8.19.0)
       multi_json
-    excon (1.2.8)
+    excon (1.3.0)
       logger
-    faraday (2.13.3)
+    faraday (2.13.4)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -213,13 +213,13 @@ GEM
     fluent-plugin-windows-exporter (1.0.0)
       bindata (~> 2.4)
       fluentd (>= 0.14.10, < 2)
-    google-protobuf (4.31.1-aarch64-linux-gnu)
+    google-protobuf (4.32.0-aarch64-linux-gnu)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.31.1-x64-mingw-ucrt)
+    google-protobuf (4.32.0-x64-mingw-ucrt)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.31.1-x86_64-linux-gnu)
+    google-protobuf (4.32.0-x86_64-linux-gnu)
       bigdecimal
       rake (>= 13)
     hirb (0.7.3)
@@ -230,12 +230,12 @@ GEM
     io-event (1.10.2)
     io-stream (0.7.0)
     jmespath (1.6.2)
-    json (2.13.0)
+    json (2.13.2)
     linux-utmpx (0.3.0)
       bindata (~> 2.4.8)
     logger (1.7.0)
     ltsv (0.1.2)
-    metrics (0.12.2)
+    metrics (0.13.0)
     mini_portile2 (2.8.9)
     msgpack (1.8.0)
     multi_json (1.17.0)
@@ -260,7 +260,7 @@ GEM
     prometheus-client (4.2.5)
       base64
     protocol-hpack (1.5.1)
-    protocol-http (0.51.0)
+    protocol-http (0.53.0)
     protocol-http1 (0.34.1)
       protocol-http (~> 0.22)
     protocol-http2 (0.22.1)
@@ -307,13 +307,13 @@ GEM
     td-client (2.0.0)
       httpclient (>= 2.7)
       msgpack (>= 0.5.6, < 2)
-    td-logger (0.4.0)
+    td-logger (0.5.0)
       fluent-logger (>= 0.5.0, < 2.0)
       logger
       msgpack (>= 0.5.6, < 2.0)
       mutex_m (>= 0.2.0, < 1.0)
-      td-client (>= 1.0.8, < 3.0)
-    traces (0.15.2)
+      td-client (>= 1.0.8, < 4.0)
+    traces (0.17.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2025.2)
@@ -353,7 +353,7 @@ DEPENDENCIES
   cmetrics (= 0.3.3)
   cool.io (= 1.9.0)
   digest-murmurhash (= 1.1.1)
-  elasticsearch (= 9.0.3)
+  elasticsearch (= 8.19.0)
   ffi (= 1.17.0)
   ffi-win32-extensions (= 1.1.0)
   fiddle (= 1.1.8)


### PR DESCRIPTION
Related to https://github.com/uken/fluent-plugin-elasticsearch/issues/1061#issuecomment-2912230835

elasticsearch 9 series does not support ES8.
We should consider ES8 as the default version for a while.
Users who want to use ES9 need to update the gems manually.