### PR TITLE
rpm: add signing to fluent-release package

### DIFF
--- a/fluent-package/manage-fluent-repositories.sh
+++ b/fluent-package/manage-fluent-repositories.sh
@@ -169,13 +169,18 @@ EOF
 	;;
     rpm)
 	# resign rpm packages
-	find $FLUENT_RELEASE_DIR/6 -name "*$FLUENT_PACKAGE_VERSION*.rpm"
+	RPM_PATTERN=(
+	      -name "*$FLUENT_PACKAGE_VERSION*.rpm"
+	  -or -name "*fluent-release*.rpm"
+	  -or -name "*fluent-lts-release*.rpm"
+	)
+	find $FLUENT_RELEASE_DIR/6 "${RPM_PATTERN[@]}"
 	echo "Ready to type signing passphrase? (process starts in 10 seconds, Ctrl+C to abort)"
 	sleep 10
 	export GPG_TTY=$(tty)
-	find $FLUENT_RELEASE_DIR/6 -name "*$FLUENT_PACKAGE_VERSION*.rpm" | xargs rpm --resign --define "_gpg_name $SIGNING_KEY"
+	find $FLUENT_RELEASE_DIR/6 "${RPM_PATTERN[@]}" | xargs rpm --resign --define "_gpg_name $SIGNING_KEY"
 	# check whether packages are signed correctly.
-	find $FLUENT_RELEASE_DIR/6 -name "*$FLUENT_PACKAGE_VERSION*.rpm" | xargs rpm -K || \
+	find $FLUENT_RELEASE_DIR/6 "${RPM_PATTERN[@]}" | xargs rpm -K || \
 	    (echo "Import public key to verify: rpm --import https://s3.amazonaws.com/packages.treasuredata.com/GPG-KEY-fluent-package" && exit 1)
 
 	# update & sign rpm repository


### PR DESCRIPTION
This PR will add signing to fluent-release package due to fix following `Package fluent-release-2025.9.29-1.el9.noarch.rpm is not signed` message with `sudo yum update`.

```
$ sudo yum update -y
Fluentd Project                                 177 kB/s |  80 kB     00:00
Dependencies resolved.
================================================================================
 Package            Arch       Version              Repository             Size
================================================================================
Upgrading:
 epel-release       noarch     9-10.el9             epel                   19 k
 fluent-release     noarch     2025.9.29-1.el9      fluent-package-v6      12 k

Transaction Summary
================================================================================
Upgrade  2 Packages

Total download size: 31 k
Downloading Packages:
(1/2): epel-release-9-10.el9.noarch.rpm         298 kB/s |  19 kB     00:00
(2/2): fluent-release-2025.9.29-1.el9.noarch.rp  42 kB/s |  12 kB     00:00
--------------------------------------------------------------------------------
Total                                            19 kB/s |  31 kB     00:01
Extra Packages for Enterprise Linux 9 - x86_64  1.6 MB/s | 1.6 kB     00:00
Importing GPG key 0x3228467C:
 Userid     : "Fedora (epel9) <epel@fedoraproject.org>"
 Fingerprint: FF8A D134 4597 106E CE81 3B91 8A38 72BF 3228 467C
 From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-9
Key imported successfully
The downloaded packages were saved in cache until the next successful transaction.
You can remove cached packages by executing 'yum clean packages'.
Package fluent-release-2025.9.29-1.el9.noarch.rpm is not signed
```