### PR TITLE
rpm: pack fluent-lts-release as artifact

### DIFF
--- a/.github/workflows/yum-arm.yml
+++ b/.github/workflows/yum-arm.yml
@@ -58,6 +58,11 @@ jobs:
         with:
           name: packages-release-${{ matrix.rake-job }}-aarch64
           path: fluent-release/yum/repositories
+      - name: Upload fluent-lts-release rpm
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages-lts-release-${{ matrix.rake-job }}-aarch64
+          path: fluent-lts-release/yum/repositories
   check_package_size:
     name: Check Package Size
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -72,6 +72,11 @@ jobs:
         with:
           name: packages-release-${{ matrix.rake-job }}
           path: fluent-release/yum/repositories
+      - name: Upload fluent-lts-release rpm
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages-lts-release-${{ matrix.rake-job }}
+          path: fluent-lts-release/yum/repositories
       - name: Upload v7 fluent-package rpm
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
NOTE: when beginning LTS branch fluent-package-v6, stop to ship fluent-lts-release from master branch.