### PR TITLE
jemalloc: upgrade from 3.6.0 to 5.3.1

### DIFF
--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -693,8 +693,9 @@ class BuildTask
     puts "::group::Build jemalloc from source" if ENV["CI"]
     tarball = @download_task.file_jemalloc_source
     source_dir = tarball.sub(/\.tar\.bz2$/, '')
+    tar_options = ["--no-same-owner"]
 
-    sh(*tar_command, "xvf", tarball, "-C", DOWNLOADS_DIR)
+    sh(*tar_command, "xvf", tarball, "-C", DOWNLOADS_DIR, *tar_options)
 
     configure_opts = [
       "--prefix=#{install_prefix}",
@@ -1051,7 +1052,7 @@ class BuildTask
       tarball = @download_task.file_jemalloc_source
       source_dir = File.basename(tarball.sub(/\.tar\.bz2$/, ''))
       license_file = File.join(source_dir, "COPYING")
-      tar_options = []
+      tar_options = ["--no-same-owner"]
       tar_options << "--force-local" if windows?
       sh(*tar_command, "xf", tarball, license_file, *tar_options)
       mv(license_file, "LICENSE-jemalloc.txt")

--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -702,19 +702,10 @@ class BuildTask
     ]
 
     if JEMALLOC_VERSION.split('.')[0].to_i >= 4
-      if ENV["FLUENT_PACKAGE_STAGING_PATH"] and
-        (ENV["FLUENT_PACKAGE_STAGING_PATH"].end_with?("el8.aarch64") or
-         ENV["FLUENT_PACKAGE_STAGING_PATH"].end_with?("el7.aarch64"))
-        # NOTE: There is a case that PAGE_SIZE detection on
-        # CentOS 7 CentOS 8 with aarch64 AWS ARM instance.
-        # So, explicitly set PAGE_SIZE by with-lg-page 16 (2^16 = 65536)
-        configure_opts.concat(["--with-lg-page=16"])
-      end
-      if ENV["FLUENT_PACKAGE_STAGING_PATH"] and
-        ENV["FLUENT_PACKAGE_STAGING_PATH"].end_with?("el8.ppc64le")
-        # NOTE: There is a case that PAGE_SIZE detection on
-        # CentOS 8 with ppc64le.
-        # So, explicitly set PAGE_SIZE by with-lg-page 16 (2^16 = 65536)
+      if ["aarch64", "ppc64le"].include?(Etc.uname[:machine])
+        # NOTE: Improve compatibility with kernel-64K.
+        # Then, explicitly set PAGE_SIZE=16 by --with-lg-page 16 (2^16 = 65536)
+        # Forcing PAGE_SIZE=16 to avoid "Unsuported system page size" runtime error.
         configure_opts.concat(["--with-lg-page=16"])
       end
     end

--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -699,6 +699,7 @@ class BuildTask
 
     configure_opts = [
       "--prefix=#{install_prefix}",
+      "--disable-cxx"
     ]
 
     if JEMALLOC_VERSION.split('.')[0].to_i >= 4

--- a/fluent-package/config.rb
+++ b/fluent-package/config.rb
@@ -13,8 +13,8 @@ FLUENTD_LOCAL_GEM_REPO = "file://" + File.expand_path(File.join(__dir__, "local_
 # https://github.com/jemalloc/jemalloc/releases
 # Use jemalloc 3.x to reduce memory usage
 # See https://github.com/fluent-plugins-nursery/fluent-package-builder/issues/305
-JEMALLOC_VERSION = "3.6.0"
-#JEMALLOC_VERSION = "5.2.1"
+#JEMALLOC_VERSION = "3.6.0"
+JEMALLOC_VERSION = "5.3.1"
 
 # https://www.openssl.org/source/
 OPENSSL_FOR_MACOS_VERSION = "3.0.8"

--- a/fluent-package/templates/etc/systemd/fluentd.service.erb
+++ b/fluent-package/templates/etc/systemd/fluentd.service.erb
@@ -19,6 +19,7 @@ Environment=FLUENT_CONF_INCLUDE_DIR=/etc/<%= package_dir %>/conf.d
 Environment=FLUENT_PLUGIN=/etc/<%= package_dir %>/plugin
 Environment=FLUENT_SOCKET=/var/run/<%= package_dir %>/<%= service_name %>.sock
 Environment=FLUENT_PACKAGE_LOG_FILE=/var/log/<%= package_dir %>/<%= service_name %>.log
+Environment=MALLOC_CONF="dirty_decay_ms:400,muzzy_decay_ms:0,narenas:2,background_thread:true,thp:never,abort_conf:true"
 <% if pkg_type == 'deb' %>
 EnvironmentFile=-/etc/default/<%= service_name %>
 <% else %>


### PR DESCRIPTION
In the historical reasons, there are memory consumption issue between 4.x and 5.2.x for fluent-package.

Since 5.3.x, the situation seems changed about that issue, upgrade it from 3.6.0.

There are trade of about memory and performance, adopted already tuned MALLOC_CONF parameters from here:

https://gist.github.com/jjb/9ff0d3f622c8bbe904fe7a82e35152fc