### PR TITLE
deb: add missing Architectures: field

### DIFF
--- a/fluent-apt-source/debian/rules
+++ b/fluent-apt-source/debian/rules
@@ -42,6 +42,7 @@ override_dh_auto_build:
 	  echo "URIs: https://fluentd.cdn.cncf.io/6/$${distribution}/$${code_name}/"; \
 	  echo "Suites: $${code_name}"; \
 	  echo "Components: contrib"; \
+	  echo "Architectures: amd64 arm64"; \
 	  echo "Signed-By: /usr/share/keyrings/fluent-archive-keyring.asc"; \
 	) > fluent.sources
 

--- a/fluent-lts-apt-source/debian/rules
+++ b/fluent-lts-apt-source/debian/rules
@@ -42,6 +42,7 @@ override_dh_auto_build:
 	  echo "URIs: https://fluentd.cdn.cncf.io/lts/6/$${distribution}/$${code_name}/"; \
 	  echo "Suites: $${code_name}"; \
 	  echo "Components: contrib"; \
+	  echo "Architectures: amd64 arm64"; \
 	  echo "Signed-By: /usr/share/keyrings/fluent-lts-archive-keyring.asc"; \
 	) > fluent-lts.sources
 


### PR DESCRIPTION
It is better to specify supported architectures in Architectures: field explicitly.

Without it, if other architecture was enabled (e.g. i386 was enabled additionally with multiarch), apt emits the following message:

```
  Notice: Skipping acquire of configured file
  'contrib/binary-i386/Packages' as repository
  'https://fluentd.cdn.cncf.io/lts/6/debian/trixie trixie InRelease'
  doesn't support architecture 'i386'
```