### PR TITLE
Backport(v6): Reduce build time by disabling LTO flags on RHEL 10 / Ubuntu (#1101)

### DIFF
--- a/fluent-package/debian/rules
+++ b/fluent-package/debian/rules
@@ -3,6 +3,15 @@
 export GEM2DEB_TEST_RUNNER = --check-dependencies
 export DH_RUBY = --gem-install
 
+# Ubuntu turns LTO on by default in dpkg-buildflags, and dpkg-buildpackage
+# exports those flags, so they leak into our own Ruby and every native gem
+# extension built by override_dh_auto_install. LTO is useless for us because
+# we build Ruby with its own optflags anyway, and it slows down extconf.rb
+# dramatically since mkmf links a small test program on every check. On
+# Ubuntu Jammy it turned "configuring ext/*" from 21s into 964s.
+# This is a no-op on Debian, which does not enable LTO.
+export DEB_BUILD_MAINT_OPTIONS = optimize=-lto
+
 %:
 	dh $@
 

--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -39,6 +39,16 @@
 # Stop interrupting by bytecopile errors. The errors are causes on Amazon Linux 2 and CentOS 7.
 %global _python_bytecompile_errors_terminate_build 0
 
+# RPM 4.19 (RHEL 10) exports the distribution build flags into the build
+# and install sections automatically, so they leak into our own Ruby and
+# every native gem extension. LTO is useless for us because we build Ruby
+# with its own optflags anyway, and it slows down extconf.rb dramatically
+# since mkmf links a small test program on every check. On AlmaLinux 10 it
+# turned "configuring ext/*" from 90s into 980s.
+%global _lto_cflags %{nil}
+# Likewise, the annobin plugin is loaded on every compile and link.
+%undefine _annotated_build
+
 %global __provides_exclude_from ^/opt/%{name}/.*\\.so.*
 %global __requires_exclude libjemalloc.*|libruby.*|/opt/%{name}/.*|^/usr/bin/ruby
 # Omit build_id links (/usr/lib/.build-id/xx/yy) from td-agent package


### PR DESCRIPTION
Backport #1101

## RPM
RPM 4.19, which AlmaLinux 10 ships, exports the distribution build flags into the build and install sections automatically. Previously (rpm 4.16 on AlmaLinux 9 and older) those flags were only applied through macros such as %configure or %make_build, which this spec does not use, so nothing was exported at all.

Since the whole build happens in the install section via "rake build:all", the flags now leak into jemalloc, our bundled Ruby and every native gem extension. -flto=auto -ffat-lto-objects is especially costly: mkmf links a small test program for every check in extconf.rb, and each of those links runs the full LTO machinery.

Measured on the AlmaLinux 10 x86_64 build:

  * configuring ext/*      90s -> 981s
  * Ruby core compilation  32s ->  81s
  * rdkafka native ext     62s -> 320s
  * whole job              9m34s -> 27m16s

We build Ruby with its own optflags anyway, so LTO buys us nothing here. Drop it, along with the annobin plugin which is loaded on every compile and link. The hardening flags are kept as they are.

This is a no-op on AlmaLinux 9 and older, where no flags were exported in the first place.

## Ubuntu
Ubuntu enables optimize=+lto by default in dpkg-buildflags, and dpkg-buildpackage exports the resulting flags into the environment. Debian
does not enable it, which is why only the Ubuntu jobs are affected.

Since the whole build happens in override_dh_auto_install via "rake build:all", the flags leak into jemalloc, OpenSSL, our bundled Ruby
and every native gem extension. -flto=auto -ffat-lto-objects is especially
costly: mkmf links a small test program for every check in extconf.rb, and
each of those links runs the full LTO machinery.

Measured on the amd64 builds of a single run:

  * configuring ext/*  Debian bookworm 21s vs Ubuntu Jammy 964s
  * whole job          Debian bookworm 10m vs Ubuntu Jammy 33m,
                       Noble 36m, Resolute 39m

We build Ruby with its own optflags anyway, so LTO buys us nothing here. The hardening flags are kept as they are.

This is the deb counterpart of the previous commit, which did the same for
RHEL 10.
