### PR TITLE
Backport(v6): Install rpmrebuild from upstream instead of EPEL (c3da848)

### DIFF
--- a/fluent-package/yum/systemd-test/setup-rpmrebuild.sh
+++ b/fluent-package/yum/systemd-test/setup-rpmrebuild.sh
@@ -1,9 +1,16 @@
+# Installing rpmrebuild from EPEL keeps hanging on the CI runners, so take it
+# straight from the upstream project instead.
+function install_rpmrebuild()
+{
+    curl -L -o rpmrebuild.noarch.rpm https://sourceforge.net/projects/rpmrebuild/files/latest/download
+    sudo $DNF install -y ./rpmrebuild.noarch.rpm
+}
+
 case $distribution in
     amazon)
         case $version in
             2023)
-                curl -L -o rpmrebuild.noarch.rpm https://sourceforge.net/projects/rpmrebuild/files/latest/download
-                sudo $DNF install -y ./rpmrebuild.noarch.rpm
+                install_rpmrebuild
                 ;;
             2)
                 sudo amazon-linux-extras install -y epel
@@ -12,8 +19,7 @@ case $distribution in
         esac
         ;;
     *)
-        sudo $DNF install -y epel-release
-        sudo $DNF install -y rpmrebuild
+        install_rpmrebuild
         # hotfix for rpmrebuild 2.20 bug
         # See https://sourceforge.net/p/rpmrebuild/bugs/18/
         pkg_version=$(rpm -q rpmrebuild)


### PR DESCRIPTION
"dnf install -y rpmrebuild" against EPEL keeps hanging on the CI runners. It emits no output at all and never gives up, so the job runs until someone cancels it, and re-running does not help. It was seen on RockyLinux 8 on two unrelated branches within the same hour, while the Amazon Linux 2023 tests, which are the ones that do not go through EPEL, kept passing.

The download speed is not the cause. One of the stalled runs had fetched the epel-release dependencies at 41 kB/s, but a later one fetched them at 1.7 MB/s and stalled at exactly the same line.

Take the package from the upstream project instead, the way the Amazon Linux 2023 case already does. That is rpmrebuild 2.21, so the hotfix for the 2.20 bug stops applying, but it is left in place for Amazon Linux 2, which still installs from EPEL.


(cherry picked from commit c3da84836a5eeb0a50a8b335cdf4fc5f597c8af5)