### PR TITLE
ci: force newer CMake policy

### DIFF
--- a/.github/workflows/maintenance-bundle-update.yml
+++ b/.github/workflows/maintenance-bundle-update.yml
@@ -19,6 +19,8 @@ jobs:
           ruby-version: 3.4 # Use same Ruby version with fluent-package bundled
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Bundle Update
+        env:
+          CMAKE_POLICY_VERSION_MINIMUM: "3.5"
         run: |
           cd fluent-package
           gem install bundler:2.3.27

--- a/.github/workflows/maintenance-bundle-update.yml
+++ b/.github/workflows/maintenance-bundle-update.yml
@@ -19,6 +19,8 @@ jobs:
           ruby-version: 3.4 # Use same Ruby version with fluent-package bundled
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Bundle Update
+        env:
+          CMAKE_POLICY_VERSION_MINIMUM: "3.5"
         run: |
           cd fluent-package
           gem install bundler:2.3.27


### PR DESCRIPTION
newer CMake drops policy version < 3.5, so keeping build with older policy (e.g. cmetrics), raise border to 3.5 on windows-latest

```
  -----
  CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
    Compatibility with CMake < 3.5 has been removed from CMake.
    Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
    to tell CMake that the project requires at least <min> but has been updated
    to work with policies introduced by <max> or earlier.
    Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
  -- Configuring incomplete, errors occurred!
  ----- end of file -----
  *** extconf.rb failed ***
```