### PR TITLE
ci: reinforce update-to-next-major-version test

### DIFF
--- a/fluent-package/yum/systemd-test/update-to-next-major-version.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-major-version.sh
@@ -9,8 +9,11 @@ status_before_update=$2 # active / inactive
 
 install_current
 
+sudo systemctl enable fluentd
+
 if [ "$status_before_update" = active ]; then
     sudo systemctl start fluentd
+    main_pid=$(eval $(systemctl show fluentd --property=MainPID) && echo $MainPID)
 fi
 
 # Set FLUENT_PACKAGE_SERVICE_RESTART
@@ -30,13 +33,81 @@ sudo $DNF install -y $package
 # Show bundled ruby version
 /opt/fluent/bin/ruby -v
 
-# Test: Check whether plugin/gem were installed during upgrading
-if [ "$service_restart" != manual ] && [ "$status_before_update" = active ]; then
-    # plugin gem should be installed automatically
-    /opt/fluent/bin/fluent-gem list | grep fluent-plugin-concat
-    # Non fluent-plugin- prefix gem should not be installed automatically
-    (! /opt/fluent/bin/fluent-gem list | grep gqtp)
-else
-    # plugin gem should not be installed automatically
+# Test: The service should take over the state
+systemctl is-enabled fluentd
+
+if [ "$status_before_update" = inactive ]; then
+    # Test: The service should NOT start automatically
+    (! systemctl is-active fluentd)
+    # Test: Plugin gem should not be installed automatically
     (! /opt/fluent/bin/fluent-gem list | grep fluent-plugin-concat)
+else
+    # Test: The process before update should continue to run
+    systemctl is-active fluentd
+    test $main_pid -eq $(eval $(systemctl show fluentd --property=MainPID) && echo $MainPID)
+
+    sleep 15
+
+    if [ "$service_restart" = manual ]; then
+        # Test: Plugin gem should not be installed automatically
+        (! /opt/fluent/bin/fluent-gem list | grep fluent-plugin-concat)
+        # Test: Main process should NOT be replaced until USR2 signal fired
+        test $main_pid  -eq $(eval $(systemctl show fluentd --property=MainPID) && echo $MainPID)
+
+        sudo kill -USR2 $main_pid
+        sleep 15
+
+        # Test: Main process should be replaced by USR2 signal
+        test $main_pid -ne $(eval $(systemctl show fluentd --property=MainPID) && echo $MainPID)
+    else
+        # Test: Plugin gem should be installed automatically
+        /opt/fluent/bin/fluent-gem list | grep fluent-plugin-concat
+        # Test: Non fluent-plugin- prefix gem should not be installed automatically
+        (! /opt/fluent/bin/fluent-gem list | grep gqtp)
+        # Test: Main process should be replaced automatically
+        test $main_pid -ne $(eval $(systemctl show fluentd --property=MainPID) && echo $MainPID)
+    fi
 fi
+
+# Ensure the service is started
+sudo systemctl start fluentd
+
+# Test: migration process from v4 must not be done
+(! test -e /etc/td-agent)
+(! test -e /etc/fluent/td-agent.conf)
+(! test -e /var/log/td-agent)
+(! test -e /var/log/fluent/td-agent.log)
+(! test -h /usr/sbin/td-agent)
+(! test -h /usr/sbin/td-agent-gem)
+
+# Test: environmental variables
+pid=$(eval $(systemctl show fluentd --property=MainPID) && echo $MainPID)
+env_vars=$(sudo sed -e 's/\x0/\n/g' /proc/$pid/environ)
+test $(eval $env_vars && echo $HOME) = "/var/lib/fluent"
+test $(eval $env_vars && echo $LOGNAME) = "fluentd"
+test $(eval $env_vars && echo $USER) = "fluentd"
+test $(eval $env_vars && echo $FLUENT_CONF) = "/etc/fluent/fluentd.conf"
+test $(eval $env_vars && echo $FLUENT_PACKAGE_LOG_FILE) = "/var/log/fluent/fluentd.log"
+test $(eval $env_vars && echo $FLUENT_PLUGIN) = "/etc/fluent/plugin"
+test $(eval $env_vars && echo $FLUENT_SOCKET) = "/var/run/fluent/fluentd.sock"
+
+# Test: logs
+sleep 3
+test -e /var/log/fluent/fluentd.log
+(! grep -e '\[warn\]' -e '\[error\]' -e '\[fatal\]' /var/log/fluent/fluentd.log)
+
+# Uninstall
+sudo $DNF remove -y fluent-package
+sudo systemctl daemon-reload
+
+(! getent passwd td-agent >/dev/null)
+(! getent group td-agent >/dev/null)
+getent passwd fluentd >/dev/null
+getent group fluentd >/dev/null
+
+# `sudo systemctl daemon-reload` clears the service completely.
+#   (The result of `systemctl status` will be `unfound`)
+# Note: RPM does not leave links like `@/etc/systemd/system/fluentd.service`.
+#   (Different from deb)
+
+(! systemctl status --no-pager fluentd)


### PR DESCRIPTION
The new test code are from other update-to-next-version tests.
Those tests need rpmrebuild, but looks like it is not supported on EPEL for AlmaLinux 10 yet.
So, those tests can not be done for AlmaLinux 10.
It would be better to cover those tests on this test as well.