### PR TITLE
fluent-release: remove unnecessary dependencies

### DIFF
--- a/fluent-lts-release/yum/fluent-lts-release.spec.in
+++ b/fluent-lts-release/yum/fluent-lts-release.spec.in
@@ -13,17 +13,6 @@ License:	ASL 2.0
 URL:		https://docs.fluentd.org/
 Source0:	@PACKAGE@-@VERSION@.tar.gz
 
-%if ! %{is_amazon_linux}
-Requires: epel-release
-Requires: dnf-command(config-manager)
-%else
-%if %{_amzn} == 2
-Requires: yum-utils
-%else
-Requires: dnf-command(config-manager)
-%endif
-%endif
-
 %description
 The stable distribution of Fluentd release repository files
 

--- a/fluent-release/yum/fluent-release.spec.in
+++ b/fluent-release/yum/fluent-release.spec.in
@@ -13,17 +13,6 @@ License:	ASL 2.0
 URL:		https://docs.fluentd.org/
 Source0:	@PACKAGE@-@VERSION@.tar.gz
 
-%if ! %{is_amazon_linux}
-Requires: epel-release
-Requires: dnf-command(config-manager)
-%else
-%if %{_amzn} == 2
-Requires: yum-utils
-%else
-Requires: dnf-command(config-manager)
-%endif
-%endif
-
 %description
 The stable distribution of Fluentd release repository files
 


### PR DESCRIPTION
Currently, the following dependencies are installed. (Confirmed on AlmaLinux 8)

* dbus-glib
* dnf-plugins-core
* epel-release
* python3-dateutil
* python3-dbus
* python3-dnf-plugins
* python3-six
* python3-systemd

These dependencies would not be intended.
Especially, it appears that `epel-release` could not be installed on RHEL.