### PR TITLE
Skip building the current major version in the next major lane

### DIFF
--- a/.github/actions/build-rpm/action.yml
+++ b/.github/actions/build-rpm/action.yml
@@ -37,36 +37,10 @@ runs:
         gem install serverspec --no-document
 
     - name: Build rpm with Docker
-      if: ${{ steps.cache-rpm.outputs.cache-hit != 'true' }}
+      if: ${{ steps.cache-rpm.outputs.cache-hit != 'true' && inputs.next-major != 'true' }}
       shell: bash
       run: |
         rake yum:build YUM_TARGETS=${{ inputs.rake-job }}
-
-    - name: Ensure RHEL9 compatibility
-      if: ${{ steps.cache-rpm.outputs.cache-hit != 'true' && startsWith(inputs.rake-job, 'almalinux-9') }}
-      shell: bash
-      run: |
-        if find fluent-package/yum/repositories -type f -name 'fluent-package-*.rpm' \
-          ! -name '*debug*' ! -name '*.src.rpm' | xargs rpm -qp --requires | grep -qE "GLIBC_2\.(3[6-9]|[4-9][0-9])|OPENSSL_3\.[1-9]"; then
-          echo "::error::Incompatible dependencies (GLIBC_2.36 or later, OPENSSL_3.1.x or later) were detected!"
-          exit 1
-        else
-          echo "Compatibility with GLIBC_ and OPENSSL_ ABI check passed. No incompatible dependencies found."
-        fi
-
-    - name: Ensure RHEL10 compatibility
-      if: ${{ steps.cache-rpm.outputs.cache-hit != 'true' && startsWith(inputs.rake-job, 'almalinux-10') }}
-      shell: bash
-      run: |
-        if find fluent-package/yum/repositories -type f -name 'fluent-package-*.rpm' \
-          ! -name '*debug*' ! -name '*.src.rpm' | xargs rpm -qp --requires | grep -qE "GLIBC_2\.(4[0-9]|[5-9][0-9])|OPENSSL_3\.[3-9]"; then
-          echo "::error::Incompatible dependencies (GLIBC_2.40, OPENSSL_3.3.0 or later) were detected!"
-          find fluent-package/yum/repositories -type f -name 'fluent-package-*.rpm' \
-            ! -name '*debug*' ! -name '*.src.rpm' | xargs rpm -qp --requires
-          exit 1
-        else
-          echo "Compatibility with GLIBC_ and OPENSSL_ API check passed. No incompatible dependencies found."
-        fi
 
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       if: ${{ steps.cache-rpm.outputs.cache-hit != 'true' && inputs.next-major == 'true' }}
@@ -82,6 +56,45 @@ runs:
         git config user.name "Fluentd developers"
         git am fluent-package/bump-version-v7.patch
         rake yum:build YUM_TARGETS=${{ inputs.rake-job }}
+
+    - name: Ensure RHEL9 compatibility
+      if: ${{ steps.cache-rpm.outputs.cache-hit != 'true' && startsWith(inputs.rake-job, 'almalinux-9') }}
+      shell: bash
+      env:
+        REPOSITORIES: ${{ inputs.next-major == 'true' && 'v7-test/fluent-package/yum/repositories' || 'fluent-package/yum/repositories' }}
+      run: |
+        rpms=$(find "${REPOSITORIES}" -type f -name 'fluent-package-*.rpm' \
+          ! -name '*debug*' ! -name '*.src.rpm' || true)
+        if [ -z "${rpms}" ]; then
+          echo "::error::No rpm to check was found under ${REPOSITORIES}"
+          exit 1
+        fi
+        if echo "${rpms}" | xargs rpm -qp --requires | grep -qE "GLIBC_2\.(3[6-9]|[4-9][0-9])|OPENSSL_3\.[1-9]"; then
+          echo "::error::Incompatible dependencies (GLIBC_2.36 or later, OPENSSL_3.1.x or later) were detected!"
+          exit 1
+        else
+          echo "Compatibility with GLIBC_ and OPENSSL_ ABI check passed. No incompatible dependencies found."
+        fi
+
+    - name: Ensure RHEL10 compatibility
+      if: ${{ steps.cache-rpm.outputs.cache-hit != 'true' && startsWith(inputs.rake-job, 'almalinux-10') }}
+      shell: bash
+      env:
+        REPOSITORIES: ${{ inputs.next-major == 'true' && 'v7-test/fluent-package/yum/repositories' || 'fluent-package/yum/repositories' }}
+      run: |
+        rpms=$(find "${REPOSITORIES}" -type f -name 'fluent-package-*.rpm' \
+          ! -name '*debug*' ! -name '*.src.rpm' || true)
+        if [ -z "${rpms}" ]; then
+          echo "::error::No rpm to check was found under ${REPOSITORIES}"
+          exit 1
+        fi
+        if echo "${rpms}" | xargs rpm -qp --requires | grep -qE "GLIBC_2\.(4[0-9]|[5-9][0-9])|OPENSSL_3\.[3-9]"; then
+          echo "::error::Incompatible dependencies (GLIBC_2.40, OPENSSL_3.3.0 or later) were detected!"
+          echo "${rpms}" | xargs rpm -qp --requires
+          exit 1
+        else
+          echo "Compatibility with GLIBC_ and OPENSSL_ API check passed. No incompatible dependencies found."
+        fi
 
     - name: Upload fluent-package rpm
       if: ${{ inputs.next-major != 'true' }}


### PR DESCRIPTION
"Build next major" ran "rake yum:build" twice: once for the current version and once more for the v7 one in v7-test. The first build's artifacts are discarded, since all three upload-artifact steps for them are guarded by next-major != 'true', so it was pure waste. The deb counterpart already guards the step this way; only the rpm one was left behind.

Measured on the AlmaLinux 10 x86_64 lane of run 30994758570:

  * Build             rake yum:build (v6)   8m27s
  * Build next major  rake yum:build (v6)   6m56s  <- discarded
                      rake yum:build (v7)   6m16s

To keep the RHEL9 and RHEL10 ABI checks meaningful, move them after the v7 build and point them at whichever repositories directory the lane actually produced. This makes the next major lane check the v7 packages instead of repeating what the "Build" lane already checks.

Also fail loudly when no rpm is found to check, so that a wrong directory cannot be mistaken for a clean result.