### PR TITLE
Backport(v5): yum: Disable package-note-file to remove unnecessary linker flag (#877)

### DIFF
--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -138,6 +138,13 @@ The stable distribution of Fluentd, formerly known as td-agent.
 %if %{use_scl_ruby}
 . /opt/rh/rh-ruby%{scl_ruby_ver}/enable
 %endif
+
+# Disable package-note-file which embeds build environment path
+# in LDFLAGS. It blocks build process with third-party gems which
+# requires compile procedure.
+%undefine _package_note_file  # For AmazonLinux 2023
+%undefine _package_note_flags # For RHEL 10
+
 rake build:rpm_config FLUENT_PACKAGE_STAGING_PATH=%{buildroot} NO_VAR_RUN=1
 rake build:all FLUENT_PACKAGE_STAGING_PATH=%{buildroot} PATH="$HOME/.cargo/bin:$PATH"
 mkdir -p %{buildroot}%{_mandir}/man1


### PR DESCRIPTION
Backport #877

The user can refer the Ruby configure results through `RbConfig::CONFIG`.
`RbConfig::CONFIG` is mainly used when installing gems which has C extension.

If flags remain that use linker scripts that do not exist in the user's environment,
it causes errors when user install the gem.

When creating a package using `fluent-package.spec.in`, the environment variable `LDFLAGS` was automatically set as follows.

```
LDFLAGS='-Wl,-z,relro -Wl,--as-needed  -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1    -Wl,--build-id=sha1 -Wl,-dT,/root/rpmbuild/BUILD/fluent-package-6.0.0/.package_note-fluent-package-6.0.0-1.amzn2023.x86_64.ld'
```

Ruby's `configure` refers to the environment variable `LDFLAGS`, and it expands into `RbConfig::CONFIG`.

Fix
https://github.com/fluent-plugins-nursery/fluent-plugin-node-exporter-metrics/issues/21 Fix https://github.com/fluent/fluent-package-builder/issues/590

---------