### PR TITLE
tmpfiles.d: ensure tmp dir for lock files not be cleaned up

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -253,6 +253,7 @@ jobs:
           - "update-without-data-lost.sh v6 v7"
           - "update-without-data-lost.sh v7 v6"
           - "obsolete-plugins.sh"
+          - "tmpfiles.sh"
         include:
           - label: Debian bookworm amd64
             rake-job: debian-bookworm

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -310,6 +310,7 @@ jobs:
           - "update-without-data-lost.sh v6 v7"
           - "update-without-data-lost.sh v7 v6"
           - "obsolete-plugins.sh"
+          - "tmpfiles.sh"
         include: ${{ fromJSON(needs.define-matrix.outputs.matrix).include }}
         exclude:
           - label: Amazon Linux 2023 x86_64

--- a/fluent-package/apt/systemd-test/tmpfiles.sh
+++ b/fluent-package/apt/systemd-test/tmpfiles.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -exu
+
+. $(dirname $0)/../commonvar.sh
+
+# Display unit info for debug
+sudo systemctl cat systemd-tmpfiles-clean.service
+sudo systemctl cat systemd-tmpfiles-clean.timer
+
+# Install the built package
+sudo apt install -V -y \
+    /host/${distribution}/pool/${code_name}/${channel}/*/*/fluent-package_*_${architecture}.deb
+
+# Wait all processes to start
+systemctl status --no-pager fluentd
+sleep 3
+
+# Test: the files under /tmp/ exist and not be cleaned up by default
+ls -d /tmp/fluent
+ls -d /tmp/fluentd-lock-*
+sudo systemd-tmpfiles --clean
+ls -d /tmp/fluent
+ls -d /tmp/fluentd-lock-*
+
+# Make timestamps old
+touch -d "2 months ago" /tmp/fluentd
+touch -d "2 months ago" /tmp/fluentd-lock-*
+
+# Test: the files under /tmp/ not be cleaned up even if they are old
+sudo systemd-tmpfiles --clean
+ls -d /tmp/fluent
+ls -d /tmp/fluentd-lock-*

--- a/fluent-package/templates/usr/lib/tmpfiles.d/fluentd.conf
+++ b/fluent-package/templates/usr/lib/tmpfiles.d/fluentd.conf
@@ -19,3 +19,4 @@ d /var/run/<%= package_dir %> 0755 <%= service_name %> <%= service_name %> - -
 
 # Exclude <%= service_name %>
 x /tmp/<%= package_dir %>
+X /tmp/fluentd-lock-*

--- a/fluent-package/yum/systemd-test/tmpfiles.sh
+++ b/fluent-package/yum/systemd-test/tmpfiles.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -exu
+
+. $(dirname $0)/common.sh
+
+# Display unit info for debug
+sudo systemctl cat systemd-tmpfiles-clean.service
+sudo systemctl cat systemd-tmpfiles-clean.timer
+
+# Install the built package
+install_current
+
+# Wait all processes to start
+(! systemctl status --no-pager fluentd)
+sudo systemctl enable --now fluentd
+systemctl status --no-pager fluentd
+sleep 3
+
+# Test: the files under /tmp/ exist and not be cleaned up by default
+ls -d /tmp/fluent
+ls -d /tmp/fluentd-lock-*
+sudo systemd-tmpfiles --clean
+ls -d /tmp/fluent
+ls -d /tmp/fluentd-lock-*
+
+# Make timestamps old
+touch -d "2 months ago" /tmp/fluentd
+touch -d "2 months ago" /tmp/fluentd-lock-*
+
+# Test: the files under /tmp/ not be cleaned up even if they are old
+sudo systemd-tmpfiles --clean
+ls -d /tmp/fluent
+ls -d /tmp/fluentd-lock-*


### PR DESCRIPTION
We should exclude `/tmp/fluentd-lock-*` directory.
If `/tmp/fluentd-lock-*` is cleaned up while Fluentd is running:

* out_file can fail flushing.
* out_secondary can fail flushing.
* The supervisor process exit abnormally when Fluentd stops.

At least, RHEL 8 has the following default conf for tmpfiles.d:

/usr/lib/tmpfiles.d/tmp.conf

    q /tmp 1777 root root 10d

This can delete directories under `/tmp` if they are not used for more than 10 days.

We don't need to protect the old lock files under
`/tmp/fluentd-lock-*/`, so use `X` instead of `x`.

In configs where lock files are not used, there is no problem even if this directory is deleted.
In configurations that do use lock files, it’s unlikely that this directory would not be updated for more than 10 days. Therefore, the cases where this actually becomes an issue should be quite limited.
If only out_secondary_file uses lock files, this can become an issue.