### PR TITLE
yum: add missing perl modules on CentOS 7

### DIFF
--- a/fluent-package/yum/centos-7/Dockerfile
+++ b/fluent-package/yum/centos-7/Dockerfile
@@ -68,6 +68,8 @@ FROM ${FROM}
 #     tar \
 #     zlib-devel \
 #     rpmlint \
+#     perl-IPC-Cmd \
+#     perl-Time-Piece \
 #     cmake3 && \
 #   # raise IPv4 priority
 #   echo "precedence ::ffff:0:0/96 100" > /etc/gai.conf && \


### PR DESCRIPTION
It is required to execute configure script for OpenSSL.
This is just an attempt for unofficial build.