### PR TITLE
Add missing 6.1.0 changelog entry

### DIFF
--- a/fluent-package/bump-version-v7.patch
+++ b/fluent-package/bump-version-v7.patch
@@ -54,7 +54,7 @@ index 2614fac..95eb903 100644
 +
 + -- Shizuo Fujita <fujita@clear-code.com>  Sun, 29 Aug 2027 13:55:06 -0000
 +
- fluent-package (6.0.0-1) unstable; urgency=low
+ fluent-package (6.1.0-1) unstable; urgency=low
  
    * New upstream release.
 diff --git a/fluent-package/yum/fluent-package.spec.in b/fluent-package/yum/fluent-package.spec.in
@@ -68,7 +68,7 @@ index 9a13f9a..1ab7905 100644
 +* Sun Aug 29 2027 Shizuo Fujita <fujita@clear-code.com> - 7.0.0-1
 +- New upstream release.
 +
- * Fri Aug 29 2025 Kentaro Hayashi <hayashi@clear-code.com> - 6.0.0-1
+ * Wed Aug 05 2026 Shizuo Fujita <fujita@clear-code.com> - 6.1.0-1
  - New upstream release.
  
 -- 

--- a/fluent-package/debian/changelog
+++ b/fluent-package/debian/changelog
@@ -1,3 +1,9 @@
+fluent-package (6.1.0-1) unstable; urgency=low
+
+  * New upstream release.
+
+ -- Shizuo Fujita <fujita@clear-code.com>  Wed, 05 Aug 2026 05:12:35 -0000
+
 fluent-package (6.0.0-1) unstable; urgency=low
 
   * New upstream release.

--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -472,6 +472,9 @@ fi
 # NOTE: %{_tmpfilesdir} is available since CentOS 7
 %attr(0755,fluentd,fluentd) %dir /tmp/@PACKAGE_DIR@
 %changelog
+* Wed Aug 05 2026 Shizuo Fujita <fujita@clear-code.com> - 6.1.0-1
+- New upstream release.
+
 * Fri Aug 29 2025 Kentaro Hayashi <hayashi@clear-code.com> - 6.0.0-1
 - New upstream release.
 


### PR DESCRIPTION
Bump master version (#1097) bumped PACKAGE_VERSION to 6.1.0 in config.rb, but debian/changelog was left at 6.0.0-1.

As a result, dpkg-source looked for fluent-package_6.0.0.orig.tar.gz while rake apt:build had prepared fluent-package_6.1.0.orig.tar.gz, and asked "continue anyway? [y/N]" on the TTY which "docker run --tty" allocates. Nothing answers it in CI, so every Apt build job hung until it was cancelled.